### PR TITLE
Use pagination options with plugin when only one plugin configured.

### DIFF
--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages_test.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages_test.go
@@ -255,6 +255,28 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 			},
 			statusCode: codes.NotFound,
 		},
+		{
+			name: "it should defer to the plugin pagination and sorting for a single plugin",
+			configuredPlugins: []pkgPluginsWithServer{
+				mockedPackagingPlugin1,
+			},
+			request: &corev1.GetAvailablePackageSummariesRequest{
+				Context: &corev1.Context{
+					Cluster:   "",
+					Namespace: globalPackagingNamespace,
+				},
+			},
+
+			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
+					plugin_test.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin1.plugin),
+					plugin_test.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin1.plugin),
+				},
+				Categories:    []string{"cat-1"},
+				NextPageToken: "1",
+			},
+			statusCode: codes.OK,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Updates the core packages plugin so that if only a single plugin is used, it will pass through the pagination options and return the next page token of the plugin.

This small change (on top of #4654) will allow me to start updating the individual plugins without affecting the combined behaviour for now.

### Benefits

<!-- What benefits will be realized by the code change? -->
I can continue by next updating the helm plugin from a page number to an item number.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3399 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
