### PR TITLE
Rename `additionalFlags` to `extraFlags`

### DIFF
--- a/docs/howto/OIDC/OAuth2OIDC-VMware-cloud-services.md
+++ b/docs/howto/OIDC/OAuth2OIDC-VMware-cloud-services.md
@@ -39,7 +39,7 @@ authProxy:
   clientSecret: <your app secret>
   cookieSecret: <your random seed string for secure cookies>
   scope: openid email group_names
-  additionalFlags:
+  extraFlags:
     # VMware Cloud Services has different endpoints for production and staging:
     # To use the staging endpoints, replace:
     # 'gaz.csp-vidm-prod.com' with 'gaz-preview.csp-vidm-prod.com'

--- a/docs/howto/OIDC/OAuth2OIDC-azure-active-directory.md
+++ b/docs/howto/OIDC/OAuth2OIDC-azure-active-directory.md
@@ -71,7 +71,7 @@ authProxy:
   provider: oidc
   clientID: <MY-APPLICATION-ID>
   clientSecret: <MY-SECRET>
-  additionalFlags:
+  extraFlags:
     - --oidc-issuer-url=https://login.microsoftonline.com/<MY-TENANT-ID>/v2.0 # required for azure
     - --scope=openid email 6dae42f8-4368-4678-94ff-3960e28e3630/user.read # required for azure, exactly this string without modification
 ```

--- a/docs/howto/OIDC/OAuth2OIDC-debugging.md
+++ b/docs/howto/OIDC/OAuth2OIDC-debugging.md
@@ -68,7 +68,7 @@ Prior to the Kubeapps chart version 7.1.0, the auth proxy configuration did not 
 To avoid this issue, you can do one of the following:
 
 - upgrade the Kubeapps chart to version 7.1.0+ which sets a default of `--cookie-refresh=2m` and exposes the value in the chart values as `authProxy.cookieRefresh`.
-- update Kubeapps by adding the option `--cookie-refresh=2m` to `authProxy.additionalFlags`.
+- update Kubeapps by adding the option `--cookie-refresh=2m` to `authProxy.extraFlags`.
 
 The duration for the refresh must be less than the access/openid expiration time configured in the OAuth2/OIDC provider.
 

--- a/docs/howto/OIDC/OAuth2OIDC-keycloak.md
+++ b/docs/howto/OIDC/OAuth2OIDC-keycloak.md
@@ -296,7 +296,7 @@ authProxy:
  emailDomain: "*"
  ## Additional flags for oauth2-proxy
  ##
- additionalFlags:
+ extraFlags:
   - --ssl-insecure-skip-verify
   - --cookie-secure=false
   - --scope=openid email groups

--- a/docs/howto/OIDC/OAuth2OIDC-oauth2-proxy.md
+++ b/docs/howto/OIDC/OAuth2OIDC-oauth2-proxy.md
@@ -10,7 +10,7 @@ Kubeapps chart allows you to automatically deploy the proxy for you as a sidecar
   # ... other OIDC flags
  --set authProxy.oauthLoginURI="/subpath/oauth2/login" \
  --set authProxy.oauthLogoutURI="/subpath/oauth2/logout" \
- --set authProxy.additionalFlags="{<other flags>,--proxy-prefix=/subpath/oauth2}"\
+ --set authProxy.extraFlags="{<other flags>,--proxy-prefix=/subpath/oauth2}"\
 ```
 
 **Example 1: Using the OIDC provider**
@@ -25,7 +25,7 @@ helm install kubeapps bitnami/kubeapps \
   --set authProxy.clientID=my-client-id.apps.googleusercontent.com \
   --set authProxy.clientSecret=my-client-secret \
   --set authProxy.cookieSecret=$(echo "not-good-secret" | base64) \
-  --set authProxy.additionalFlags="{--cookie-secure=false,--oidc-issuer-url=https://accounts.google.com}" \
+  --set authProxy.extraFlags="{--cookie-secure=false,--oidc-issuer-url=https://accounts.google.com}" \
 ```
 
 **Example 2: Using a custom oauth2-proxy provider**
@@ -42,7 +42,7 @@ helm install kubeapps bitnami/kubeapps \
   --set authProxy.clientID=my-client-id.apps.googleusercontent.com \
   --set authProxy.clientSecret=my-client-secret \
   --set authProxy.cookieSecret=$(echo "not-good-secret" | base64) \
-  --set authProxy.additionalFlags="{--cookie-secure=false}"
+  --set authProxy.extraFlags="{--cookie-secure=false}"
 ```
 
 **Example 3: Authentication for Kubeapps on a GKE cluster**
@@ -64,7 +64,7 @@ helm install kubeapps bitnami/kubeapps \
   --set authProxy.clientSecret=my-client-secret \
   --set authProxy.cookieSecret=$(echo "not-good-secret" | base64) \
   --set authProxy.scope="https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/cloud-platform" \
-  --set authProxy.additionalFlags="{--cookie-secure=false}" \
+  --set authProxy.extraFlags="{--cookie-secure=false}" \
   --set frontend.proxypassAccessTokenAsBearer=true
 ```
 

--- a/docs/tutorials/kubeapps-on-tkg/step-2.md
+++ b/docs/tutorials/kubeapps-on-tkg/step-2.md
@@ -105,7 +105,7 @@ authProxy:
   clientID: CLIENT-ID
   clientSecret: CLIENT-SECRET
   cookieSecret: COOKIE-SECRET
-  additionalFlags:
+  extraFlags:
     - --skip-oidc-discovery=true
     - --oidc-issuer-url=OIDC-ISSUER-URL # In CSP: https://gaz.csp-vidm-prod.com
     - --login-url=OIDC-LOGIN-URL # In CSP: https://console.cloud.vmware.com/csp/gateway/discovery


### PR DESCRIPTION
### Description of the change

I've noticed we left unchanged some of our docs during the chart standardization. Specifically, with respect to this change:
>- `authProxy.additionalFlags` renamed as `authProxy.extraFlags`


This PR is to update our docs to to use `extraFlags` instead of `additionalFlags`.

### Benefits

Our docs will be up to date and will be consistent with our current chart values.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

There is still another file using `additionalFlags`, but it is the chart readme, so we better change it upstream, so that the change get published sooner.
