### PR TITLE
Fix the unbound env var README_GENERATOR_REPO

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -773,7 +773,7 @@ jobs:
           # This token is passed as a GITHUB_TOKEN env var via CircleCI
           name: Run the chart_sync script
           command: |
-            ./script/chart_sync.sh << pipeline.parameters.CI_BOT_USERNAME >> << pipeline.parameters.CI_BOT_EMAIL >> << pipeline.parameters.CI_BOT_GPG >> << pipeline.parameters.CHARTS_REPO_ORIGINAL >> << pipeline.parameters.BRANCH_CHARTS_REPO_ORIGINAL >> << pipeline.parameters.CHARTS_REPO_FORKED >> << pipeline.parameters.BRANCH_CHARTS_REPO_FORKED >>
+            ./script/chart_sync.sh << pipeline.parameters.CI_BOT_USERNAME >> << pipeline.parameters.CI_BOT_EMAIL >> << pipeline.parameters.CI_BOT_GPG >> << pipeline.parameters.CHARTS_REPO_ORIGINAL >> << pipeline.parameters.BRANCH_CHARTS_REPO_ORIGINAL >> << pipeline.parameters.CHARTS_REPO_FORKED >> << pipeline.parameters.BRANCH_CHARTS_REPO_FORKED >> << pipeline.parameters.README_GENERATOR_REPO >>
   sync_chart_from_bitnami:
     environment:
       <<: *common_envars

--- a/script/chart_sync.sh
+++ b/script/chart_sync.sh
@@ -16,6 +16,7 @@ CHARTS_REPO_ORIGINAL=${4:?Missing base chart repository}
 BRANCH_CHARTS_REPO_ORIGINAL=${5:?Missing base chart repository branch}
 CHARTS_REPO_FORKED=${6:?Missing forked chart repository}
 BRANCH_CHARTS_REPO_FORKED=${7:?Missing forked chart repository branch}
+README_GENERATOR_REPO=${8:?Missing readme generator repository}
 
 currentVersion=$(grep -oP '(?<=^version: ).*' <"${KUBEAPPS_CHART_DIR}/Chart.yaml")
 externalVersion=$(curl -s "https://raw.githubusercontent.com/${CHARTS_REPO_ORIGINAL}/${BRANCH_CHARTS_REPO_ORIGINAL}/${CHART_REPO_PATH}/Chart.yaml" | grep -oP '(?<=^version: ).*')


### PR DESCRIPTION
CI error: /script/chart_sync.sh: line 38: README_GENERATOR_REPO: unbound variable

Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

The release job failed with: /script/chart_sync.sh: line 38: README_GENERATOR_REPO: unbound variable

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
