### PR TITLE
Fix timeout for Carvel installed package summaries

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
@@ -324,15 +324,15 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 			versions map[string]*datapackagingv1alpha1.Package
 		}
 		pkgDatas := make(map[string]map[string]*pkgMetaAndVersionsData)
-		for _, pi := range pkgInstalls {
-			pkgDataForNamespaces, ok := pkgDatas[pi.Spec.PackageRef.RefName]
+		for _, pkgInstall := range pkgInstalls {
+			pkgDataForNamespaces, ok := pkgDatas[pkgInstall.Spec.PackageRef.RefName]
 			if !ok {
 				pkgDataForNamespaces = map[string]*pkgMetaAndVersionsData{}
-				pkgDatas[pi.Spec.PackageRef.RefName] = pkgDataForNamespaces
+				pkgDatas[pkgInstall.Spec.PackageRef.RefName] = pkgDataForNamespaces
 			}
 			// As each package install could potentially be from a pkg in the same
 			// namespace or a package in the global namespace, we track both.
-			for _, ns := range []string{pi.Namespace, s.globalPackagingNamespace} {
+			for _, ns := range []string{pkgInstall.Namespace, s.globalPackagingNamespace} {
 				pkgData, ok := pkgDataForNamespaces[ns]
 				if !ok {
 					pkgData = &pkgMetaAndVersionsData{
@@ -340,9 +340,9 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 					}
 					pkgDataForNamespaces[ns] = pkgData
 				}
-				_, ok = pkgData.versions[pi.Status.Version]
+				_, ok = pkgData.versions[pkgInstall.Status.Version]
 				if !ok {
-					pkgData.versions[pi.Status.Version] = nil
+					pkgData.versions[pkgInstall.Status.Version] = nil
 				}
 			}
 		}

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	packagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
@@ -285,7 +284,7 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 		cluster = s.globalPackagingCluster
 	}
 
-	// retrieve the list of installed packages
+	// retrieve the paginated list of installed packages
 	// TODO(agamez): we should be paginating this request rather than requesting everything every time
 	pkgInstalls, err := s.getPkgInstalls(ctx, cluster, namespace)
 	if err != nil {
@@ -293,83 +292,119 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 	}
 
 	// paginate the list of results
-	installedPkgSummaries := make([]*corev1.InstalledPackageSummary, len(pkgInstalls))
+	installedPkgSummaries := []*corev1.InstalledPackageSummary{}
 
-	// create the waiting group for processing each item aynchronously
-	var wg sync.WaitGroup
-
-	// TODO(agamez): DRY up this logic (cf GetAvailablePackageSummaries)
 	if len(pkgInstalls) > 0 {
 		startAt := -1
 		if pageSize > 0 {
 			startAt = int(pageSize) * pageOffset
-		}
-		for i, pkgInstall := range pkgInstalls {
-			wg.Add(1)
-			if startAt <= i {
-				go func(i int, pkgInstall *packagingv1alpha1.PackageInstall) error {
-					defer wg.Done()
-					// fetch additional information from the package metadata
-					// TODO(agamez): if the repository where the package belongs to is not installed, it will throw an error;
-					// decide whether we should ignore it or it is ok with returning an error
-					pkgMetadata, err := s.getPkgMetadata(ctx, cluster, pkgInstall.ObjectMeta.Namespace, pkgInstall.Spec.PackageRef.RefName)
-					if err != nil {
-						return statuserror.FromK8sError("get", "PackageMetadata", pkgInstall.Spec.PackageRef.RefName, err)
-					}
-
-					// Use the field selector to return only Package CRs that match on the spec.refName.
-					fieldSelector := fmt.Sprintf("spec.refName=%s", pkgInstall.Spec.PackageRef.RefName)
-					pkgs, err := s.getPkgsWithFieldSelector(ctx, cluster, pkgInstall.ObjectMeta.Namespace, fieldSelector)
-					if err != nil {
-						return statuserror.FromK8sError("get", "Package", "", err)
-					}
-					pkgVersionsMap, err := getPkgVersionsMap(pkgs)
-					if err != nil {
-						return err
-					}
-
-					// generate the installedPackageSummary from the fetched information
-					installedPackageSummary, err := s.buildInstalledPackageSummary(pkgInstall, pkgMetadata, pkgVersionsMap, cluster)
-					if err != nil {
-						return status.Errorf(codes.Internal, fmt.Sprintf("unable to create the InstalledPackageSummary: %v", err))
-					}
-
-					// append the availablePackageSummary to the slice
-					installedPkgSummaries[i] = installedPackageSummary
-
-					return nil
-				}(i, pkgInstall)
+			if startAt > len(pkgInstalls) {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid pagination arguments %v", request.GetPaginationOptions())
 			}
-			// if we've reached the end of the page, stop iterating
-			if pageSize > 0 && len(installedPkgSummaries) == int(pageSize) {
-				break
+			pkgInstalls = pkgInstalls[startAt:]
+			if len(pkgInstalls) > int(pageSize) {
+				pkgInstalls = pkgInstalls[:pageSize]
 			}
 		}
-	}
-	// Wait until each goroutine has finished
-	wg.Wait()
 
-	// TODO(agamez): the slice with make is filled with <nil>, in case of an error in the
-	// i goroutine, the i-th <nil> stub will remain. Check if 'errgroup' works here, but I haven't
-	// been able so far.
-	// An alternative is using channels to perform a fine-grained control... but not sure if it worths
-	// However, should we just return an error if so? See https://github.com/vmware-tanzu/kubeapps/pull/3784#discussion_r754836475
-	// filter out <nil> values
-	installedPkgSummariesNilSafe := []*corev1.InstalledPackageSummary{}
-	for _, installedPkgSummary := range installedPkgSummaries {
-		if installedPkgSummary != nil {
-			installedPkgSummariesNilSafe = append(installedPkgSummariesNilSafe, installedPkgSummary)
+		// Collect a set of all package names with their corresponding
+		// package metadata and package version data.
+		type pkgMetaAndVersionsData struct {
+			meta     *datapackagingv1alpha1.PackageMetadata
+			versions map[string]*datapackagingv1alpha1.Package
+		}
+		pkgDatas := make(map[string]*pkgMetaAndVersionsData)
+		for _, pi := range pkgInstalls {
+			pkgData, ok := pkgDatas[pi.Spec.PackageRef.RefName]
+			if !ok {
+				pkgData = &pkgMetaAndVersionsData{
+					versions: make(map[string]*datapackagingv1alpha1.Package),
+				}
+				pkgDatas[pi.Spec.PackageRef.RefName] = pkgData
+			}
+			_, ok = pkgData.versions[pi.Status.Version]
+			if !ok {
+				pkgData.versions[pi.Status.Version] = nil
+			}
+		}
+
+		// First get all the package metadatas for the namespace and filter
+		// to match the pkgInstalls. While filtering, we populate the
+		// collected package data with the metadata.
+		pkgMetadatas, err := s.getPkgMetadatas(ctx, cluster, namespace)
+		if err != nil {
+			return nil, statuserror.FromK8sError("get", "PackageMetadata", "", err)
+		}
+		filteredPkgMetadatas := []*datapackagingv1alpha1.PackageMetadata{}
+		for _, pm := range pkgMetadatas {
+			if pkgData, ok := pkgDatas[pm.Name]; ok {
+				filteredPkgMetadatas = append(filteredPkgMetadatas, pm)
+				pkgData.meta = pm
+			}
+		}
+
+		// Create a channel to receive all packages available in the namespace.
+		// Using a buffered channel so that we don't block the network request if we
+		// can't process fast enough.
+		getPkgsChannel := make(chan *datapackagingv1alpha1.Package, PACKAGES_CHANNEL_BUFFER_SIZE)
+		var getPkgsError error
+		go func() {
+			getPkgsError = s.getPkgs(ctx, cluster, namespace, getPkgsChannel)
+		}()
+
+		// For each package, we check if we need it to populate our
+		// package data.
+		pkgsForVersionMap := []*datapackagingv1alpha1.Package{}
+		for pkg := range getPkgsChannel {
+			pkgdata, ok := pkgDatas[pkg.Spec.RefName]
+			if !ok {
+				continue
+			}
+			pkgsForVersionMap = append(pkgsForVersionMap, pkg)
+			_, ok = pkgdata.versions[pkg.Spec.Version]
+			if !ok {
+				continue
+			}
+			pkgdata.versions[pkg.Spec.Version] = pkg
+		}
+
+		// Verify no error during go routine.
+		if getPkgsError != nil {
+			return nil, statuserror.FromK8sError("get", "Package", "", err)
+		}
+
+		// Calculate the version map for all packages that we're interested
+		// in for this paginated call.
+		pkgVersionsMap, err := getPkgVersionsMap(pkgsForVersionMap)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, fmt.Sprintf("unable to calculate package versions map: %v", err))
+		}
+
+		// We now have all the data we need to return the result:
+
+		for _, pkgi := range pkgInstalls {
+			pkgName := pkgi.Spec.PackageRef.RefName
+			pkgData := pkgDatas[pkgName]
+			// generate the installedPackageSummary from the fetched information
+			log.Errorf("pkgDatas: %v", pkgDatas)
+			installedPackageSummary, err := s.buildInstalledPackageSummary(pkgi, pkgData.meta, pkgVersionsMap, cluster)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, fmt.Sprintf("unable to create the InstalledPackageSummary: %v", err))
+			}
+
+			// append the availablePackageSummary to the slice
+			installedPkgSummaries = append(installedPkgSummaries, installedPackageSummary)
 		}
 	}
 
 	// Only return a next page token if the request was for pagination and
 	// the results are a full page.
 	nextPageToken := ""
