### PR TITLE
Update flux plugin to use item offset rather than page offset.

### DIFF
--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
@@ -58,7 +58,7 @@ func (s packagesServer) GetAvailablePackageSummaries(ctx context.Context, reques
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetContext().GetCluster(), request.GetContext().GetNamespace())
 	log.Infof("+core GetAvailablePackageSummaries %s", contextMsg)
 
-	pageOffset, err := paginate.PageOffsetFromAvailableRequest(request)
+	pageOffset, err := paginate.PageOffsetFromPageToken(request.GetPaginationOptions().GetPageToken())
 	pageSize := request.GetPaginationOptions().GetPageSize()
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "Unable to intepret page token %q: %v", request.GetPaginationOptions().GetPageToken(), err)

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart.go
@@ -197,7 +197,7 @@ func passesFilter(chart models.Chart, filters *corev1.FilterOptions) bool {
 	return ok
 }
 
-func filterAndPaginateCharts(filters *corev1.FilterOptions, pageSize int32, pageOffset int, charts map[string][]models.Chart) ([]*corev1.AvailablePackageSummary, error) {
+func filterAndPaginateCharts(filters *corev1.FilterOptions, pageSize int32, itemOffset int, charts map[string][]models.Chart) ([]*corev1.AvailablePackageSummary, error) {
 	// this loop is here for 3 reasons:
 	// 1) to convert from []interface{} which is what the generic cache implementation
 	// returns for cache hits to a typed array object.
@@ -208,7 +208,7 @@ func filterAndPaginateCharts(filters *corev1.FilterOptions, pageSize int32, page
 	i := 0
 	startAt := -1
 	if pageSize > 0 {
-		startAt = int(pageSize) * pageOffset
+		startAt = itemOffset
 	}
 	for _, packages := range charts {
 		for _, chart := range packages {

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release.go
@@ -79,7 +79,7 @@ func (s *Server) getReleaseInCluster(ctx context.Context, key types.NamespacedNa
 	return &rel, nil
 }
 
-func (s *Server) paginatedInstalledPkgSummaries(ctx context.Context, namespace string, pageSize int32, pageOffset int) ([]*corev1.InstalledPackageSummary, error) {
+func (s *Server) paginatedInstalledPkgSummaries(ctx context.Context, namespace string, pageSize int32, itemOffset int) ([]*corev1.InstalledPackageSummary, error) {
 	releasesFromCluster, err := s.listReleasesInCluster(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -89,7 +89,7 @@ func (s *Server) paginatedInstalledPkgSummaries(ctx context.Context, namespace s
 	if len(releasesFromCluster) > 0 {
 		startAt := -1
 		if pageSize > 0 {
-			startAt = int(pageSize) * pageOffset
+			startAt = itemOffset
 		}
 
 		for i, r := range releasesFromCluster {

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
@@ -168,7 +168,7 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 			request.Context.Cluster)
 	}
 
-	pageOffset, err := paginate.PageOffsetFromAvailableRequest(request)
+	itemOffset, err := paginate.ItemOffsetFromPageToken(request.GetPaginationOptions().GetPageToken())
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 
 	pageSize := request.GetPaginationOptions().GetPageSize()
 	packageSummaries, err := filterAndPaginateCharts(
-		request.GetFilterOptions(), pageSize, pageOffset, charts)
+		request.GetFilterOptions(), pageSize, itemOffset, charts)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 	// the results are a full page.
 	nextPageToken := ""
 	if pageSize > 0 && len(packageSummaries) == int(pageSize) {
-		nextPageToken = fmt.Sprintf("%d", pageOffset+1)
+		nextPageToken = fmt.Sprintf("%d", itemOffset+int(pageSize))
 	}
 
 	return &corev1.GetAvailablePackageSummariesResponse{

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
@@ -291,7 +291,7 @@ func (s *Server) GetAvailablePackageVersions(ctx context.Context, request *corev
 // GetInstalledPackageSummaries returns the installed packages managed by the 'fluxv2' plugin
 func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *corev1.GetInstalledPackageSummariesRequest) (*corev1.GetInstalledPackageSummariesResponse, error) {
 	log.Infof("+fluxv2 GetInstalledPackageSummaries [%v]", request)
-	pageOffset, err := paginate.PageOffsetFromInstalledRequest(request)
+	itemOffset, err := paginate.ItemOffsetFromPageToken(request.GetPaginationOptions().GetPageToken())
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 
 	pageSize := request.GetPaginationOptions().GetPageSize()
 	installedPkgSummaries, err := s.paginatedInstalledPkgSummaries(
-		ctx, request.GetContext().GetNamespace(), pageSize, pageOffset)
+		ctx, request.GetContext().GetNamespace(), pageSize, itemOffset)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 	// the results are a full page.
 	nextPageToken := ""
 	if pageSize > 0 && len(installedPkgSummaries) == int(pageSize) {
-		nextPageToken = fmt.Sprintf("%d", pageOffset+1)
+		nextPageToken = fmt.Sprintf("%d", itemOffset+int(pageSize))
 	}
 
 	response := &corev1.GetInstalledPackageSummariesResponse{

--- a/cmd/kubeapps-apis/plugins/pkg/paginate/paginate.go
+++ b/cmd/kubeapps-apis/plugins/pkg/paginate/paginate.go
@@ -6,7 +6,6 @@ package paginate
 import (
 	"strconv"
 
-	corev1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -17,6 +16,7 @@ import (
 // contains an offset to the item, not the page so we can
 // aggregate paginated results. Same as helm plug-in.
 // Update this when helm plug-in does so
+// TODO(minelson) This will be removed once the core pagination is updated.
 func PageOffsetFromPageToken(pageToken string) (int, error) {
 	if pageToken == "" {
 		return 0, nil
@@ -27,24 +27,6 @@ func PageOffsetFromPageToken(pageToken string) (int, error) {
 			pageToken, err)
 	}
 	return int(offset), nil
-}
-
-func PageOffsetFromInstalledRequest(request *corev1.GetInstalledPackageSummariesRequest) (int, error) {
-	offset, err := PageOffsetFromPageToken(request.GetPaginationOptions().GetPageToken())
-	if err != nil {
-		return 0, err
-	} else {
-		return offset, nil
-	}
-}
-
-func PageOffsetFromAvailableRequest(request *corev1.GetAvailablePackageSummariesRequest) (int, error) {
-	offset, err := PageOffsetFromPageToken(request.GetPaginationOptions().GetPageToken())
-	if err != nil {
-		return 0, err
-	} else {
-		return offset, nil
-	}
 }
 
 // Plugins should be designed to use an offset to the next item, rather than the

--- a/cmd/kubeapps-apis/plugins/pkg/paginate/paginate_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/paginate/paginate_test.go
@@ -6,7 +6,6 @@ package paginate
 import (
 	"testing"
 
-	corev1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -23,55 +22,5 @@ func TestPageOffsetFromPageToken(t *testing.T) {
 	_, err = PageOffsetFromPageToken("not a number")
 	if got, want := status.Code(err), codes.InvalidArgument; got != want {
 		t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
-	}
-
-	req1 := &corev1.GetInstalledPackageSummariesRequest{
-		Context: &corev1.Context{Namespace: "namespace-1"},
-	}
-	offset, err = PageOffsetFromInstalledRequest(req1)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if offset != 0 {
-		t.Fatalf("expected 1, got: %d", offset)
-	}
-
-	req2 := &corev1.GetInstalledPackageSummariesRequest{
-		Context: &corev1.Context{Namespace: "namespace-1"},
-		PaginationOptions: &corev1.PaginationOptions{
-			PageToken: "1",
-		},
-	}
-	offset, err = PageOffsetFromInstalledRequest(req2)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if offset != 1 {
-		t.Fatalf("expected 1, got: %d", offset)
-	}
-
-	req3 := &corev1.GetAvailablePackageSummariesRequest{
-		Context: &corev1.Context{Namespace: "namespace-1"},
-	}
-	offset, err = PageOffsetFromAvailableRequest(req3)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if offset != 0 {
-		t.Fatalf("expected 1, got: %d", offset)
-	}
-
-	req4 := &corev1.GetAvailablePackageSummariesRequest{
-		Context: &corev1.Context{Namespace: "namespace-1"},
-		PaginationOptions: &corev1.PaginationOptions{
-			PageToken: "1",
-		},
-	}
-	offset, err = PageOffsetFromAvailableRequest(req4)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if offset != 1 {
-		t.Fatalf("expected 1, got: %d", offset)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Follows on from #4678 with the similar change for the flux plugin.

Verified it works in real life:
![flux-item-offset](https://user-images.githubusercontent.com/497518/167533336-1058c514-2aec-4528-86ea-35c64740e3ad.png)

The existing unit tests for pagination still pass because they use a pageSize of 1, so that an itemOffset is the same as a pageOffset.

Haven't checked @gfichtenholt 's integration tests. Might give them a spin after lunch and see (but they shouldn't be affected unless they're introspecting the page token).

~~Hmm, also didn't update the repo endpoints which I assume use the same/similar pagination. Marking this as a draft until I've done that~~ Checked, they don't use pagination.

### Benefits

<!-- What benefits will be realized by the code change? -->
Now I can do the core pagination :)

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3399 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
