### PR TITLE
Don't assume kubeapps namespace is the global repos one.

### DIFF
--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -659,8 +659,9 @@ describe("filters by application repository", () => {
     // The repo name is "foo"
     const input = wrapper.find("input").findWhere(i => i.prop("value") === "foo");
     input.simulate("change", { target: { value: "foo" } });
-    // It should have pushed with the filter
-    expect(fetchRepos).toHaveBeenCalledWith("kubeapps");
+    // It should have pushed with the filter and fetches global repos since
+    // the "kubeapps" namespace isn't the global repos namespace.
+    expect(fetchRepos).toHaveBeenCalledWith("kubeapps", true);
     expect(mockDispatch).toHaveBeenCalledWith({
       payload: {
         args: ["/c/default-cluster/ns/kubeapps/catalog?Repository=foo"],
@@ -696,6 +697,44 @@ describe("filters by application repository", () => {
       },
       type: "@@router/CALL_HISTORY_METHOD",
     });
+  });
+
+  it("does not additionally fetch global repos when the global repo is selected", () => {
+    mountWrapper(
+      getStore({
+        ...populatedState,
+        repos: { repos: [{ metadata: { name: "foo" } } as IAppRepository] },
+      }),
+      <MemoryRouter
+        initialEntries={[
+          `/c/${defaultProps.cluster}/ns/${initialState.config.globalReposNamespace}/catalog`,
+        ]}
+      >
+        <Route path={routePath}>
+          <Catalog />
+        </Route>
+      </MemoryRouter>,
+    );
+
+    // Called without the boolean `true` option to additionally fetch global repos.
+    expect(fetchRepos).toHaveBeenCalledWith(initialState.config.globalReposNamespace);
+  });
+
+  it("fetches from the global repos namespace for other clusters", () => {
+    mountWrapper(
+      getStore({
+        ...populatedState,
+        repos: { repos: [{ metadata: { name: "foo" } } as IAppRepository] },
+      }),
+      <MemoryRouter initialEntries={[`/c/other-cluster/ns/my-ns/catalog`]}>
+        <Route path={routePath}>
+          <Catalog />
+        </Route>
+      </MemoryRouter>,
+    );
+
+    // Only the global repos should have been fetched.
+    expect(fetchRepos).toHaveBeenCalledWith(initialState.config.globalReposNamespace);
   });
 });
 

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -87,7 +87,7 @@ export default function Catalog() {
     },
     operators,
     repos: { repos },
-    config: { appVersion, kubeappsCluster, kubeappsNamespace, featureFlags },
+    config: { appVersion, kubeappsCluster, globalReposNamespace, featureFlags },
   } = useSelector((state: IStoreState) => state);
   const { cluster, namespace } = ReactRouter.useParams() as IRouteParams;
   const location = ReactRouter.useLocation();
@@ -176,15 +176,15 @@ export default function Catalog() {
   // We do not currently support app repositories on additional clusters.
   const supportedCluster = cluster === kubeappsCluster;
   useEffect(() => {
-    if (!supportedCluster || namespace === kubeappsNamespace) {
+    if (!supportedCluster || namespace === globalReposNamespace) {
       // Global namespace or other cluster, show global repos only
-      dispatch(actions.repos.fetchRepos(kubeappsNamespace));
+      dispatch(actions.repos.fetchRepos(globalReposNamespace));
       return () => {};
     }
     // In other case, fetch global and namespace repos
     dispatch(actions.repos.fetchRepos(namespace, true));
     return () => {};
-  }, [dispatch, supportedCluster, namespace, kubeappsNamespace]);
+  }, [dispatch, supportedCluster, namespace, globalReposNamespace]);
 
   useEffect(() => {
     // Ignore operators if specified

--- a/dashboard/src/shared/specs/mountWrapper.tsx
+++ b/dashboard/src/shared/specs/mountWrapper.tsx
@@ -30,6 +30,7 @@ export const initialState = {
     ...cloneDeep(configInitialState),
     kubeappsCluster: "default-cluster",
     kubeappsNamespace: "kubeapps",
+    globalReposNamespace: "kubeapps-repos-global",
   },
   kube: cloneDeep(kubeInitialState),
   clusters: {


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

See #4539 for the problem.

The fix is to remove the now incorrect assumption in the Catalog component that the kubeapps namespace is the global repos namespace.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->
CI passes (on GKE - haven't looked yet why this is only relevant for that env, but assume the global repos dir is set to kubeapps for the others).

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #4539

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

Confirmed locally in CI env that this change results in the repo filter being present: 
![ci-kubeapps-repo](https://user-images.githubusercontent.com/497518/160969678-a6001ee2-abf8-4639-a139-4926919e0f17.png)