-	if pageSize > 0 && len(installedPkgSummariesNilSafe) == int(pageSize) {
+	if pageSize > 0 && len(installedPkgSummaries) == int(pageSize) {
 		nextPageToken = fmt.Sprintf("%d", pageOffset+1)
 	}
 	response := &corev1.GetInstalledPackageSummariesResponse{
-		InstalledPackageSummaries: installedPkgSummariesNilSafe,
+		InstalledPackageSummaries: installedPkgSummaries,
 		NextPageToken:             nextPageToken,
 	}
 	return response, nil

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_adapters.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_adapters.go
@@ -163,7 +163,7 @@ func (s *Server) buildInstalledPackageSummary(pkgInstall *packagingv1alpha1.Pack
 		IconUrl: iconStringBuilder.String(),
 		InstalledPackageRef: &corev1.InstalledPackageReference{
 			Context: &corev1.Context{
-				Namespace: pkgMetadata.Namespace,
+				Namespace: pkgInstall.Namespace,
 				Cluster:   cluster,
 			},
 			Plugin:     &pluginDetail,

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
@@ -1330,6 +1330,101 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 		expectedStatusCode codes.Code
 	}{
 		{
+			name: "it returns an error if a non-existent page is requested",
+			request: &corev1.GetInstalledPackageSummariesRequest{
+				Context: defaultContext,
+				PaginationOptions: &corev1.PaginationOptions{
+					PageToken: "2",
+					PageSize:  2,
+				},
+			},
+			existingObjects: []runtime.Object{
+				&datapackagingv1alpha1.PackageMetadata{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       pkgMetadataResource,
+						APIVersion: datapackagingAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tetris.foo.example.com",
+					},
+					Spec: datapackagingv1alpha1.PackageMetadataSpec{
+						DisplayName:        "Classic Tetris",
+						IconSVGBase64:      "Tm90IHJlYWxseSBTVkcK",
+						ShortDescription:   "A great game for arcade gamers",
+						LongDescription:    "A few sentences but not really a readme",
+						Categories:         []string{"logging", "daemon-set"},
+						Maintainers:        []datapackagingv1alpha1.Maintainer{{Name: "person1"}, {Name: "person2"}},
+						SupportDescription: "Some support information",
+						ProviderName:       "Tetris inc.",
+					},
+				},
+				&datapackagingv1alpha1.Package{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       pkgResource,
+						APIVersion: datapackagingAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tetris.foo.example.com.1.2.3",
+					},
+					Spec: datapackagingv1alpha1.PackageSpec{
+						RefName:                         "tetris.foo.example.com",
+						Version:                         "1.2.3",
+						Licenses:                        []string{"my-license"},
+						ReleaseNotes:                    "release notes",
+						CapactiyRequirementsDescription: "capacity description",
+						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+					},
+				},
+				&packagingv1alpha1.PackageInstall{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       pkgInstallResource,
+						APIVersion: packagingAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation",
+					},
+					Spec: packagingv1alpha1.PackageInstallSpec{
+						ServiceAccountName: "default",
+						PackageRef: &packagingv1alpha1.PackageRef{
+							RefName: "tetris.foo.example.com",
+							VersionSelection: &vendirversions.VersionSelectionSemver{
+								Constraints: "1.2.3",
+							},
+						},
+						Values: []packagingv1alpha1.PackageInstallValues{{
+							SecretRef: &packagingv1alpha1.PackageInstallValuesSecretRef{
+								Name: "my-installation-default-values",
+							},
+						},
+						},
+						Paused:     false,
+						Canceled:   false,
+						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						NoopDelete: false,
+					},
+					Status: packagingv1alpha1.PackageInstallStatus{
+						GenericStatus: kappctrlv1alpha1.GenericStatus{
+							ObservedGeneration: 1,
+							Conditions: []kappctrlv1alpha1.AppCondition{{
+								Type:    kappctrlv1alpha1.ReconcileSucceeded,
+								Status:  k8scorev1.ConditionTrue,
+								Reason:  "baz",
+								Message: "qux",
+							}},
+							FriendlyDescription: "foo",
+							UsefulErrorMessage:  "Deployed",
+						},
+						Version:              "1.2.3",
+						LastAttemptedVersion: "1.2.3",
+					},
+				},
+			},
+			expectedStatusCode: codes.InvalidArgument,
+		},
+		{
 			name:    "it returns carvel empty installed package summary when no package install is present",
 			request: &corev1.GetInstalledPackageSummariesRequest{Context: defaultContext},
 			existingObjects: []runtime.Object{
@@ -1494,7 +1589,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 			},
 		},
 		{
-			name: "it returns carvel installed package from different namespaces if context.namespace=='' ",
+			name: "it returns carvel installed package from different namespaces if context.namespace==''",
 			request: &corev1.GetInstalledPackageSummariesRequest{
 				Context: &corev1.Context{
 					Namespace: "",

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
@@ -1589,6 +1589,134 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 			},
 		},
 		{
+			name: "it returns carvel installed package summary with complete metadata from global namespace",
+			// Request in test has to use empty namespace to search across all
+			// namespaces since in real life the metadata and package resources
+			// are not actual CRs but aggregated APIs that return data across
+			// namespaces.
+			request: &corev1.GetInstalledPackageSummariesRequest{
+				Context: &corev1.Context{
+					Namespace: "",
+					Cluster:   defaultContext.Cluster,
+				},
+			},
+			existingObjects: []runtime.Object{
+				&datapackagingv1alpha1.PackageMetadata{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       pkgMetadataResource,
+						APIVersion: datapackagingAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: globalPackagingNamespace,
+						Name:      "tetris.foo.example.com",
+					},
+					Spec: datapackagingv1alpha1.PackageMetadataSpec{
+						DisplayName:        "Classic Tetris",
+						IconSVGBase64:      "Tm90IHJlYWxseSBTVkcK",
+						ShortDescription:   "A great game for arcade gamers",
+						LongDescription:    "A few sentences but not really a readme",
+						Categories:         []string{"logging", "daemon-set"},
+						Maintainers:        []datapackagingv1alpha1.Maintainer{{Name: "person1"}, {Name: "person2"}},
+						SupportDescription: "Some support information",
+						ProviderName:       "Tetris inc.",
+					},
+				},
+				&datapackagingv1alpha1.Package{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       pkgResource,
+						APIVersion: datapackagingAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: globalPackagingNamespace,
+						Name:      "tetris.foo.example.com.1.2.3",
+					},
+					Spec: datapackagingv1alpha1.PackageSpec{
+						RefName:                         "tetris.foo.example.com",
+						Version:                         "1.2.3",
+						Licenses:                        []string{"my-license"},
+						ReleaseNotes:                    "release notes",
+						CapactiyRequirementsDescription: "capacity description",
+						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+					},
+				},
+				&packagingv1alpha1.PackageInstall{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       pkgInstallResource,
+						APIVersion: packagingAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation",
+					},
+					Spec: packagingv1alpha1.PackageInstallSpec{
+						ServiceAccountName: "default",
+						PackageRef: &packagingv1alpha1.PackageRef{
+							RefName: "tetris.foo.example.com",
+							VersionSelection: &vendirversions.VersionSelectionSemver{
+								Constraints: "1.2.3",
+							},
+						},
+						Values: []packagingv1alpha1.PackageInstallValues{{
+							SecretRef: &packagingv1alpha1.PackageInstallValuesSecretRef{
+								Name: "my-installation-default-values",
+							},
+						},
+						},
+						Paused:     false,
+						Canceled:   false,
+						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						NoopDelete: false,
+					},
+					Status: packagingv1alpha1.PackageInstallStatus{
+						GenericStatus: kappctrlv1alpha1.GenericStatus{
+							ObservedGeneration: 1,
+							Conditions: []kappctrlv1alpha1.AppCondition{{
+								Type:    kappctrlv1alpha1.ReconcileSucceeded,
+								Status:  k8scorev1.ConditionTrue,
+								Reason:  "baz",
+								Message: "qux",
+							}},
+							FriendlyDescription: "foo",
+							UsefulErrorMessage:  "Deployed",
+						},
+						Version:              "1.2.3",
+						LastAttemptedVersion: "1.2.3",
+					},
+				},
+			},
+			expectedPackages: []*corev1.InstalledPackageSummary{
+				{
+					InstalledPackageRef: &corev1.InstalledPackageReference{
+						Context:    defaultContext,
+						Plugin:     &pluginDetail,
+						Identifier: "my-installation",
+					},
+					Name:           "my-installation",
+					PkgDisplayName: "Classic Tetris",
+					LatestVersion: &corev1.PackageAppVersion{
+						PkgVersion: "1.2.3",
+						AppVersion: "1.2.3",
+					},
+					IconUrl:             "data:image/svg+xml;base64,Tm90IHJlYWxseSBTVkcK",
+					ShortDescription:    "A great game for arcade gamers",
+					PkgVersionReference: &corev1.VersionReference{Version: "1.2.3"},
+					CurrentVersion: &corev1.PackageAppVersion{
+						PkgVersion: "1.2.3",
+						AppVersion: "1.2.3",
+					},
+					LatestMatchingVersion: &corev1.PackageAppVersion{
+						PkgVersion: "1.2.3",
+						AppVersion: "1.2.3",
+					},
+					Status: &corev1.InstalledPackageStatus{
+						Ready:      true,
+						Reason:     corev1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
+						UserReason: "Deployed",
+					},
+				},
+			},
+		},
+		{
 			name: "it returns carvel installed package from different namespaces if context.namespace==''",
 			request: &corev1.GetInstalledPackageSummariesRequest{
 				Context: &corev1.Context{
@@ -2239,6 +2367,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 							unstructuredObjects...,
 						)).Build(), nil
 				},
