### PR TITLE
Update asset-syncer and kubeops to ensure userAgent set correctly.

### DIFF
--- a/cmd/asset-syncer/cmd/root_test.go
+++ b/cmd/asset-syncer/cmd/root_test.go
@@ -18,8 +18,9 @@ func TestParseFlagsCorrect(t *testing.T) {
 		conf server.Config
 	}{
 		{
-			"all arguments are captured (root command)",
+			"all arguments are captured (invalidate command)",
 			[]string{
+				"invalidate-cache",
 				"--database-url", "foo01",
 				"--database-name", "foo02",
 				"--database-user", "foo03",
@@ -30,7 +31,6 @@ func TestParseFlagsCorrect(t *testing.T) {
 				"--tls-insecure-skip-verify", "true",
 				"--filter-rules", "foo06",
 				"--pass-credentials", "true",
-				"--oci-repositories", "foo07",
 			},
 			server.Config{
 				DatabaseURL:           "foo01",
@@ -39,11 +39,12 @@ func TestParseFlagsCorrect(t *testing.T) {
 				Debug:                 true,
 				Namespace:             "foo04",
 				GlobalReposNamespace:  "kubeapps-global",
-				OciRepositories:       []string{"foo07"},
+				OciRepositories:       []string{},
 				TlsInsecureSkipVerify: true,
 				FilterRules:           "foo06",
 				PassCredentials:       true,
 				UserAgent:             "asset-syncer/devel (foo05)",
+				UserAgentComment:      "foo05",
 			},
 		},
 		{
@@ -74,6 +75,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 				FilterRules:           "foo06",
 				PassCredentials:       true,
 				UserAgent:             "asset-syncer/devel (foo05)",
+				UserAgentComment:      "foo05",
 			},
 		},
 		{
@@ -90,7 +92,6 @@ func TestParseFlagsCorrect(t *testing.T) {
 				"--tls-insecure-skip-verify", "true",
 				"--filter-rules", "foo06",
 				"--pass-credentials", "true",
-				"--oci-repositories", "foo07",
 			},
 			server.Config{
 				DatabaseURL:           "foo01",
@@ -99,26 +100,24 @@ func TestParseFlagsCorrect(t *testing.T) {
 				Debug:                 true,
 				Namespace:             "foo04",
 				GlobalReposNamespace:  "kubeapps-global",
-				OciRepositories:       []string{"foo07"},
+				OciRepositories:       []string{},
 				TlsInsecureSkipVerify: true,
 				FilterRules:           "foo06",
 				PassCredentials:       true,
 				UserAgent:             "asset-syncer/devel (foo05)",
+				UserAgentComment:      "foo05",
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := newRootCmd()
+			cmd := newCmd()
 			b := bytes.NewBufferString("")
 			cmd.SetOut(b)
 			cmd.SetErr(b)
-			setRootFlags(cmd)
-			setSyncFlags(cmd)
 			cmd.SetArgs(tt.args)
 			cmd.Execute()
-			serveOpts.UserAgent = server.GetUserAgent(version, serveOpts.UserAgent)
 			if got, want := serveOpts, tt.conf; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}

--- a/cmd/asset-syncer/server/utils.go
+++ b/cmd/asset-syncer/server/utils.go
@@ -56,6 +56,7 @@ type Config struct {
 	FilterRules           string
 	PassCredentials       bool
 	UserAgent             string
+	UserAgentComment      string
 	GlobalReposNamespace  string
 	KubeappsNamespace     string
 	AuthorizationHeader   string

--- a/cmd/kubeops/cmd/root.go
+++ b/cmd/kubeops/cmd/root.go
@@ -29,6 +29,7 @@ func newRootCmd() *cobra.Command {
 		Use:   "kubeops",
 		Short: "Kubeops is a micro-service that creates an API endpoint for accessing the Helm API and Kubernetes resources.",
 		PreRun: func(cmd *cobra.Command, args []string) {
+			serveOpts.UserAgent = getUserAgent(version, serveOpts.UserAgentComment)
 			log.Infof("kubeops has been configured with: %#v", serveOpts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -49,7 +50,6 @@ func init() {
 	rootCmd = newRootCmd()
 	rootCmd.SetVersionTemplate(version)
 	setFlags(rootCmd)
-	serveOpts.UserAgent = getUserAgent(version, serveOpts.UserAgentComment)
 }
 
 func setFlags(c *cobra.Command) {

--- a/cmd/kubeops/cmd/root_test.go
+++ b/cmd/kubeops/cmd/root_test.go
@@ -61,7 +61,6 @@ func TestParseFlagsCorrect(t *testing.T) {
 			setFlags(cmd)
 			cmd.SetArgs(tt.args)
 			cmd.Execute()
-			serveOpts.UserAgent = getUserAgent(version, serveOpts.UserAgentComment)
 			if got, want := serveOpts, tt.conf; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Following on from the fix for 4470, it looks like with #3449 we may have also broke the userAgent setting for kubeops and the asset-syncer.

This PR updates the tests to actually verify that the userAgent is set and fixes accordingly.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
