### PR TITLE
Remove readme-generator call for upstream PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -773,7 +773,7 @@ jobs:
           # This token is passed as a GITHUB_TOKEN env var via CircleCI
           name: Run the chart_sync script
           command: |
-            ./script/chart_sync.sh << pipeline.parameters.CI_BOT_USERNAME >> << pipeline.parameters.CI_BOT_EMAIL >> << pipeline.parameters.CI_BOT_GPG >> << pipeline.parameters.CHARTS_REPO_ORIGINAL >> << pipeline.parameters.BRANCH_CHARTS_REPO_ORIGINAL >> << pipeline.parameters.CHARTS_REPO_FORKED >> << pipeline.parameters.BRANCH_CHARTS_REPO_FORKED >> << pipeline.parameters.README_GENERATOR_REPO >>
+            ./script/chart_sync.sh << pipeline.parameters.CI_BOT_USERNAME >> << pipeline.parameters.CI_BOT_EMAIL >> << pipeline.parameters.CI_BOT_GPG >> << pipeline.parameters.CHARTS_REPO_ORIGINAL >> << pipeline.parameters.BRANCH_CHARTS_REPO_ORIGINAL >> << pipeline.parameters.CHARTS_REPO_FORKED >> << pipeline.parameters.BRANCH_CHARTS_REPO_FORKED >>
   sync_chart_from_bitnami:
     environment:
       <<: *common_envars

--- a/script/chart_sync.sh
+++ b/script/chart_sync.sh
@@ -16,7 +16,6 @@ CHARTS_REPO_ORIGINAL=${4:?Missing base chart repository}
 BRANCH_CHARTS_REPO_ORIGINAL=${5:?Missing base chart repository branch}
 CHARTS_REPO_FORKED=${6:?Missing forked chart repository}
 BRANCH_CHARTS_REPO_FORKED=${7:?Missing forked chart repository branch}
-README_GENERATOR_REPO=${8:?Missing readme generator repository}
 
 currentVersion=$(grep -oP '(?<=^version: ).*' <"${KUBEAPPS_CHART_DIR}/Chart.yaml")
 externalVersion=$(curl -s "https://raw.githubusercontent.com/${CHARTS_REPO_ORIGINAL}/${BRANCH_CHARTS_REPO_ORIGINAL}/${CHART_REPO_PATH}/Chart.yaml" | grep -oP '(?<=^version: ).*')
@@ -36,7 +35,6 @@ if [[ ${semverCompare} -gt 0 ]]; then
     prBranchName="kubeapps-bump-${currentVersion}"
 
     updateRepoWithLocalChanges "${TMP_DIR}" "${latestVersion}" "${CHARTS_REPO_ORIGINAL}" "${BRANCH_CHARTS_REPO_ORIGINAL}" "${BRANCH_CHARTS_REPO_FORKED}"
-    generateReadme "${README_GENERATOR_REPO}" "${TMP_DIR}/${CHART_REPO_PATH}"
     commitAndSendExternalPR "${TMP_DIR}" "${prBranchName}" "${currentVersion}" "${CHARTS_REPO_ORIGINAL}" "${BRANCH_CHARTS_REPO_ORIGINAL}"
 elif [[ ${semverCompare} -lt 0 ]]; then
     echo "Skipping Chart sync. WARNING Current chart version (${currentVersion}) is less than the chart external version (${externalVersion})"


### PR DESCRIPTION
Since upstream now run the readme generator as an action when PR is
created.

Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

@antgamdia This PR reverts the fix I did in #4548 to ensure the env var for the readme generator repo was bound, since the run with that change successfully ran the readme generator, but then `commitAndSendExternalPR` failed with "Wrong repo path. You should provide the root of the repository", as though after the readme generator ran, the chart.yaml wasn't in the expected place.

Although I've not verified the above, I also realised that for the upstream PR against bitnami/charts, we actually don't need to run the readme generator, as it's now run automatically as an action for each PR. So this just removes that step. I'm not confident that it'll fix the issue, but needs to be done anyway. Let me know if you've any other thoughts.
