### PR TITLE
Return NotFound immediately when kapp configmap not found.

### DIFF
--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -6,8 +6,6 @@
 FROM bitnami/golang:1.17.6 as builder
 WORKDIR /go/src/github.com/vmware-tanzu/kubeapps
 COPY go.mod go.sum ./
-COPY pkg pkg
-COPY cmd cmd
 ARG VERSION="devel"
 
 ARG BUF_VERSION="1.0.0-rc11"
@@ -18,6 +16,11 @@ RUN curl -sSL "https://github.com/bufbuild/buf/releases/download/v$BUF_VERSION/b
 RUN --mount=type=cache,target=/go/pkg/mod  \
     --mount=type=cache,target=/root/.cache/go-build \
     go mod download
+
+# We don't copy the pkg and cmd directories until here so the above layers can
+# be reused.
+COPY pkg pkg
+COPY cmd cmd
 
 # Lint the proto files to detect errors at build time
 RUN /tmp/buf lint ./cmd/kubeapps-apis

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
@@ -5310,6 +5310,63 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 				Context: defaultContext,
 			},
 		},
+		{
+			name: "returns NotFound if the app configmap is not yet available",
+			request: &corev1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &corev1.InstalledPackageReference{
+					Context:    defaultContext,
+					Plugin:     &pluginDetail,
+					Identifier: "my-installation",
+				},
+			},
+			existingObjects: []runtime.Object{
+				&packagingv1alpha1.PackageInstall{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       pkgInstallResource,
+						APIVersion: packagingAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation",
+					},
+					Spec: packagingv1alpha1.PackageInstallSpec{
+						ServiceAccountName: "default",
+						PackageRef: &packagingv1alpha1.PackageRef{
+							RefName: "tetris.foo.example.com",
+							VersionSelection: &vendirversions.VersionSelectionSemver{
+								Constraints: "1.2.3",
+							},
+						},
+						Values: []packagingv1alpha1.PackageInstallValues{{
+							SecretRef: &packagingv1alpha1.PackageInstallValuesSecretRef{
+								Name: "my-installation-default-values",
+							},
+						},
+						},
+						Paused:     false,
+						Canceled:   false,
+						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						NoopDelete: false,
+					},
+					Status: packagingv1alpha1.PackageInstallStatus{
+						GenericStatus: kappctrlv1alpha1.GenericStatus{
+							ObservedGeneration: 1,
+							Conditions: []kappctrlv1alpha1.AppCondition{{
+								Type:    kappctrlv1alpha1.ReconcileSucceeded,
+								Status:  k8scorev1.ConditionTrue,
+								Reason:  "baz",
+								Message: "qux",
+							}},
+							FriendlyDescription: "foo",
+							UsefulErrorMessage:  "foo",
+						},
+						Version:              "1.2.3",
+						LastAttemptedVersion: "1.2.3",
+					},
+				},
+			},
+			expectedStatusCode: codes.NotFound,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Updates the `GetInstalledPackageResourceRefs()` call so that it will not wait indefinitely (or until a timeout) for the kapp config map to have been created.

Instead, the code now returns a NotFound error immediately, which is already handled by the dashboard code with an explanatory comment at:

https://github.com/vmware-tanzu/kubeapps/blob/06774a4476219b6e031b5b2fb436f1c12a8048bd/dashboard/src/components/AppView/AppView.tsx#L180-L187

### Benefits

We neither wait for a timeout, nor do we switch to an error after the timeout, fixing case 2 of #4614 .
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #4614

### Additional information

I'll now check the case 1 situation, which may be harder (optimizing the response when all the data is there). EDIT: Nothing to do there, even for a kubeapps carvel install, `GetInstallPackageResourceRefs` is returning in under 500ms.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
