### PR TITLE
Update CI vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,13 @@ parameters:
     default: "1.18"
   NODE_VERSION:
     type: string
-    default: "16.14.2"
+    default: "16.15.0"
   RUST_VERSION:
     type: string
-    default: "1.59.0"
+    default: "1.60.0"
   DOCKER_VERSION:
     type: string
-    default: "20.10.11"
+    default: "20.10.14"
   HELM_VERSION_MIN:
     type: "string"
     default: "v3.2.0"
@@ -23,31 +23,31 @@ parameters:
     default: "v3.8.1"
   OLM_VERSION:
     type: "string"
-    default: "v0.20.0"
+    default: "v0.21.1"
   KAPP_CONTROLLER_VERSION:
     type: "string"
-    default: "v0.32.0"
+    default: "v0.36.1"
   MKCERT_VERSION:
     type: "string"
-    default: "v1.4.3"
+    default: "v1.4.4"
   KUBECTL_VERSION:
     type: "string"
-    default: "v1.22.8"
+    default: "v1.22.9"
   GITHUB_VERSION:
     type: "string"
-    default: "2.4.0"
+    default: "2.9.0"
   SEMVER_VERSION:
     type: "string"
     default: "3.3.0"
   KIND_VERSION:
     type: "string"
-    default: "v0.11.1"
+    default: "v0.12.0"
   K8S_KIND_VERSION:
     type: "string"
-    default: "v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
+    default: "v1.22.7@sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166"
   POSTGRESQL_VERSION:
     type: "string"
-    default: "14.2.0-debian-10-r45"
+    default: "14.2.0-debian-10-r88"
   GKE_STABLE_VERSION:
     type: "string"
     default: "1.20"
@@ -56,7 +56,7 @@ parameters:
     default: "1.21"
   DEFAULT_MACHINE_IMG:
     type: "string"
-    default: "ubuntu-2004:202111-02"
+    default: "ubuntu-2004:202201-02"
   IMAGES_TO_PUSH:
     type: "string"
     default: "kubeapps/apprepository-controller kubeapps/dashboard kubeapps/asset-syncer kubeapps/assetsvc kubeapps/kubeops kubeapps/pinniped-proxy kubeapps/kubeapps-apis"

--- a/cmd/apprepository-controller/Dockerfile
+++ b/cmd/apprepository-controller/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax = docker/dockerfile:1
 
-FROM bitnami/golang:1.18.0 as builder
+FROM bitnami/golang:1.18.1 as builder
 WORKDIR /go/src/github.com/vmware-tanzu/kubeapps
 COPY go.mod go.sum ./
 COPY pkg pkg

--- a/cmd/asset-syncer/Dockerfile
+++ b/cmd/asset-syncer/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax = docker/dockerfile:1
 
-FROM bitnami/golang:1.18.0 as builder
+FROM bitnami/golang:1.18.1 as builder
 WORKDIR /go/src/github.com/vmware-tanzu/kubeapps
 COPY go.mod go.sum ./
 COPY pkg pkg

--- a/cmd/asset-syncer/server/postgresql_db_test.go
+++ b/cmd/asset-syncer/server/postgresql_db_test.go
@@ -4,7 +4,7 @@
 // Currently these tests will be skipped entirely unless the
 // ENABLE_PG_INTEGRATION_TESTS env var is set.
 // Run the local postgres with
-// docker run --publish 5432:5432 -e ALLOW_EMPTY_PASSWORD=yes bitnami/postgresql:14.2.0-debian-10-r35
+// docker run --publish 5432:5432 -e ALLOW_EMPTY_PASSWORD=yes bitnami/postgresql:14.2.0-debian-10-r88
 // in another terminal.
 package server
 

--- a/cmd/assetsvc/Dockerfile
+++ b/cmd/assetsvc/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax = docker/dockerfile:1
 
-FROM bitnami/golang:1.18.0 as builder
+FROM bitnami/golang:1.18.1 as builder
 WORKDIR /go/src/github.com/vmware-tanzu/kubeapps
 COPY go.mod go.sum ./
 COPY pkg pkg

--- a/cmd/assetsvc/pkg/utils/postgres_db_test.go
+++ b/cmd/assetsvc/pkg/utils/postgres_db_test.go
@@ -4,7 +4,7 @@
 // Currently these tests will be skipped entirely unless the
 // ENABLE_PG_INTEGRATION_TESTS env var is set.
 // Run the local postgres with
