### PR TITLE
Bump ECMAScript version up to 13

### DIFF
--- a/dashboard/.eslintrc.json
+++ b/dashboard/.eslintrc.json
@@ -7,7 +7,7 @@
     "ecmaFeatures": {
       "jsx": true
     },
-    "ecmaVersion": 2020,
+    "ecmaVersion": 2022,
     "sourceType": "module",
     "project": "./tsconfig.json"
   },

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -11,7 +11,7 @@
       "dom.iterable",
       "esnext"
     ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-    "target": "ES2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     /* Modules */
     "baseUrl": "src" /* Specify the base directory to resolve non-relative module names. */,
     "module": "esnext" /* Specify what module code is generated. */,


### PR DESCRIPTION
### Description of the change

This PR just increases the ecmascript version we are transpiling to from ES2020 to ES2022 (to be officially released in June)

### Benefits

Some interesting features have been added since 2020. For instance, the `replaceAll` function or the logical assignments operators (like `??=`). More info below:

https://dev.to/naimlatifi5/ecmascript-2021-es12-new-features-2l67
https://dev.to/faithfulojebiyi/new-features-in-ecmascript-2021-with-code-examples-302h

### Possible drawbacks

N/A

### Applicable issues

- related #4661

### Additional information

N/A