### PR TITLE
Remove knowledge of pagination internals from UX/Client

### DIFF
--- a/dashboard/src/actions/availablepackages.test.tsx
+++ b/dashboard/src/actions/availablepackages.test.tsx
@@ -25,7 +25,7 @@ let store: any;
 const namespace = "package-namespace";
 const cluster = "default";
 const repos = "foo";
-const defaultPage = 1;
+const defaultPaginationToken = "defaultPaginationToken";
 const defaultSize = 0;
 const plugin = { name: "my.plugin", version: "0.0.1" } as Plugin;
 
@@ -80,138 +80,153 @@ interface IfetchAvailablePackageSummariesTestCase {
   name: string;
   response: GetAvailablePackageSummariesResponse;
   requestedRepos: string;
-  requestedPage: number;
+  requestedPageToken: string;
   requestedQuery?: string;
   expectedActions: any;
   expectedParams: any[];
 }
+
+const currentPageToken = "currentPageToken";
+const nextPageToken = "nextPageToken";
 
 const fetchAvailablePackageSummariesTestCases: IfetchAvailablePackageSummariesTestCase[] = [
   {
     name: "fetches packages with query",
     response: {
       availablePackageSummaries: [defaultAvailablePackageSummary],
-      nextPageToken: "1",
+      nextPageToken,
       categories: ["foo"],
     },
     requestedRepos: "",
-    requestedPage: 1,
+    requestedPageToken: currentPageToken,
     requestedQuery: "foo",
     expectedActions: [
-      { type: getType(actions.availablepackages.requestAvailablePackageSummaries), payload: 1 },
+      {
+        type: getType(actions.availablepackages.requestAvailablePackageSummaries),
+        payload: currentPageToken,
+      },
       {
         type: getType(actions.availablepackages.receiveAvailablePackageSummaries),
         payload: {
           response: {
             availablePackageSummaries: [defaultAvailablePackageSummary],
-            nextPageToken: "1",
+            nextPageToken,
             categories: ["foo"],
           },
-          page: 1,
+          paginationToken: currentPageToken,
         } as IReceivePackagesActionPayload,
       },
     ],
-    expectedParams: [cluster, namespace, "", 1, defaultSize, "foo"],
+    expectedParams: [cluster, namespace, "", currentPageToken, defaultSize, "foo"],
   },
   {
     name: "fetches packages from a repo (first page)",
     response: {
       availablePackageSummaries: [defaultAvailablePackageSummary],
-      nextPageToken: "3",
+      nextPageToken,
       categories: ["foo"],
     },
     requestedRepos: repos,
-    requestedPage: 1,
+    requestedPageToken: "",
     expectedActions: [
-      { type: getType(actions.availablepackages.requestAvailablePackageSummaries), payload: 1 },
+      { type: getType(actions.availablepackages.requestAvailablePackageSummaries), payload: "" },
       {
         type: getType(actions.availablepackages.receiveAvailablePackageSummaries),
         payload: {
           response: {
             availablePackageSummaries: [defaultAvailablePackageSummary],
-            nextPageToken: "3",
+            nextPageToken,
             categories: ["foo"],
           },
-          page: 1,
+          paginationToken: "",
         } as IReceivePackagesActionPayload,
       },
     ],
-    expectedParams: [cluster, namespace, repos, 1, defaultSize, undefined],
+    expectedParams: [cluster, namespace, repos, "", defaultSize, undefined],
   },
   {
     name: "fetches packages from a repo (middle page)",
     response: {
       availablePackageSummaries: [defaultAvailablePackageSummary],
-      nextPageToken: "3",
+      nextPageToken,
       categories: ["foo"],
     },
     requestedRepos: repos,
-    requestedPage: 2,
+    requestedPageToken: currentPageToken,
     expectedActions: [
-      { type: getType(actions.availablepackages.requestAvailablePackageSummaries), payload: 2 },
+      {
+        type: getType(actions.availablepackages.requestAvailablePackageSummaries),
+        payload: currentPageToken,
+      },
       {
         type: getType(actions.availablepackages.receiveAvailablePackageSummaries),
         payload: {
           response: {
             availablePackageSummaries: [defaultAvailablePackageSummary],
-            nextPageToken: "3",
+            nextPageToken,
             categories: ["foo"],
           },
-          page: 2,
+          paginationToken: currentPageToken,
         } as IReceivePackagesActionPayload,
       },
     ],
-    expectedParams: [cluster, namespace, repos, 2, defaultSize, undefined],
+    expectedParams: [cluster, namespace, repos, currentPageToken, defaultSize, undefined],
   },
   {
     name: "fetches packages from a repo (last page)",
     response: {
       availablePackageSummaries: [defaultAvailablePackageSummary],
-      nextPageToken: "3",
+      nextPageToken: "",
       categories: ["foo"],
     },
     requestedRepos: repos,
-    requestedPage: 3,
+    requestedPageToken: currentPageToken,
     expectedActions: [
-      { type: getType(actions.availablepackages.requestAvailablePackageSummaries), payload: 3 },
+      {
+        type: getType(actions.availablepackages.requestAvailablePackageSummaries),
+        payload: currentPageToken,
+      },
       {
         type: getType(actions.availablepackages.receiveAvailablePackageSummaries),
         payload: {
           response: {
             availablePackageSummaries: [defaultAvailablePackageSummary],
-            nextPageToken: "3",
+            nextPageToken: "",
             categories: ["foo"],
           },
-          page: 3,
+          paginationToken: currentPageToken,
         } as IReceivePackagesActionPayload,
       },
     ],
-    expectedParams: [cluster, namespace, repos, 3, defaultSize, undefined],
+    expectedParams: [cluster, namespace, repos, currentPageToken, defaultSize, undefined],
   },
   {
     name: "fetches packages from a repo (already processed page)",
     response: {
       availablePackageSummaries: [defaultAvailablePackageSummary],
-      nextPageToken: "3",
+      nextPageToken,
       categories: ["foo"],
     },
     requestedRepos: repos,
-    requestedPage: 2,
+    requestedPageToken: currentPageToken,
     expectedActions: [
-      { type: getType(actions.availablepackages.requestAvailablePackageSummaries), payload: 2 },
+      {
+        type: getType(actions.availablepackages.requestAvailablePackageSummaries),
+        payload: currentPageToken,
+      },
       {
         type: getType(actions.availablepackages.receiveAvailablePackageSummaries),
         payload: {
+          paginationToken: currentPageToken,
           response: {
             availablePackageSummaries: [defaultAvailablePackageSummary],
-            nextPageToken: "3",
+            nextPageToken,
             categories: ["foo"],
           },
-          page: 2,
         } as IReceivePackagesActionPayload,
       },
     ],
-    expectedParams: [cluster, namespace, repos, 2, defaultSize, undefined],
+    expectedParams: [cluster, namespace, repos, currentPageToken, defaultSize, undefined],
   },
   {
     name: "fetches packages from a repo (off-limits page)",
@@ -221,9 +236,12 @@ const fetchAvailablePackageSummariesTestCases: IfetchAvailablePackageSummariesTe
       categories: ["foo"],
     },
     requestedRepos: repos,
-    requestedPage: 4,
+    requestedPageToken: "next-page-token",
     expectedActions: [
-      { type: getType(actions.availablepackages.requestAvailablePackageSummaries), payload: 4 },
+      {
+        type: getType(actions.availablepackages.requestAvailablePackageSummaries),
+        payload: "next-page-token",
+      },
       {
         type: getType(actions.availablepackages.receiveAvailablePackageSummaries),
         payload: {
@@ -232,11 +250,11 @@ const fetchAvailablePackageSummariesTestCases: IfetchAvailablePackageSummariesTe
             nextPageToken: "3",
             categories: ["foo"],
           },
-          page: 4,
+          paginationToken: "next-page-token",
         } as IReceivePackagesActionPayload,
       },
     ],
