### PR TITLE
Enable CI edit user to view secrets in global repos namespace.

### DIFF
--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -395,9 +395,21 @@ kubectl create rolebinding kubeapps-view-user-apprepo-read -n kubeapps-user-name
 kubectl create rolebinding kubeapps-view-user -n kubeapps-user-namespace --clusterrole=edit --serviceaccount kubeapps:kubeapps-view
 ## Create edit user
 kubectl create serviceaccount kubeapps-edit -n kubeapps
+# TODO(minelson): Many of these roles/bindings need to be cleaned up. Some are
+# unnecessary (with chart changes), some should not be created (such as edit
+# here having the edit cluster role in the kubeapps namespace - should just be
+# default).
 kubectl create rolebinding kubeapps-edit -n kubeapps --clusterrole=edit --serviceaccount kubeapps:kubeapps-edit
 kubectl create rolebinding kubeapps-edit -n default --clusterrole=edit --serviceaccount kubeapps:kubeapps-edit
 kubectl create rolebinding kubeapps-repositories-read -n kubeapps --clusterrole kubeapps:kubeapps:apprepositories-read --serviceaccount kubeapps:kubeapps-edit
+# TODO(minelson): Similar to the `global-repos-read` rolebinding that the chart
+# adds to the `kubeapps-repos-global` namespace for all authenticated users, we
+# should eventually consider adding a similar rolebinding for secrets in the
+# `kubeapps-repos-global` namespace also (but not if the global repos namespace
+# is configured to be the kubeapps namespace, of course.) For now, explicit
+# creation because CI tests with a repo with creds in the global repos ns.
+kubectl create role view-secrets -n ${GLOBAL_REPOS_NS} --verb=get,list,watch --resource=secrets
+kubectl create rolebinding global-repos-secrets-read -n ${GLOBAL_REPOS_NS} --role=view-secrets --serviceaccount kubeapps:kubeapps-edit
 
 ## Give the cluster some time to avoid issues like
 ## https://circleci.com/gh/kubeapps/kubeapps/16102

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -398,7 +398,7 @@ kubectl create serviceaccount kubeapps-edit -n kubeapps
 # TODO(minelson): Many of these roles/bindings need to be cleaned up. Some are
 # unnecessary (with chart changes), some should not be created (such as edit
 # here having the edit cluster role in the kubeapps namespace - should just be
-# default).
+# default). See https://github.com/vmware-tanzu/kubeapps/issues/4435
 kubectl create rolebinding kubeapps-edit -n kubeapps --clusterrole=edit --serviceaccount kubeapps:kubeapps-edit
 kubectl create rolebinding kubeapps-edit -n default --clusterrole=edit --serviceaccount kubeapps:kubeapps-edit
 kubectl create rolebinding kubeapps-repositories-read -n kubeapps --clusterrole kubeapps:kubeapps:apprepositories-read --serviceaccount kubeapps:kubeapps-edit
@@ -408,6 +408,7 @@ kubectl create rolebinding kubeapps-repositories-read -n kubeapps --clusterrole 
 # `kubeapps-repos-global` namespace also (but not if the global repos namespace
 # is configured to be the kubeapps namespace, of course.) For now, explicit
 # creation because CI tests with a repo with creds in the global repos ns.
+# See https://github.com/vmware-tanzu/kubeapps/issues/4435
 kubectl create role view-secrets -n ${GLOBAL_REPOS_NS} --verb=get,list,watch --resource=secrets
 kubectl create rolebinding global-repos-secrets-read -n ${GLOBAL_REPOS_NS} --role=view-secrets --serviceaccount kubeapps:kubeapps-edit
 


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
After fixing one issue related to the GKE environment in #4539, the prerelease CI failed again on the same tests but with a different error:

![test-failed-2](https://user-images.githubusercontent.com/497518/160987300-b1b4c937-edda-44b4-a5a6-80aaad17bf70.png)

It turns out that since our CI tests were recently updated to include a private repo (no pull secrets, just repo access) in the global repos namespace, the edit service account didn't have access to read secrets in the global repos namespace.

This PR just explicitly adds this RBAC for CI, but I've left a couple of TODOs because we should clean up the CI RBAC and eventually (when it's no longer possible to use the `kubeapps` namespace for global repos) enable authenticated users to read secrets in the global repos namespace (only).

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