-// docker run --publish 5432:5432 -e ALLOW_EMPTY_PASSWORD=yes bitnami/postgresql:14.2.0-debian-10-r35
+// docker run --publish 5432:5432 -e ALLOW_EMPTY_PASSWORD=yes bitnami/postgresql:14.2.0-debian-10-r88
 // in another terminal.
 package utils
 

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -66,7 +66,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 # Note: unlike the other docker images for go, we cannot use scratch as the plugins
 # are loaded using the dynamic linker.
-FROM bitnami/minideb:buster
+FROM bitnami/minideb:bullseye
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/vmware-tanzu/kubeapps/kubeapps-apis /kubeapps-apis
 COPY --from=builder /kapp-controller-packages-v1alpha1-plugin.so /plugins/kapp-controller-packages/

--- a/cmd/kubeops/Dockerfile
+++ b/cmd/kubeops/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax = docker/dockerfile:1
 
-FROM bitnami/golang:1.18.0 as builder
+FROM bitnami/golang:1.18.1 as builder
 WORKDIR /go/src/github.com/vmware-tanzu/kubeapps
 COPY go.mod go.sum ./
 COPY pkg pkg

--- a/cmd/pinniped-proxy/Dockerfile
+++ b/cmd/pinniped-proxy/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax = docker/dockerfile:1
 
-FROM rust:1.59.0 as builder
+FROM rust:1.60.0 as builder
 
 WORKDIR /pinniped-proxy
 ARG VERSION
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 RUN --mount=type=cache,target=/pinniped-proxy/target \
     cp /pinniped-proxy/target/release/pinniped-proxy /pinniped-proxy/pinniped-proxy
 
-FROM bitnami/minideb:buster
+FROM bitnami/minideb:bullseye
 RUN apt-get update && apt-get install -y ca-certificates libssl1.1 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /pinniped-proxy/pinniped-proxy /pinniped-proxy
 ENV PATH="/:$PATH"

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2018-2022 the Kubeapps contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM bitnami/node:16.14.2 AS build
+FROM bitnami/node:16.15.0 AS build
 WORKDIR /app
 
 COPY package.json yarn.lock /app/