-    expectedParams: [cluster, namespace, repos, 4, defaultSize, undefined],
+    expectedParams: [cluster, namespace, repos, "next-page-token", defaultSize, undefined],
   },
 ];
 
@@ -255,7 +273,7 @@ describe("fetchAvailablePackageSummaries", () => {
           cluster,
           namespace,
           tc.requestedRepos,
-          tc.requestedPage,
+          tc.requestedPageToken,
           defaultSize,
           tc.requestedQuery,
         ),
@@ -267,7 +285,10 @@ describe("fetchAvailablePackageSummaries", () => {
 
   it("returns a 404 error", async () => {
     const expectedActions = [
-      { type: getType(actions.availablepackages.requestAvailablePackageSummaries), payload: 1 },
+      {
+        type: getType(actions.availablepackages.requestAvailablePackageSummaries),
+        payload: defaultPaginationToken,
+      },
       {
         type: getType(actions.availablepackages.createErrorPackage),
         payload: new FetchError("could not find package"),
@@ -284,7 +305,7 @@ describe("fetchAvailablePackageSummaries", () => {
         cluster,
         namespace,
         "foo",
-        defaultPage,
+        defaultPaginationToken,
         defaultSize,
       ),
     );
@@ -293,7 +314,10 @@ describe("fetchAvailablePackageSummaries", () => {
 
   it("returns a generic error", async () => {
     const expectedActions = [
-      { type: getType(actions.availablepackages.requestAvailablePackageSummaries), payload: 1 },
+      {
+        type: getType(actions.availablepackages.requestAvailablePackageSummaries),
+        payload: defaultPaginationToken,
+      },
       {
         type: getType(actions.availablepackages.createErrorPackage),
         payload: new Error("something went wrong"),
@@ -310,7 +334,7 @@ describe("fetchAvailablePackageSummaries", () => {
         cluster,
         namespace,
         "foo",
-        defaultPage,
+        defaultPaginationToken,
         defaultSize,
       ),
     );
@@ -319,7 +343,10 @@ describe("fetchAvailablePackageSummaries", () => {
 
   it("returns a generic error and it is cleared later", async () => {
     const expectedActions = [
-      { type: getType(actions.availablepackages.requestAvailablePackageSummaries), payload: 1 },
+      {
+        type: getType(actions.availablepackages.requestAvailablePackageSummaries),
+        payload: defaultPaginationToken,
+      },
       {
         type: getType(actions.availablepackages.createErrorPackage),
         payload: new Error("something went wrong"),
@@ -337,7 +364,7 @@ describe("fetchAvailablePackageSummaries", () => {
         cluster,
         namespace,
         "foo",
-        defaultPage,
+        defaultPaginationToken,
         defaultSize,
       ),
     );

--- a/dashboard/src/actions/availablepackages.ts
+++ b/dashboard/src/actions/availablepackages.ts
@@ -24,7 +24,7 @@ const { createAction } = deprecated;
 export const requestAvailablePackageSummaries = createAction(
   "REQUEST_AVAILABLE_PACKAGE_SUMMARIES",
   resolve => {
-    return (page?: number) => resolve(page);
+    return (paginationToken: string) => resolve(paginationToken);
   },
 );
 
@@ -103,22 +103,22 @@ export function fetchAvailablePackageSummaries(
   cluster: string,
   namespace: string,
   repos: string,
-  page: number,
+  paginationToken: string,
   size: number,
   query?: string,
 ): ThunkAction<Promise<void>, IStoreState, null, PackagesAction> {
   return async dispatch => {
-    dispatch(requestAvailablePackageSummaries(page));
+    dispatch(requestAvailablePackageSummaries(paginationToken));
     try {
       const response = await PackagesService.getAvailablePackageSummaries(
         cluster,
         namespace,
         repos,
-        page,
+        paginationToken,
         size,
         query,
       );
-      dispatch(receiveAvailablePackageSummaries({ response, page }));
+      dispatch(receiveAvailablePackageSummaries({ response, paginationToken }));
     } catch (e: any) {
       dispatch(createErrorPackage(new FetchError(e.message)));
     }

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -530,14 +530,30 @@ describe("pagination and package fetching", () => {
     );
 
     expect(wrapper.find(PackageCatalogItem).length).toBe(2);
-    expect(fetchAvailablePackageSummaries).toHaveBeenCalledWith(
-      "default-cluster",
-      "kubeapps",
-      "",
-      "nextPageToken",
-      20,
-      "",
+  });
+
+  it("does not fetch again after finishing pagination", () => {
+    const fetchAvailablePackageSummaries = jest.fn();
+    actions.availablepackages.fetchAvailablePackageSummaries = fetchAvailablePackageSummaries;
+
+    const packages = {
+      ...defaultPackageState,
+      hasFinishedFetching: true,
+      isFetching: false,
+      items: [availablePkgSummary1],
+    } as any;
+    const wrapper = mountWrapper(
+      getStore({ ...populatedState, packages: packages } as IStoreState),
+      <MemoryRouter initialEntries={[routePathParam]}>
+        <Route path={routePath}>
+          <Catalog />
+        </Route>
+      </MemoryRouter>,
     );
+
+    expect(wrapper.find(CatalogItems).prop("isFirstPage")).toBe(false);
+    expect(wrapper.find(PackageCatalogItem).length).toBe(1);
+    expect(fetchAvailablePackageSummaries).not.toHaveBeenCalled();
   });
 
   describe("pagination", () => {

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -36,6 +36,7 @@ const defaultPackageState = {
   selected: {} as IPackageState["selected"],
   items: [],
   categories: [],
+  nextPageToken: "",
   size: 20,
 } as IPackageState;
 const defaultProps = {
@@ -464,14 +465,14 @@ describe("pagination and package fetching", () => {
       </MemoryRouter>,
     );
 
-    expect(wrapper.find(CatalogItems).prop("page")).toBe(0);
+    expect(wrapper.find(CatalogItems).prop("isFirstPage")).toBe(false);
     expect(wrapper.find(PackageCatalogItem).length).toBe(0);
     expect(fetchAvailablePackageSummaries).toHaveBeenNthCalledWith(
       1,
       "default-cluster",
       "kubeapps",
       "",
-      0,
+      "",
       20,
       "",
     );
@@ -496,13 +497,13 @@ describe("pagination and package fetching", () => {
       </MemoryRouter>,
     );
 
-    expect(wrapper.find(CatalogItems).prop("page")).toBe(0);
+    expect(wrapper.find(CatalogItems).prop("isFirstPage")).toBe(false);
     expect(wrapper.find(PackageCatalogItem).length).toBe(1);
     expect(fetchAvailablePackageSummaries).toHaveBeenCalledWith(
       "default-cluster",
       "kubeapps",
       "",
-      0,
+      "",
       20,
       "",
     );
@@ -517,7 +518,8 @@ describe("pagination and package fetching", () => {
       hasFinishedFetching: true,
       isFetching: false,
       items: [availablePkgSummary1, availablePkgSummary2],
-    } as any;
+      nextPageToken: "nextPageToken",
+    } as IPackageState;
     const wrapper = mountWrapper(
       getStore({ ...populatedState, packages: packages } as IStoreState),
       <MemoryRouter initialEntries={[routePathParam]}>
@@ -527,13 +529,12 @@ describe("pagination and package fetching", () => {
       </MemoryRouter>,
     );
 
-    expect(wrapper.find(CatalogItems).prop("page")).toBe(0);
     expect(wrapper.find(PackageCatalogItem).length).toBe(2);
     expect(fetchAvailablePackageSummaries).toHaveBeenCalledWith(
       "default-cluster",
       "kubeapps",
       "",
-      0,
+      "nextPageToken",
       20,
       "",
     );
@@ -542,7 +543,7 @@ describe("pagination and package fetching", () => {
   describe("pagination", () => {
     let spyOnUseState: jest.SpyInstance;
     const setState = jest.fn();
-    const setPage = jest.fn();
+    const setPageNum = jest.fn();
 
     beforeEach(() => {
       spyOnUseState = jest
@@ -554,8 +555,8 @@ describe("pagination and package fetching", () => {
             return [true, setState];
           }
           if (init === 0) {
-            // Mocking the result of setPage to ensure it's called
-            return [0, setPage];
+            // Mocking the result of setPageNum to ensure it's called
+            return [0, setPageNum];
           }
           return [init, setState];
         });
@@ -590,7 +591,7 @@ describe("pagination and package fetching", () => {
           </Route>
         </MemoryRouter>,
       );
-      expect(setPage).toHaveBeenCalledWith(0);
+      expect(setPageNum).toHaveBeenCalledWith(0);
     });
     // TODO(agamez): add a test case covering it "resets page when one of the filters changes"
     // https://github.com/vmware-tanzu/kubeapps/pull/2264/files/0d3c77448543668255809bf05039aca704cf729f..22343137efb1c2292b0aa4795f02124306cb055e#r565486271

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -134,7 +134,16 @@ export default function Catalog() {
         searchFilter,
       ),
     );
-  }, [dispatch, nextPageToken, size, cluster, namespace, reposFilter, searchFilter]);
+  }, [
+    dispatch,
+    nextPageToken,
+    size,
+    cluster,
+    namespace,
+    reposFilter,
+    searchFilter,
+    hasFinishedFetching,
+  ]);
 
   // hasLoadedFirstPage is used to not bump the current page until the first page is fully
   // requested first

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -121,6 +121,9 @@ export default function Catalog() {
   const searchFilter = filters[filterNames.SEARCH]?.toString().replace(tmpStrRegex, ",") || "";
   const reposFilter = filters[filterNames.REPO]?.join(",") || "";
   useEffect(() => {
+    if (hasFinishedFetching) {
+      return;
+    }
     dispatch(
       actions.availablepackages.fetchAvailablePackageSummaries(
         cluster,

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -79,6 +79,7 @@ export default function Catalog() {
   const {
     packages: {
       hasFinishedFetching,
+      nextPageToken,
       selected: { error },
       items: availablePackageSummaries,
       categories,
@@ -94,7 +95,10 @@ export default function Catalog() {
   const dispatch = useDispatch();
 
   const [filters, setFilters] = React.useState(initialFilterState());
-  const [page, setPage] = React.useState(0);
+  // pageNum is only used to avoid flicker in the CatalogItems.
+  // It is no longer used for pagination which is handled by the server's
+  // opaque nextPageToken etc.
+  const [pageNum, setPageNum] = React.useState(0);
   const [hasRequestedFirstPage, setHasRequestedFirstPage] = React.useState(false);
   const [hasLoadedFirstPage, setHasLoadedFirstPage] = React.useState(false);
 
@@ -122,12 +126,12 @@ export default function Catalog() {
         cluster,
         namespace,
         reposFilter,
-        page,
+        nextPageToken,
         size,
         searchFilter,
       ),
     );
-  }, [dispatch, page, size, cluster, namespace, reposFilter, searchFilter]);
+  }, [dispatch, nextPageToken, size, cluster, namespace, reposFilter, searchFilter]);
 
   // hasLoadedFirstPage is used to not bump the current page until the first page is fully
   // requested first
@@ -195,7 +199,7 @@ export default function Catalog() {
 
   // detect changes in cluster/ns/repos/search and reset the current package list
   useEffect(() => {
-    setPage(0);
+    setPageNum(0);
     dispatch(actions.availablepackages.resetAvailablePackageSummaries());
     dispatch(actions.availablepackages.resetSelectedAvailablePackageDetail());
   }, [dispatch, cluster, namespace, reposFilter, searchFilter]);
@@ -250,7 +254,7 @@ export default function Catalog() {
     .filter(
       c =>
         filters[filterNames.CATEGORY].length === 0 ||
-        intersection(filters[filterNames.CATEGORY], getOperatorCategories(c)).length,
+        intersection(filters[filterNames.CATEGORY], getOperatorCategories(c)).length > 0,
     );
 
   // Required to have the latest value of page
@@ -267,7 +271,7 @@ export default function Catalog() {
         cluster,
         namespace,
         reposFilter,
-        page,
+        nextPageToken,
         size,
         searchFilter,
       ),
@@ -275,7 +279,7 @@ export default function Catalog() {
   };
 
   const increaseRequestedPage = () => {
-    setPage(page + 1);
+    setPageNum(pageNum + 1);
   };
 
   const observeBorder = (node: any) => {
@@ -457,7 +461,7 @@ export default function Catalog() {
                       csvs={filteredCSVs}
                       cluster={cluster}
                       namespace={namespace}
-                      page={page}
+                      isFirstPage={pageNum === 1}
                       hasLoadedFirstPage={hasLoadedFirstPage}
                       hasFinishedFetching={hasFinishedFetching}
                     />

--- a/dashboard/src/components/Catalog/CatalogItems.test.tsx
+++ b/dashboard/src/components/Catalog/CatalogItems.test.tsx
@@ -63,7 +63,7 @@ const defaultProps = {
   cluster: "default",
   namespace: "default",
   hasLoadedFirstPage: true,
-  page: 1,
+  isFirstPage: true,
   hasFinishedFetching: true,
 } as ICatalogItemsProps;
 const populatedProps = {
@@ -91,7 +91,7 @@ it("shows a message if no items are passed and it stopped fetching", () => {
 it("no items if it's fetching and it's the first page (prevents showing incomplete list during the first render)", () => {
   const wrapper = mountWrapper(
     defaultStore,
-    <CatalogItems {...populatedProps} hasLoadedFirstPage={false} page={1} />,
+    <CatalogItems {...populatedProps} hasLoadedFirstPage={false} isFirstPage={true} />,
   );
   const items = wrapper.find(CatalogItem);
   expect(items).toHaveLength(0);
@@ -100,7 +100,7 @@ it("no items if it's fetching and it's the first page (prevents showing incomple
 it("show items if it's fetching but it is NOT the first page (allow pagination without scrolling issues)", () => {
   const wrapper = mountWrapper(
     defaultStore,
-    <CatalogItems {...populatedProps} hasLoadedFirstPage={false} page={2} />,
+    <CatalogItems {...populatedProps} hasLoadedFirstPage={false} isFirstPage={false} />,
   );
   const items = wrapper.find(CatalogItem);
   expect(items).toHaveLength(3);

--- a/dashboard/src/components/Catalog/CatalogItems.tsx
+++ b/dashboard/src/components/Catalog/CatalogItems.tsx
@@ -15,7 +15,7 @@ export interface ICatalogItemsProps {
   csvs: IClusterServiceVersion[];
   cluster: string;
   namespace: string;
-  page: number;
+  isFirstPage: boolean;
   hasLoadedFirstPage: boolean;
   hasFinishedFetching: boolean;
 }
@@ -25,7 +25,7 @@ export default function CatalogItems({
   csvs,
   cluster,
   namespace,
-  page,
+  isFirstPage,
   hasLoadedFirstPage,
   hasFinishedFetching,
 }: ICatalogItemsProps) {
@@ -76,7 +76,7 @@ export default function CatalogItems({
   );
 
   const sortedItems =
-    !hasLoadedFirstPage && page === 1
+    !hasLoadedFirstPage && isFirstPage
       ? []
       : packageItems
           .concat(crdItems)

--- a/dashboard/src/components/PackageHeader/PackageView.test.tsx
+++ b/dashboard/src/components/PackageHeader/PackageView.test.tsx
@@ -79,6 +79,7 @@ const defaultPackageState = {
   } as IPackageState["selected"],
   items: [],
   categories: [],
+  nextPageToken: "",
   size: 20,
 } as IPackageState;
 

--- a/dashboard/src/reducers/availablepackages.test.ts
+++ b/dashboard/src/reducers/availablepackages.test.ts
@@ -7,6 +7,10 @@ import { getType } from "typesafe-actions";
 import actions from "../actions";
 import { IPackageState, IReceivePackagesActionPayload } from "../shared/types";
 import packageReducer from "./availablepackages";
+import { PackagesAction } from "../actions/availablepackages";
+
+const nextPageToken = "nextPageToken";
+const currentPageToken = "currentPageToken";
 
 describe("packageReducer", () => {
   let initialState: IPackageState;
@@ -47,6 +51,7 @@ describe("packageReducer", () => {
       selected: {
         versions: [],
       },
+      nextPageToken: "",
       size: 20,
     };
   });
@@ -86,7 +91,7 @@ describe("packageReducer", () => {
   it("requestAvailablePackageSummaries (with page)", () => {
     const state = packageReducer(undefined, {
       type: getType(actions.availablepackages.requestAvailablePackageSummaries) as any,
-      payload: 2,
+      payload: "currentPageToken",
     });
     expect(state).toEqual({
       ...initialState,
@@ -100,10 +105,9 @@ describe("packageReducer", () => {
       payload: {
         response: {
           availablePackageSummaries: [availablePackageSummary1],
-          nextPageToken: "3",
+          nextPageToken,
           categories: ["foo"],
         },
-        page: 1,
       } as IReceivePackagesActionPayload,
     });
     expect(state).toEqual({
@@ -112,6 +116,7 @@ describe("packageReducer", () => {
       hasFinishedFetching: false,
       categories: ["foo"],
       items: [availablePackageSummary1],
+      nextPageToken,
     });
   });
 
@@ -123,10 +128,9 @@ describe("packageReducer", () => {
         payload: {
           response: {
             availablePackageSummaries: [availablePackageSummary1],
-            nextPageToken: "3",
+            nextPageToken,
             categories: ["foo"],
           },
-          page: 2,
         } as IReceivePackagesActionPayload,
       },
     );
@@ -136,6 +140,7 @@ describe("packageReducer", () => {
       hasFinishedFetching: false,
       categories: ["foo"],
       items: [availablePackageSummary1],
+      nextPageToken,
     });
   });
 
@@ -147,10 +152,9 @@ describe("packageReducer", () => {
         payload: {
           response: {
             availablePackageSummaries: [availablePackageSummary1],
-            nextPageToken: "3",
+            nextPageToken,
             categories: ["foo"],
           },
-          page: 2,
         } as IReceivePackagesActionPayload,
       },
     );
@@ -160,6 +164,7 @@ describe("packageReducer", () => {
       hasFinishedFetching: false,
       categories: ["foo"],
       items: [availablePackageSummary1],
+      nextPageToken,
     });
   });
 
@@ -173,10 +178,9 @@ describe("packageReducer", () => {
         payload: {
           response: {
             availablePackageSummaries: [availablePackageSummary1],
-            nextPageToken: "3",
+            nextPageToken: "",
             categories: ["foo"],
           },
-          page: 3,
         } as IReceivePackagesActionPayload,
       },
     );
@@ -195,10 +199,9 @@ describe("packageReducer", () => {
       payload: {
         response: {
           availablePackageSummaries: [availablePackageSummary1],
-          nextPageToken: "2",
+          nextPageToken,
           categories: ["foo"],
         },
-        page: 1,
       } as IReceivePackagesActionPayload,
     });
     const state2 = packageReducer(state1, {
@@ -206,10 +209,9 @@ describe("packageReducer", () => {
       payload: {
         response: {
           availablePackageSummaries: [availablePackageSummary2],
-          nextPageToken: "2",
+          nextPageToken: "",
           categories: ["foo"],
         },
-        page: 2,
       } as IReceivePackagesActionPayload,
     });
     expect(state2).toEqual({
@@ -218,6 +220,7 @@ describe("packageReducer", () => {
       hasFinishedFetching: true,
       categories: ["foo"],
       items: [availablePackageSummary1, availablePackageSummary2],
+      nextPageToken: "",
     });
     expect(state2.items.length).toBe(2);
   });
@@ -225,8 +228,7 @@ describe("packageReducer", () => {
   it("requestAvailablePackageSummaries and receiveAvailablePackageSummaries with multiple pages", () => {
     const stateReq1 = packageReducer(initialState, {
       type: getType(actions.availablepackages.requestAvailablePackageSummaries) as any,
-      payload: 1,
-    });
+    } as PackagesAction);
     expect(stateReq1).toEqual({
       ...initialState,
       isFetching: true,
@@ -238,10 +240,9 @@ describe("packageReducer", () => {
       payload: {
         response: {
           availablePackageSummaries: [availablePackageSummary1],
-          nextPageToken: "3",
+          nextPageToken: "page-2",
           categories: ["foo"],
         },
-        page: 1,
       } as IReceivePackagesActionPayload,
     });
     expect(stateRec1).toEqual({
@@ -250,10 +251,10 @@ describe("packageReducer", () => {
       categories: ["foo"],
       items: [availablePackageSummary1],
       hasFinishedFetching: false,
+      nextPageToken: "page-2",
     });
     const stateReq2 = packageReducer(stateRec1, {
       type: getType(actions.availablepackages.requestAvailablePackageSummaries) as any,
-      payload: 2,
     });
     expect(stateReq2).toEqual({
       ...initialState,
@@ -261,16 +262,16 @@ describe("packageReducer", () => {
       hasFinishedFetching: false,
       categories: ["foo"],
       items: [availablePackageSummary1],
+      nextPageToken: "page-2",
     });
     const stateRec2 = packageReducer(stateReq2, {
       type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
       payload: {
         response: {
           availablePackageSummaries: [availablePackageSummary2],
-          nextPageToken: "3",
+          nextPageToken: "page-3",
           categories: ["foo"],
         },
-        page: 2,
       } as IReceivePackagesActionPayload,
     });
     expect(stateRec2).toEqual({
@@ -279,10 +280,10 @@ describe("packageReducer", () => {
       hasFinishedFetching: false,
       categories: ["foo"],
       items: [availablePackageSummary1, availablePackageSummary2],
+      nextPageToken: "page-3",
     });
     const stateReq3 = packageReducer(stateRec2, {
       type: getType(actions.availablepackages.requestAvailablePackageSummaries) as any,
-      payload: 3,
     });
     expect(stateReq3).toEqual({
       ...initialState,
@@ -290,16 +291,16 @@ describe("packageReducer", () => {
       hasFinishedFetching: false,
       categories: ["foo"],
       items: [availablePackageSummary1, availablePackageSummary2],
+      nextPageToken: "page-3",
     });
     const stateRec3 = packageReducer(stateReq3, {
       type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
       payload: {
         response: {
           availablePackageSummaries: [availablePackageSummary1],
-          nextPageToken: "3",
+          nextPageToken: "",
           categories: ["foo"],
         },
-        page: 3,
       } as IReceivePackagesActionPayload,
     });
     expect(stateRec3).toEqual({
@@ -308,6 +309,7 @@ describe("packageReducer", () => {
       hasFinishedFetching: true,
       categories: ["foo"],
       items: [availablePackageSummary1, availablePackageSummary2],
+      nextPageToken: "",
     });
   });
 
@@ -319,10 +321,10 @@ describe("packageReducer", () => {
       payload: {
         response: {
           availablePackageSummaries: [availablePackageSummary1],
-          nextPageToken: "1",
+          nextPageToken,
           categories: ["foo"],
         },
-        page: 1,
+        paginationToken: currentPageToken,
       } as IReceivePackagesActionPayload,
     });
     const state2 = packageReducer(state1, {
@@ -330,10 +332,10 @@ describe("packageReducer", () => {
       payload: {
         response: {
           availablePackageSummaries: [],
-          nextPageToken: "2",
+          nextPageToken,
           categories: ["foo"],
         },
-        page: 2,
+        paginationToken: currentPageToken,
       } as IReceivePackagesActionPayload,
     });
     const state3 = packageReducer(state2, {
@@ -343,6 +345,7 @@ describe("packageReducer", () => {
       ...initialState,
       isFetching: false,
       categories: ["foo"],
+      nextPageToken,
       items: [availablePackageSummary1],
     });
   });
@@ -353,10 +356,9 @@ describe("packageReducer", () => {
       payload: {
         response: {
           availablePackageSummaries: [availablePackageSummary1],
-          nextPageToken: "5",
+          nextPageToken,
           categories: ["foo"],
         },
-        page: 1,
       } as IReceivePackagesActionPayload,
     });
     const state2 = packageReducer(state1, {
@@ -370,6 +372,7 @@ describe("packageReducer", () => {
       isFetching: false,
       items: [availablePackageSummary1],
       categories: ["foo"],
+      nextPageToken,
       selected: initialState.selected,
     });
   });

--- a/dashboard/src/reducers/availablepackages.ts
+++ b/dashboard/src/reducers/availablepackages.ts
@@ -12,6 +12,7 @@ import { NamespaceAction } from "../actions/namespace";
 export const initialState: IPackageState = {
   isFetching: false,
   hasFinishedFetching: false,
+  nextPageToken: "",
   items: [],
   categories: [],
   selected: {
@@ -67,13 +68,17 @@ const packageReducer = (
     case getType(actions.availablepackages.requestSelectedAvailablePackageVersions):
       return { ...state, isFetching: true };
     case getType(actions.availablepackages.receiveAvailablePackageSummaries): {
-      const isLastPage =
-        action.payload.page >= parseInt(action.payload.response.nextPageToken) ||
-        action.payload.response.nextPageToken === "";
+      // Note that the same condition identifies *before* we've fetched
+      // the first page and *after* we've fetched the last page. In both
+      // cases, the nextPageToken is empty. Since we have just fetched a
+      // page, only one option is possible.
+      const isLastPage = action.payload.response.nextPageToken === "";
       return {
         ...state,
         isFetching: false,
+        // TODO(minelson): Can we remove hasFinishedFetching ?
         hasFinishedFetching: isLastPage,
+        nextPageToken: action.payload.response.nextPageToken,
         categories: action.payload.response.categories,
         items: uniqBy(
           [...state.items, ...action.payload.response.availablePackageSummaries],
@@ -104,6 +109,7 @@ const packageReducer = (
         ...state,
         hasFinishedFetching: false,
         items: [],
+        nextPageToken: "",
       };
     case getType(actions.availablepackages.createErrorPackage):
       return {

--- a/dashboard/src/reducers/availablepackages.ts
+++ b/dashboard/src/reducers/availablepackages.ts
@@ -76,7 +76,9 @@ const packageReducer = (
       return {
         ...state,
         isFetching: false,
-        // TODO(minelson): Can we remove hasFinishedFetching ?
+        // TODO(minelson): Something is triggering a new request even after
+        // hasFinishedFetching is true, the response for which resets it.
+        // Or it could be that double requests are sent (seen in server logs)
         hasFinishedFetching: isLastPage,
         nextPageToken: action.payload.response.nextPageToken,
         categories: action.payload.response.categories,

--- a/dashboard/src/shared/PackagesService.test.ts
+++ b/dashboard/src/shared/PackagesService.test.ts
@@ -16,7 +16,7 @@ import PackagesService from "./PackagesService";
 
 const cluster = "cluster-name";
 const namespace = "namespace-name";
-const defaultPage = 1;
+const defaultPageToken = "defaultPageToken";
 const defaultSize = 0;
 describe("App", () => {
   beforeEach(() => {
@@ -39,7 +39,7 @@ describe("App", () => {
           cluster: cluster,
           namespace: namespace,
           repos: "",
-          page: defaultPage,
+          nextPageToken: defaultPageToken,
           size: defaultSize,
           query: "",
         },
@@ -49,7 +49,7 @@ describe("App", () => {
             query: "",
             repositories: [],
           },
-          paginationOptions: { pageToken: defaultPage.toString(), pageSize: defaultSize },
+          paginationOptions: { pageToken: defaultPageToken, pageSize: defaultSize },
         },
       },
       {
@@ -58,7 +58,7 @@ describe("App", () => {
           cluster: cluster,
           namespace: namespace,
           repos: "",
-          page: defaultPage,
+          nextPageToken: defaultPageToken,
           size: defaultSize,
           query: "cms",
         },
@@ -68,7 +68,7 @@ describe("App", () => {
             query: "cms",
             repositories: [],
           },
-          paginationOptions: { pageToken: defaultPage.toString(), pageSize: defaultSize },
+          paginationOptions: { pageToken: defaultPageToken, pageSize: defaultSize },
         },
       },
       {
@@ -77,7 +77,7 @@ describe("App", () => {
           cluster: cluster,
           namespace: namespace,
           repos: "repo1,repo2",
-          page: defaultPage,
+          nextPageToken: defaultPageToken,
           size: defaultSize,
           query: "",
         },
@@ -87,7 +87,7 @@ describe("App", () => {
             query: "",
             repositories: ["repo1", "repo2"],
           },
-          paginationOptions: { pageToken: defaultPage.toString(), pageSize: defaultSize },
+          paginationOptions: { pageToken: defaultPageToken, pageSize: defaultSize },
         },
       },
       {
@@ -96,7 +96,7 @@ describe("App", () => {
           cluster: cluster,
           namespace: namespace,
           repos: "repo1,repo2",
-          page: defaultPage,
+          nextPageToken: defaultPageToken,
           size: defaultSize,
           query: "cms",
         },
@@ -106,7 +106,7 @@ describe("App", () => {
             query: "cms",
             repositories: ["repo1", "repo2"],
           },
-          paginationOptions: { pageToken: defaultPage.toString(), pageSize: defaultSize },
+          paginationOptions: { pageToken: defaultPageToken, pageSize: defaultSize },
         },
       },
     ].forEach(t => {
@@ -128,7 +128,7 @@ describe("App", () => {
           t.args.cluster,
           t.args.namespace,
           t.args.repos,
-          t.args.page,
+          t.args.nextPageToken,
           t.args.size,
           t.args.query,
         );

--- a/dashboard/src/shared/PackagesService.ts
+++ b/dashboard/src/shared/PackagesService.ts
@@ -16,7 +16,7 @@ export default class PackagesService {
     cluster: string,
     namespace: string,
     repos: string,
-    page: number,
+    paginationToken: string,
     size: number,
     query?: string,
   ): Promise<GetAvailablePackageSummariesResponse> {
@@ -26,7 +26,7 @@ export default class PackagesService {
         query: query,
         repositories: repos ? repos.split(",") : [],
       },
-      paginationOptions: { pageSize: size, pageToken: page.toString() },
+      paginationOptions: { pageSize: size, pageToken: paginationToken },
     });
   }
 

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -77,12 +77,13 @@ export interface IRepo {
 
 export interface IReceivePackagesActionPayload {
   response: GetAvailablePackageSummariesResponse;
-  page: number;
+  paginationToken: string;
 }
 
 export interface IPackageState {
   isFetching: boolean;
   hasFinishedFetching: boolean;
+  nextPageToken: string;
   selected: {
     error?: FetchError | Error;
     availablePackageDetail?: AvailablePackageDetail;


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This is the first step towards fixing #3399 . When we initially updated the dashboard to use the new UX, we'd encoded knowledge of the pagination token in the frontend, which we really need to avoid. The plugin should simply be able to set the `NextPageToken` in the response and the client sends that back with the next request.

The main change is to remove the `page` (int) state and replace it with the token verbatim which is returned by the API. There was one existing point where we need to track which page number to avoid jitter (? not sure, didn't verify, just maintained the same behaviour) so the page state is still counted within the catalog view but not used for anything other than calculating `isFirstPage` for the CatalogItems component.

### Benefits

<!-- What benefits will be realized by the code change? -->
I'd like to encode more info into the next page token so that the core packages plugin is able to track pagination across plugins.


### Possible drawbacks

<!-- Describe any known limitations with your change -->

Potential issues paginating with the current plugins. I've tested the helm plugin in real life and it works fine, paginating the results until finished.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3399 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

One thing I've noticed, which isn't new, is that we continue paginating regardless of the scroll position at the moment. Each time a response comes back, the state changes (used to be page, now it's nextPageToken) which triggers the effect again to request the next results, until finished.