### PR TITLE
Auto add issues to the new project board

### DIFF
--- a/.github/workflows/add-issues-to-project.yaml
+++ b/.github/workflows/add-issues-to-project.yaml
@@ -1,21 +1,20 @@
 # Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Auto Assign to Project(s)
+# From https://github.com/github/feedback/discussions/5378#discussioncomment-2137318
+name: Project automation
 
 on:
   issues:
-    types: [opened]
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+    types:
+      - opened
 
 jobs:
-  assign_one_project:
+  add_issue_to_project:
+    name: Add new issues to project board
     runs-on: ubuntu-latest
-    name: Assign to One Project
     steps:
-    - name: Assign NEW issues to project
-      uses: srggrs/assign-one-project-github-action@1.3.1
-      if: github.event.action == 'opened'
-      with:
-        project: 'https://github.com/orgs/kubeapps/projects/4'
+      - run: |
+          gh api graphql -f query='mutation($project:ID!, $issue:ID!) { addProjectNextItem(input: {projectId: $project, contentId: $issue}) { projectNextItem { id }  } }' -f project=${{ secrets.PROJECT_BOARD_ID }} -f issue=${{ github.event.issue.node_id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}

--- a/.github/workflows/add-issues-to-project.yaml
+++ b/.github/workflows/add-issues-to-project.yaml
@@ -1,3 +1,6 @@
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 name: Auto Assign to Project(s)
 
 on:

--- a/.github/workflows/ci-custodian-rules.yaml
+++ b/.github/workflows/ci-custodian-rules.yaml
@@ -1,3 +1,6 @@
+# Copyright 2022 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
 name: Custodian rules for Kubeapps
 on:
   schedule:

--- a/.github/workflows/custodian-rules/remove-unattached-disks.yaml
+++ b/.github/workflows/custodian-rules/remove-unattached-disks.yaml
@@ -1,3 +1,6 @@
+# Copyright 2022 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 policies:
   - name: remove-unattached-disks


### PR DESCRIPTION
### Description of the change

This PR simply adds a new GitHub action, extracted from [here](https://github.com/github/feedback/discussions/5378#discussioncomment-2137318), that automatically adds new issues to the board.

I've already set the proper environment variables in the GitHub repo.

### Benefits

Since we moved to the new projects (beta) boards, we need to add new issues there, so a change was required anyway. Besides, the current gh action we had, wasn't working at all (see https://github.com/vmware-tanzu/kubeapps/actions/runs/2114620529)

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

Added copyright headers that were missing.