--- a/docs/reference/developer/release-process.md
+++ b/docs/reference/developer/release-process.md
@@ -11,64 +11,68 @@ It consists of four main stages: update the development images, update the CI, u
 
 For building the [development container images](https://hub.docker.com/u/kubeapps), a number of base images are used in the build stage. Specifically:
 
-- The [dashboard/Dockerfile](../../dashboard/Dockerfile) uses:
+- The [dashboard/Dockerfile](../../../dashboard/Dockerfile) uses:
   - [bitnami/node](https://hub.docker.com/r/bitnami/node/tags) for building the static files for production.
   - [bitnami/nginx](https://hub.docker.com/r/bitnami/nginx/tags) for serving the HTML and JS files as a simple web server.
 - Those services written in Golang use the same image for building the binary, but then a [scratch](https://hub.docker.com/_/scratch) image is used for actually running it. These Dockerfiles are:
-  - [apprepository-controller/Dockerfile](../../cmd/apprepository-controller/Dockerfile).
-  - [asset-syncer/Dockerfile](../../cmd/asset-syncer/Dockerfile).
-  - [assetsvc/Dockerfile](../../cmd/assetsvc/Dockerfile).
-  - [kubeops/Dockerfile](../../cmd/kubeops/Dockerfile).
-- The [pinniped-proxy/Dockerfile](../../cmd/pinniped-proxy/Dockerfile) uses:
+  - [apprepository-controller/Dockerfile](../../../cmd/apprepository-controller/Dockerfile).
+  - [asset-syncer/Dockerfile](../../../cmd/asset-syncer/Dockerfile).
+  - [assetsvc/Dockerfile](../../../cmd/assetsvc/Dockerfile).
+  - [kubeops/Dockerfile](../../../cmd/kubeops/Dockerfile).
+- The [pinniped-proxy/Dockerfile](../../../cmd/pinniped-proxy/Dockerfile) uses:
   - [\_/rust](https://hub.docker.com/_/rust) for building the binary.
-  - [bitnami/minideb:buster](https://hub.docker.com/r/bitnami/minideb) for running it.
+  - [bitnami/minideb](https://hub.docker.com/r/bitnami/minideb) for running it.
 
 > As part of this release process, these image tags _must_ be updated to the latest minor/patch version. In case of a major version, the change _should_ be tracked in a separate PR.
-
 > **Note**: as the official container images are those being created by Bitnami, we _should_ ensure that we are using the same major version as they are using.
 
 ### 0.2 - CI configuration and images
 
 In order to be in sync with the container images while running the different CI jobs, it is necessary to also update the CI image versions.
-Find further information in the [CI configuration](./ci.md) and the [e2e tests documentation](./end-to-end-tests.md).
+Find further information in the [CI configuration](../testing/ci.md) and the [e2e tests documentation](../testing/end-to-end-tests.md).
 
 #### 0.2.1 - CI configuration
 
-In the [CircleCI configuration](../../.circleci/config.yml) we have an initial declaration of the variables used along with the file.
+In the [CircleCI configuration](../../../.circleci/config.yml) we have an initial declaration of the variables used along with the file.
 The versions used there _must_ match the ones used for building the container images. Consequently, these variables _must_ be changed accordingly:
 
-- `GOLANG_VERSION` _must_ match the versions used by our services written in Golang, for instance, [kubeops](../../cmd/kubeops/Dockerfile).
-- `NODE_VERSION` _must_ match the **major** version used by the [dashboard](../../dashboard/Dockerfile).
-- `RUST_VERSION` _must_ match the version used by the [pinniped-proxy](../../dashboard/Dockerfile).
+- `GOLANG_VERSION` _must_ match the versions used by our services written in Golang, for instance, [kubeops](../../../cmd/kubeops/Dockerfile).
+- `NODE_VERSION` _must_ match the **major** version used by the [dashboard](../../../dashboard/Dockerfile).
+- `RUST_VERSION` _must_ match the version used by the [pinniped-proxy](../../../dashboard/Dockerfile).
 - `DOCKER_VERSION` can be updated to the [latest version provided by CircleCI](https://circleci.com/docs/2.0/building-docker-images/#docker-version).
+- `HELM_VERSION_MIN` _must_ match the one listed in the [Bitnami Application Catalog prerequisites](https://github.com/bitnami/charts#prerequisites).
 - `HELM_VERSION_STABLE` should be updated with the [latest stable version from the Helm releases](https://github.com/helm/helm/releases).
 - `OLM_VERSION` should be updated with the [latest stable version from the OLM releases](https://github.com/operator-framework/operator-lifecycle-manager/releases).
+- `KAPP_CONTROLLER_VERSION` should be updated with the [latest stable version from the Kapp Controller releases](https://github.com/vmware-tanzu/carvel-kapp-controller/releases).
 - `MKCERT_VERSION` should be updated with the [latest stable version from the mkcert releases](https://github.com/FiloSottile/mkcert/releases).
+- `KUBECTL_VERSION` _should_ match the Kubernetes minor version (or minor version +1) used in `GKE_REGULAR_VERSION_XX` and listed in the [Kubernetes releases page](https://kubernetes.io/releases/).
+- `GITHUB_VERSION` should be updated with the [latest stable version from the GitHub CLI releases](https://github.com/cli/cli/releases).
+- `SEMVER_VERSION` should be updated with the [latest stable version from the semver releases](https://github.com/fsaintjacques/semver-tool/releases/tag/3.3.0).
+- `KIND_VERSION` should be updated with the [latest stable version from the kind releases](https://github.com/kubernetes-sigs/kind/releases).
+- `K8S_KIND_VERSION` _must_ match the Kubernetes minor version used in `GKE_REGULAR_VERSION_XX` and should be updated with one of the available image tags for a given [Kind release](https://github.com/kubernetes-sigs/kind/releases).
 - `POSTGRESQL_VERSION` _must_ match the version used by the [Bitnami PostgreSQL chart](https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml).
-- `DEFAULT_MACHINE_IMG` _should_ be up to date according to the [list of available machines in CircleCI](https://circleci.com/docs/2.0/configuration-reference/#available-machine-images).
+- `DEFAULT_MACHINE_IMG` _should_ be up to date according to the [list of available machines in CircleCI](https://circleci.com/docs/2.0/configuration-reference/#available-linux-machine-images).
 
 Besides, the `GKE_STABLE_VERSION_XX` and the `GKE_REGULAR_VERSION_XX` might have to be updated if the _Stable_ and _Regular_ Kubernetes versions in GKE have changed. Check this information on [this GKE release notes website](https://cloud.google.com/kubernetes-engine/docs/release-notes).
 
-> **NOTE**: at least one of those `GKE_STABLE_VERSION_XX` or `GKE_REGULAR_VERSION_XX` versions _must_ match the Kubernetes-related dependencies in [Go](../../go.mod) and [Rust](../../cmd/pinniped-proxy/Cargo.toml).
-
+> **NOTE**: at least one of those `GKE_STABLE_VERSION_XX` or `GKE_REGULAR_VERSION_XX` versions _must_ match the Kubernetes-related dependencies in [Go](../../../go.mod) and [Rust](../../../cmd/pinniped-proxy/Cargo.toml).
 > As part of this release process, these variables _must_ be updated accordingly. Other variable changes _should_ be tracked in a separate PR.
 
 #### 0.2.2 - CI integration image and dependencies
 
 We use a separate integration image for running the e2e tests consisting of a simple Node image with a set of dependencies. Therefore, upgrading it includes:
 
-- The [integration dependencies](../../dashboard/package.json) can be updated by running:
+- The [integration dependencies](../../../dashboard/package.json) can be updated by running:
 
 ```bash
 cd integration
 yarn upgrade
 ```
 
-- The [integration/Dockerfile](../../integration/Dockerfile) uses a [bitnami/node](https://hub.docker.com/r/bitnami/node/tags) image for running the e2e tests.
+- The [integration/Dockerfile](../../../integration/Dockerfile) uses a [bitnami/node](https://hub.docker.com/r/bitnami/node/tags) image for running the e2e tests.
 
 > As part of this release process, this Node image tag _may_ be updated to the latest minor/patch version. In case of a major version, the change _should_ be tracked in a separate PR. Analogously, its dependencies _may_ also be updated, but in case of a major change, it _should_ be tracked in a separate PR.
-
-> **Note**: this image is not being built automatically. Consequently, a [manual build process](./end-to-end-tests.md#building-the-kubeappsintegration-tests-image) _must_ be triggered if you happen to upgrade the integration image or its dependencies.
+> **Note**: this image is not being built automatically. Consequently, a [manual build process](../testing/end-to-end-tests.md#building-the-kubeappsintegration-tests-image) _must_ be triggered if you happen to upgrade the integration image or its dependencies.
 
 ### 0.3 - Protobuf dependencies and autogenerated code
 
@@ -94,11 +98,11 @@ npx prettier --write  ../../dashboard/src/
 
 ### 0.4 - Upgrading the code dependencies
 
-Currently, we have three types of dependencies: the [dashboard dependencies](../../dashboard/package.json), the [golang dependencies](../../go.mod), and the [rust dependencies](../../cmd/pinniped-proxy/Cargo.toml). They _must_ be upgraded to the latest minor/patch version to get the latest bug and security fixes.
+Currently, we have three types of dependencies: the [dashboard dependencies](../../../dashboard/package.json), the [golang dependencies](../../go.mod), and the [rust dependencies](../../cmd/pinniped-proxy/Cargo.toml). They _must_ be upgraded to the latest minor/patch version to get the latest bug and security fixes.
 
 #### Dashboard dependencies
 
-Upgrade the [dashboard dependencies](../../dashboard/package.json) by running:
+Upgrade the [dashboard dependencies](../../../dashboard/package.json) by running:
 
 ```bash
 cd dashboard
@@ -106,9 +110,10 @@ yarn upgrade
 ```
 
 Note: If there are certain dependencies which cannot be updated currently, `yarn upgrade-interactive` allows selecting just certain items for upgrade.
+
 #### Golang dependencies
 
-Check the outdated [golang dependencies](../../go.mod) by running the following (from [How to upgrade and downgrade dependencies](https://github.com/golang/go/wiki/Modules#how-to-upgrade-and-downgrade-dependencies)):
+Check the outdated [golang dependencies](../../../go.mod) by running the following (from [How to upgrade and downgrade dependencies](https://github.com/golang/go/wiki/Modules#how-to-upgrade-and-downgrade-dependencies)):
 
 ```bash
 go mod tidy
@@ -125,7 +130,7 @@ go get -u ./...
 
 #### Rust dependencies
 
-Upgrade the [rust dependencies](../../cmd/pinniped-proxy/Cargo.toml) by running:
+Upgrade the [rust dependencies](../../../cmd/pinniped-proxy/Cargo.toml) by running:
 
 ```bash
 cd cmd/pinniped-proxy/

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -85,9 +85,9 @@ installOLM() {
   url=https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${release}
   namespace=olm
 
-  kubectl apply -f "${url}/crds.yaml"
+  kubectl create -f "${url}/crds.yaml"
   kubectl wait --for=condition=Established -f "${url}/crds.yaml"
-  kubectl apply -f "${url}/olm.yaml"
+  kubectl create -f "${url}/olm.yaml"
 
   # wait for deployments to be ready
   kubectl rollout status -w deployment/olm-operator --namespace="${namespace}"


### PR DESCRIPTION
### Description of the change

As part of the release process, this PR is to update several dependencies used in our CI; from the versions of the images we use to the default Kubernetes version.

### Benefits

The referenced versions in our CI will be up to date.

### Possible drawbacks

N/A (let's the CI speak itself :P)

### Applicable issues

- related#4661

### Additional information

I've updated the release process docs as it included several broken links.
