### PR TITLE
Fix custodian job

### DIFF
--- a/.github/workflows/ci-custodian-rules.yaml
+++ b/.github/workflows/ci-custodian-rules.yaml
@@ -8,7 +8,7 @@ env:
   CLOUDSDK_CORE_PROJECT: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
 jobs:
   remove-unattached-disks:
-    if: github.repository == 'kubeapps/kubeapps'
+    if: github.repository == 'vmware-tanzu/kubeapps'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Description of the change

I've noticed the custodian job is failing since we transferred the repo to the `vmware-tanzu` organization. This PR is to change the hardcoded value with the correct one.

![image](https://user-images.githubusercontent.com/11535726/163161510-308b22cf-bab8-4b41-9a7f-da867690159b.png)


### Benefits

Jobs will continue to work again

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

@castelblanque , I wonder why we set `if: github.repository == 'vmware-tanzu/kubeapps'` instead of `if: github.repository == '$GITHUB_REPOSITORY'` or even removing this check. Perhaps there's a reason, but I don't recall it now haha.