### PR TITLE
fix(dashboard): Add support for "" kubeappsCluster

### DIFF
--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -54,8 +54,10 @@ export default function DeploymentForm() {
   const {
     packages: { isFetching: packagesIsFetching, selected: selectedPackage },
     apps,
+    config: { kubeappsCluster },
   } = useSelector((state: IStoreState) => state);
 
+  const packageFetchCluster = packageCluster === "-" ? kubeappsCluster : packageCluster;
   const [isDeploying, setDeploying] = useState(false);
   const [releaseName, setReleaseName] = useState("");
   const [appValues, setAppValues] = useState(selectedPackage.values || "");
@@ -76,7 +78,7 @@ export default function DeploymentForm() {
 
   const [packageReference] = useState({
     context: {
-      cluster: packageCluster,
+      cluster: packageFetchCluster,
       namespace: packageNamespace,
     },
     plugin: pluginObj,

--- a/dashboard/src/components/PackageHeader/PackageView.tsx
+++ b/dashboard/src/components/PackageHeader/PackageView.tsx
@@ -49,13 +49,15 @@ export default function PackageView() {
   } = ReactRouter.useParams() as IRouteParams;
   const {
     packages: { isFetching, selected: selectedPackage },
-    config: { skipAvailablePackageDetails },
+    config: { skipAvailablePackageDetails, kubeappsCluster },
   } = useSelector((state: IStoreState) => state);
 
   const [pluginObj] = useState({ name: pluginName, version: pluginVersion } as Plugin);
+
+  const packageFetchCluster = packageCluster === "-" ? kubeappsCluster : packageCluster;
   const [packageReference] = useState({
     context: {
-      cluster: packageCluster,
+      cluster: packageFetchCluster,
       namespace: packageNamespace,
     },
     plugin: pluginObj,
@@ -77,13 +79,13 @@ export default function PackageView() {
   useEffect(() => {
     dispatch(
       actions.availablepackages.fetchAvailablePackageVersions({
-        context: { cluster: packageCluster, namespace: packageNamespace },
+        context: { cluster: packageFetchCluster, namespace: packageNamespace },
         plugin: { name: pluginName, version: pluginVersion } as Plugin,
         identifier: packageId,
       } as AvailablePackageReference),
     );
     return () => {};
-  }, [dispatch, packageId, packageNamespace, packageCluster, pluginName, pluginVersion]);
+  }, [dispatch, packageId, packageNamespace, packageFetchCluster, pluginName, pluginVersion]);
 
   // Select version handler
   const selectVersion = (event: React.ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change
<!-- Describe the scope of your change - i.e. what the change does. -->
Related frontend changes for #4591. These changes are required so that the route params are correctly translated. 

### Todo
- Test coverage for "" cluster for routing and fetching

@absoludity when I was testing locally I also ran into something new. When trying to deploy a helm chart I run into the following:
```
An error occurred: Unable to create the installed package for the package "coreweave/argo-cd" using the plugin "helm.packages": rpc error: code = Internal desc = Unable to create kubernetes clientset: rpc error: code = FailedPrecondition desc = unable to get client : rpc error: code = FailedPrecondition desc = unable to get controller runtime client due to: Unauthorized
```
