### PR TITLE
Update Carvel plugin to use an item offset rather than page offset.

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
@@ -38,7 +38,7 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 
 	// Retrieve additional parameters from the request
 	pageSize := request.GetPaginationOptions().GetPageSize()
-	pageOffset, err := paginate.PageOffsetFromAvailableRequest(request)
+	itemOffset, err := paginate.ItemOffsetFromPageToken(request.GetPaginationOptions().GetPageToken())
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 	// Update the slice to be the correct page of results.
 	startAt := 0
 	if pageSize > 0 {
-		startAt = int(pageSize) * pageOffset
+		startAt = itemOffset
 		if startAt > len(pkgMetadatas) {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid pagination arguments %v", request.GetPaginationOptions())
 		}
@@ -137,7 +137,7 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 	// the results are a full page.
 	nextPageToken := ""
 	if pageSize > 0 && len(availablePackageSummaries) == int(pageSize) {
-		nextPageToken = fmt.Sprintf("%d", pageOffset+1)
+		nextPageToken = fmt.Sprintf("%d", itemOffset+int(pageSize))
 	}
 	response := &corev1.GetAvailablePackageSummariesResponse{
 		AvailablePackageSummaries: availablePackageSummaries,
@@ -275,7 +275,7 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 
 	// Retrieve additional parameters from the request
 	pageSize := request.GetPaginationOptions().GetPageSize()
-	pageOffset, err := paginate.PageOffsetFromInstalledRequest(request)
+	itemOffset, err := paginate.ItemOffsetFromPageToken(request.GetPaginationOptions().GetPageToken())
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +298,7 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 	if len(pkgInstalls) > 0 {
 		startAt := -1
 		if pageSize > 0 {
-			startAt = int(pageSize) * pageOffset
+			startAt = itemOffset
 			if startAt > len(pkgInstalls) {
 				return nil, status.Errorf(codes.InvalidArgument, "invalid pagination arguments %v", request.GetPaginationOptions())
 			}
@@ -430,7 +430,7 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 	// the results are a full page.
 	nextPageToken := ""
 	if pageSize > 0 && len(installedPkgSummaries) == int(pageSize) {
-		nextPageToken = fmt.Sprintf("%d", pageOffset+1)
+		nextPageToken = fmt.Sprintf("%d", itemOffset+int(pageSize))
 	}
 	response := &corev1.GetInstalledPackageSummariesResponse{
 		InstalledPackageSummaries: installedPkgSummaries,

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
@@ -623,7 +623,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 			},
 		},
 		{
-			name: "it returns paginated carvel package summaries with an offset",
+			name: "it returns paginated carvel package summaries with an item offset (not a page offset)",
 			existingObjects: []runtime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
@@ -665,6 +665,26 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						ProviderName:       "Tombi!",
 					},
 				},
+				&datapackagingv1alpha1.PackageMetadata{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       pkgMetadataResource,
+						APIVersion: datapackagingAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tunotherone.foo.example.com",
+					},
+					Spec: datapackagingv1alpha1.PackageMetadataSpec{
+						DisplayName:        "Tunotherone!",
+						IconSVGBase64:      "Tm90IHJlYWxseSBTVkcK",
+						ShortDescription:   "Another awesome game from the 90's",
+						LongDescription:    "Tunotherone! is another open world platform-adventure game with RPG elements.",
+						Categories:         []string{"platforms", "rpg"},
+						Maintainers:        []datapackagingv1alpha1.Maintainer{{Name: "person1"}, {Name: "person2"}},
+						SupportDescription: "Some support information",
+						ProviderName:       "tunotherone",
+					},
+				},
 				&datapackagingv1alpha1.Package{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgResource,
@@ -701,10 +721,28 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						ReleasedAt:                      metav1.Time{time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
 					},
 				},
+				&datapackagingv1alpha1.Package{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       pkgResource,
+						APIVersion: datapackagingAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tunotherone.foo.example.com.3.2.5",
+					},
+					Spec: datapackagingv1alpha1.PackageSpec{
+						RefName:                         "tunotherone.foo.example.com",
+						Version:                         "3.2.5",
+						Licenses:                        []string{"my-license"},
+						ReleaseNotes:                    "release notes",
+						CapactiyRequirementsDescription: "capacity description",
+						ReleasedAt:                      metav1.Time{time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
+					},
+				},
 			},
 			paginationOptions: corev1.PaginationOptions{
 				PageToken: "1",
-				PageSize:  1,
+				PageSize:  2,
 			},
 			expectedPackages: []*corev1.AvailablePackageSummary{
 				{
@@ -721,6 +759,22 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					},
 					IconUrl:          "data:image/svg+xml;base64,Tm90IHJlYWxseSBTVkcK",
 					ShortDescription: "An awesome game from the 90's",
+					Categories:       []string{"platforms", "rpg"},
+				},
+				{
+					AvailablePackageRef: &corev1.AvailablePackageReference{
+						Context:    defaultContext,
+						Plugin:     &pluginDetail,
+						Identifier: "tunotherone.foo.example.com",
+					},
+					Name:        "tunotherone.foo.example.com",
+					DisplayName: "Tunotherone!",
+					LatestVersion: &corev1.PackageAppVersion{
+						PkgVersion: "3.2.5",
+						AppVersion: "3.2.5",
+					},
+					IconUrl:          "data:image/svg+xml;base64,Tm90IHJlYWxseSBTVkcK",
+					ShortDescription: "Another awesome game from the 90's",
 					Categories:       []string{"platforms", "rpg"},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

See #3399 for the background. This PR follows #4659 which updated the Helm plugin to use an item offset rather than a page offset, and makes the same change for the kapp_controller plugin (which just works seamlessly now that the Dashboard UX client does not introspect the page token at all).

Checked in real life:

![carvel-item-based-offset](https://user-images.githubusercontent.com/497518/167527721-7fc2e6dc-5a67-4321-b570-f3c4808387c4.png)


### Benefits

2 down, 1 to go (Flux). This will enable to core plugin to interleave paginated results from plugins.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Ref #3399 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