+				globalPackagingNamespace: globalPackagingNamespace,
 			}
 
 			response, err := s.GetInstalledPackageSummaries(context.Background(), tc.request)

--- a/script/makefiles/deploy-dev.mk
+++ b/script/makefiles/deploy-dev.mk
@@ -56,7 +56,7 @@ reset-dev-kubeapps:
 # The kapp-controller support for the new Package and PackageRepository CRDs is currently
 # only available in an alpha release.
 deploy-kapp-controller:
-	kubectl --kubeconfig=${CLUSTER_CONFIG} apply -f https://github.com/vmware-tanzu/carvel-kapp-controller/releases/download/v0.32.0/release.yml
+	kubectl --kubeconfig=${CLUSTER_CONFIG} apply -f https://github.com/vmware-tanzu/carvel-kapp-controller/releases/download/v0.35.0/release.yml
 	kubectl --kubeconfig=${CLUSTER_CONFIG} apply -f https://raw.githubusercontent.com/vmware-tanzu/carvel-kapp-controller/develop/examples/packaging-with-repo/package-repository.yml
 
 # Add the flux controllers used for testing the kubeapps-apis integration.


### PR DESCRIPTION
- Solution that works with the exception of across namespaces.
- Adapt solution to cater for requests across namespaces.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

I thought this was going to be similar to #4378 but although a similar approach can be taken, the solution is quite different, due to the iteration of package installs (rather than metadata).

It also ended up substantially more complicated for two reasons that I've highlighted in the code with a comment.

### Benefits

Response times are approximately 1/6th for fetching installed package summaries (tested locally with 10 installed packages).

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #4542

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
