### PR TITLE
Skip some tests when running on Windows

### DIFF
--- a/cmd/kubeapps-apis/cmd/root_test.go
+++ b/cmd/kubeapps-apis/cmd/root_test.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"bytes"
+	"runtime"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -47,6 +48,10 @@ func TestParseFlagsCorrect(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// TODO(agamez): env vars and file paths should be handled properly for Windows operating system
+			if runtime.GOOS == "windows" {
+				t.Skip("Skipping in a Windows OS")
+			}
 			cmd := newRootCmd()
 			b := bytes.NewBufferString("")
 			cmd.SetOut(b)

--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins_test.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"testing/fstest"
 
@@ -242,6 +243,10 @@ func TestListOSFiles(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// TODO(agamez): env vars and file paths should be handled properly for Windows operating system
+			if runtime.GOOS == "windows" {
+				t.Skip("Skipping in a Windows OS")
+			}
 			fs := createTestFS(t, tc.filenames)
 
 			got, err := listSOFiles(fs, tc.pluginsDirs)

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common/utils_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common/utils_test.go
@@ -6,6 +6,7 @@ package common
 import (
 	"log"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -111,6 +112,10 @@ core:
 	opts := cmpopts.IgnoreUnexported(pkgutils.VersionsInSummary{})
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// TODO(agamez): env vars and file paths should be handled properly for Windows operating system
+			if runtime.GOOS == "windows" {
+				t.Skip("Skipping in a Windows OS")
+			}
 			filename := ""
 			if tc.pluginYAMLConf != nil {
 				pluginJSONConf, err := yaml.YAMLToJSON(tc.pluginYAMLConf)

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -37,7 +38,7 @@ import (
 	k8scorev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	disfake "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/dynamic"
@@ -85,7 +86,7 @@ func TestGetClient(t *testing.T) {
 		return clientgetter.NewBuilder().
 			WithTyped(typfake.NewSimpleClientset()).
 			WithDynamic(dynfake.NewSimpleDynamicClientWithCustomListKinds(
-				runtime.NewScheme(),
+				k8sruntime.NewScheme(),
 				map[schema.GroupVersionResource]string{
 					{Group: "foo", Version: "bar", Resource: "baz"}: "fooList",
 				},
@@ -147,7 +148,7 @@ func TestGetClient(t *testing.T) {
 func TestGetAvailablePackageSummaries(t *testing.T) {
 	testCases := []struct {
 		name               string
-		existingObjects    []runtime.Object
+		existingObjects    []k8sruntime.Object
 		expectedPackages   []*corev1.AvailablePackageSummary
 		paginationOptions  corev1.PaginationOptions
 		filterOptions      corev1.FilterOptions
@@ -160,7 +161,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it returns an internal error status if there is no corresponding package for a package metadata",
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -186,7 +187,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it returns an invalid argument error status if a page is requested that doesn't exist",
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -216,7 +217,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it returns carvel package summaries with basic info from the cluster",
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -333,7 +334,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		// corresponding pkgmeta. Let's handle this gracefully.
 		{
 			name: "it returns carvel package summaries with basic info from the cluster even when there's a missing pkg meta",
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -466,7 +467,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it returns carvel package summaries with complete metadata",
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -527,7 +528,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it returns the latest semver version in the latest version field without relying on default alpha sorting",
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -624,7 +625,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it returns paginated carvel package summaries with an item offset (not a page offset)",
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -781,7 +782,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it returns paginated carvel package summaries limited to the page size",
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -887,7 +888,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 			filterOptions: corev1.FilterOptions{
 				Query: "tetr",
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -988,9 +989,9 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var unstructuredObjects []runtime.Object
+			var unstructuredObjects []k8sruntime.Object
 			for _, obj := range tc.existingObjects {
-				unstructuredContent, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+				unstructuredContent, _ := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
 				unstructuredObjects = append(unstructuredObjects, &unstructured.Unstructured{Object: unstructuredContent})
 			}
 
@@ -999,7 +1000,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 				clientGetter: func(ctx context.Context, cluster string) (clientgetter.ClientInterfaces, error) {
 					return clientgetter.NewBuilder().
 						WithDynamic(dynfake.NewSimpleDynamicClientWithCustomListKinds(
-							runtime.NewScheme(),
+							k8sruntime.NewScheme(),
 							map[schema.GroupVersionResource]string{
 								{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgsResource}:         pkgResource + "List",
 								{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgMetadatasResource}: pkgMetadataResource + "List",
@@ -1033,7 +1034,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 func TestGetAvailablePackageVersions(t *testing.T) {
 	testCases := []struct {
 		name               string
-		existingObjects    []runtime.Object
+		existingObjects    []k8sruntime.Object
 		request            *corev1.GetAvailablePackageVersionsRequest
 		expectedStatusCode codes.Code
 		expectedResponse   *corev1.GetAvailablePackageVersionsResponse
@@ -1066,7 +1067,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 		},
 		{
 			name: "it returns the package version summary",
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.Package{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgResource,
@@ -1152,9 +1153,9 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var unstructuredObjects []runtime.Object
+			var unstructuredObjects []k8sruntime.Object
 			for _, obj := range tc.existingObjects {
-				unstructuredContent, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+				unstructuredContent, _ := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
 				unstructuredObjects = append(unstructuredObjects, &unstructured.Unstructured{Object: unstructuredContent})
 			}
 
@@ -1163,7 +1164,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 				clientGetter: func(ctx context.Context, cluster string) (clientgetter.ClientInterfaces, error) {
 					return clientgetter.NewBuilder().
 						WithDynamic(dynfake.NewSimpleDynamicClientWithCustomListKinds(
-							runtime.NewScheme(),
+							k8sruntime.NewScheme(),
 							map[schema.GroupVersionResource]string{
 								{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgsResource}: pkgResource + "List",
 							},
@@ -1193,7 +1194,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 func TestGetAvailablePackageDetail(t *testing.T) {
 	testCases := []struct {
 		name            string
-		existingObjects []runtime.Object
+		existingObjects []k8sruntime.Object
 		expectedPackage *corev1.AvailablePackageDetail
 		statusCode      codes.Code
 		request         *corev1.GetAvailablePackageDetailRequest
@@ -1206,7 +1207,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 					Identifier: "tetris.foo.example.com",
 				},
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -1297,7 +1298,7 @@ Some support information
 					Identifier: "tetris.foo.example.com",
 				},
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -1398,7 +1399,7 @@ Some support information
 				},
 				PkgVersion: "1.2.4",
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -1444,9 +1445,9 @@ Some support information
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var unstructuredObjects []runtime.Object
+			var unstructuredObjects []k8sruntime.Object
 			for _, obj := range tc.existingObjects {
-				unstructuredContent, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+				unstructuredContent, _ := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
 				unstructuredObjects = append(unstructuredObjects, &unstructured.Unstructured{Object: unstructuredContent})
 			}
 
@@ -1455,7 +1456,7 @@ Some support information
 				clientGetter: func(ctx context.Context, cluster string) (clientgetter.ClientInterfaces, error) {
 					return clientgetter.NewBuilder().
 						WithDynamic(dynfake.NewSimpleDynamicClientWithCustomListKinds(
-							runtime.NewScheme(),
+							k8sruntime.NewScheme(),
 							map[schema.GroupVersionResource]string{
 								{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgsResource}:         pkgResource + "List",
 								{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgMetadatasResource}: pkgMetadataResource + "List",
@@ -1483,7 +1484,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 	testCases := []struct {
 		name               string
 		request            *corev1.GetInstalledPackageSummariesRequest
-		existingObjects    []runtime.Object
+		existingObjects    []k8sruntime.Object
 		expectedPackages   []*corev1.InstalledPackageSummary
 		expectedStatusCode codes.Code
 	}{
@@ -1496,7 +1497,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					PageSize:  2,
 				},
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -1585,7 +1586,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 		{
 			name:    "it returns carvel empty installed package summary when no package install is present",
 			request: &corev1.GetInstalledPackageSummariesRequest{Context: defaultContext},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -1630,7 +1631,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 		{
 			name:    "it returns carvel installed package summary with complete metadata",
 			request: &corev1.GetInstalledPackageSummariesRequest{Context: defaultContext},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -1758,7 +1759,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					Cluster:   defaultContext.Cluster,
 				},
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -1882,7 +1883,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					Cluster:   defaultContext.Cluster,
 				},
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -2112,7 +2113,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 		{
 			name:    "it returns carvel installed package summary with a packageInstall without status",
 			request: &corev1.GetInstalledPackageSummariesRequest{Context: defaultContext},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -2218,7 +2219,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 		{
 			name:    "it returns the latest semver version in the latest version field with the latest matching version",
 			request: &corev1.GetInstalledPackageSummariesRequest{Context: defaultContext},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -2373,7 +2374,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 		{
 			name:    "it returns the latest semver version in the latest version field with no latest matching version if constraint is not satisfied ",
 			request: &corev1.GetInstalledPackageSummariesRequest{Context: defaultContext},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -2505,9 +2506,9 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var unstructuredObjects []runtime.Object
+			var unstructuredObjects []k8sruntime.Object
 			for _, obj := range tc.existingObjects {
-				unstructuredContent, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+				unstructuredContent, _ := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
 				unstructuredObjects = append(unstructuredObjects, &unstructured.Unstructured{Object: unstructuredContent})
 			}
 
@@ -2516,7 +2517,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 				clientGetter: func(ctx context.Context, cluster string) (clientgetter.ClientInterfaces, error) {
 					return clientgetter.NewBuilder().
 						WithDynamic(dynfake.NewSimpleDynamicClientWithCustomListKinds(
-							runtime.NewScheme(),
+							k8sruntime.NewScheme(),
 							map[schema.GroupVersionResource]string{
 								{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgsResource}:         pkgResource + "List",
 								{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgMetadatasResource}: pkgMetadataResource + "List",
@@ -2548,8 +2549,8 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 func TestGetInstalledPackageDetail(t *testing.T) {
 	testCases := []struct {
 		name                 string
-		existingObjects      []runtime.Object
-		existingTypedObjects []runtime.Object
+		existingObjects      []k8sruntime.Object
+		existingTypedObjects []k8sruntime.Object
 		expectedPackage      *corev1.InstalledPackageDetail
 		statusCode           codes.Code
 		request              *corev1.GetInstalledPackageDetailRequest
@@ -2562,7 +2563,7 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 					Identifier: "my-installation",
 				},
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -2707,7 +2708,7 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
@@ -2795,7 +2796,7 @@ fetchStderr
 					Identifier: "my-installation",
 				},
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -2905,7 +2906,7 @@ fetchStderr
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
@@ -2985,9 +2986,9 @@ fetchStderr
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var unstructuredObjects []runtime.Object
+			var unstructuredObjects []k8sruntime.Object
 			for _, obj := range tc.existingObjects {
-				unstructuredContent, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+				unstructuredContent, _ := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
 				unstructuredObjects = append(unstructuredObjects, &unstructured.Unstructured{Object: unstructuredContent})
 			}
 
@@ -2997,7 +2998,7 @@ fetchStderr
 					return clientgetter.NewBuilder().
 						WithTyped(typfake.NewSimpleClientset(tc.existingTypedObjects...)).
 						WithDynamic(dynfake.NewSimpleDynamicClientWithCustomListKinds(
-							runtime.NewScheme(),
+							k8sruntime.NewScheme(),
 							map[schema.GroupVersionResource]string{
 								{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgsResource}:         pkgResource + "List",
 								{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgMetadatasResource}: pkgMetadataResource + "List",
@@ -3026,8 +3027,8 @@ func TestCreateInstalledPackage(t *testing.T) {
 		name                   string
 		request                *corev1.CreateInstalledPackageRequest
 		pluginConfig           *kappControllerPluginParsedConfig
-		existingObjects        []runtime.Object
-		existingTypedObjects   []runtime.Object
+		existingObjects        []k8sruntime.Object
+		existingTypedObjects   []k8sruntime.Object
 		expectedStatusCode     codes.Code
 		expectedResponse       *corev1.CreateInstalledPackageResponse
 		expectedPackageInstall *packagingv1alpha1.PackageInstall
@@ -3056,7 +3057,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 				},
 			},
 			pluginConfig: defaultPluginConfig,
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -3123,7 +3124,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -3215,7 +3216,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 				defaultPrereleasesVersionSelection: defaultPluginConfig.defaultPrereleasesVersionSelection,
 				defaultAllowDowngrades:             defaultPluginConfig.defaultAllowDowngrades,
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -3255,7 +3256,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -3297,7 +3298,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 				},
 			},
 			pluginConfig: defaultPluginConfig,
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -3364,7 +3365,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -3453,7 +3454,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 				},
 			},
 			pluginConfig: defaultPluginConfig,
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -3520,7 +3521,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -3611,7 +3612,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 				defaultPrereleasesVersionSelection: nil,
 				defaultAllowDowngrades:             defaultPluginConfig.defaultAllowDowngrades,
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -3678,7 +3679,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -3770,7 +3771,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 				defaultPrereleasesVersionSelection: nil,
 				defaultAllowDowngrades:             defaultPluginConfig.defaultAllowDowngrades,
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -3837,7 +3838,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -3882,7 +3883,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 				defaultPrereleasesVersionSelection: []string{},
 				defaultAllowDowngrades:             defaultPluginConfig.defaultAllowDowngrades,
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -3949,7 +3950,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -4041,7 +4042,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 				defaultPrereleasesVersionSelection: []string{"rc"},
 				defaultAllowDowngrades:             defaultPluginConfig.defaultAllowDowngrades,
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -4108,7 +4109,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -4196,7 +4197,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 				},
 			},
 			pluginConfig: defaultPluginConfig,
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -4263,7 +4264,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -4354,7 +4355,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 				defaultPrereleasesVersionSelection: defaultPluginConfig.defaultPrereleasesVersionSelection,
 				defaultAllowDowngrades:             defaultPluginConfig.defaultAllowDowngrades,
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -4421,7 +4422,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -4512,7 +4513,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 				defaultPrereleasesVersionSelection: defaultPluginConfig.defaultPrereleasesVersionSelection,
 				defaultAllowDowngrades:             defaultPluginConfig.defaultAllowDowngrades,
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -4579,7 +4580,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -4670,7 +4671,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 				defaultPrereleasesVersionSelection: defaultPluginConfig.defaultPrereleasesVersionSelection,
 				defaultAllowDowngrades:             defaultPluginConfig.defaultAllowDowngrades,
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -4737,7 +4738,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -4828,7 +4829,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 				defaultPrereleasesVersionSelection: defaultPluginConfig.defaultPrereleasesVersionSelection,
 				defaultAllowDowngrades:             true,
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -4895,7 +4896,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -4963,14 +4964,14 @@ func TestCreateInstalledPackage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var unstructuredObjects []runtime.Object
+			var unstructuredObjects []k8sruntime.Object
 			for _, obj := range tc.existingObjects {
-				unstructuredContent, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+				unstructuredContent, _ := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
 				unstructuredObjects = append(unstructuredObjects, &unstructured.Unstructured{Object: unstructuredContent})
 			}
 
 			dynamicClient := dynfake.NewSimpleDynamicClientWithCustomListKinds(
-				runtime.NewScheme(),
+				k8sruntime.NewScheme(),
 				map[schema.GroupVersionResource]string{
 					{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgsResource}:         pkgResource + "List",
 					{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgMetadatasResource}: pkgMetadataResource + "List",
@@ -5022,8 +5023,8 @@ func TestUpdateInstalledPackage(t *testing.T) {
 		name                   string
 		request                *corev1.UpdateInstalledPackageRequest
 		pluginConfig           *kappControllerPluginParsedConfig
-		existingObjects        []runtime.Object
-		existingTypedObjects   []runtime.Object
+		existingObjects        []k8sruntime.Object
+		existingTypedObjects   []k8sruntime.Object
 		expectedStatusCode     codes.Code
 		expectedResponse       *corev1.UpdateInstalledPackageResponse
 		expectedPackageInstall *packagingv1alpha1.PackageInstall
@@ -5050,7 +5051,7 @@ func TestUpdateInstalledPackage(t *testing.T) {
 				},
 			},
 			pluginConfig: defaultPluginConfig,
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -5134,7 +5135,7 @@ func TestUpdateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
@@ -5225,7 +5226,7 @@ func TestUpdateInstalledPackage(t *testing.T) {
 				defaultPrereleasesVersionSelection: nil,
 				defaultAllowDowngrades:             defaultPluginConfig.defaultAllowDowngrades,
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgMetadataResource,
@@ -5309,7 +5310,7 @@ func TestUpdateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
@@ -5327,9 +5328,9 @@ func TestUpdateInstalledPackage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var unstructuredObjects []runtime.Object
+			var unstructuredObjects []k8sruntime.Object
 			for _, obj := range tc.existingObjects {
-				unstructuredContent, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+				unstructuredContent, _ := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
 				unstructuredObjects = append(unstructuredObjects, &unstructured.Unstructured{Object: unstructuredContent})
 			}
 
@@ -5339,7 +5340,7 @@ func TestUpdateInstalledPackage(t *testing.T) {
 					return clientgetter.NewBuilder().
 						WithTyped(typfake.NewSimpleClientset(tc.existingTypedObjects...)).
 						WithDynamic(dynfake.NewSimpleDynamicClientWithCustomListKinds(
-							runtime.NewScheme(),
+							k8sruntime.NewScheme(),
 							map[schema.GroupVersionResource]string{
 								{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgsResource}:         pkgResource + "List",
 								{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgMetadatasResource}: pkgMetadataResource + "List",
@@ -5381,8 +5382,8 @@ func TestDeleteInstalledPackage(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		request              *corev1.DeleteInstalledPackageRequest
-		existingObjects      []runtime.Object
-		existingTypedObjects []runtime.Object
+		existingObjects      []k8sruntime.Object
+		existingTypedObjects []k8sruntime.Object
 		expectedStatusCode   codes.Code
 		expectedResponse     *corev1.DeleteInstalledPackageResponse
 	}{
@@ -5395,7 +5396,7 @@ func TestDeleteInstalledPackage(t *testing.T) {
 					Identifier: "my-installation",
 				},
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&packagingv1alpha1.PackageInstall{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgInstallResource,
@@ -5441,7 +5442,7 @@ func TestDeleteInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
@@ -5465,7 +5466,7 @@ func TestDeleteInstalledPackage(t *testing.T) {
 					Identifier: "noy-my-installation",
 				},
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&packagingv1alpha1.PackageInstall{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgInstallResource,
@@ -5511,7 +5512,7 @@ func TestDeleteInstalledPackage(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
@@ -5530,9 +5531,9 @@ func TestDeleteInstalledPackage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var unstructuredObjects []runtime.Object
+			var unstructuredObjects []k8sruntime.Object
 			for _, obj := range tc.existingObjects {
-				unstructuredContent, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+				unstructuredContent, _ := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
 				unstructuredObjects = append(unstructuredObjects, &unstructured.Unstructured{Object: unstructuredContent})
 			}
 
@@ -5542,7 +5543,7 @@ func TestDeleteInstalledPackage(t *testing.T) {
 					return clientgetter.NewBuilder().
 						WithTyped(typfake.NewSimpleClientset(tc.existingTypedObjects...)).
 						WithDynamic(dynfake.NewSimpleDynamicClientWithCustomListKinds(
-							runtime.NewScheme(),
+							k8sruntime.NewScheme(),
 							map[schema.GroupVersionResource]string{
 								{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgsResource}:         pkgResource + "List",
 								{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgMetadatasResource}: pkgMetadataResource + "List",
@@ -5573,8 +5574,8 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		request              *corev1.GetInstalledPackageResourceRefsRequest
-		existingObjects      []runtime.Object
-		existingTypedObjects []runtime.Object
+		existingObjects      []k8sruntime.Object
+		existingTypedObjects []k8sruntime.Object
 		expectedStatusCode   codes.Code
 		expectedResponse     *corev1.GetInstalledPackageResourceRefsResponse
 	}{
@@ -5587,7 +5588,7 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 					Identifier: "my-installation",
 				},
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&packagingv1alpha1.PackageInstall{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgInstallResource,
@@ -5664,7 +5665,7 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 					},
 				},
 			},
-			existingTypedObjects: []runtime.Object{
+			existingTypedObjects: []k8sruntime.Object{
 				&k8scorev1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -5701,7 +5702,7 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 					Identifier: "my-installation",
 				},
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&packagingv1alpha1.PackageInstall{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgInstallResource,
@@ -5753,9 +5754,9 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var unstructuredObjects []runtime.Object
+			var unstructuredObjects []k8sruntime.Object
 			for _, obj := range tc.existingObjects {
-				unstructuredContent, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+				unstructuredContent, _ := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
 				unstructuredObjects = append(unstructuredObjects, &unstructured.Unstructured{Object: unstructuredContent})
 			}
 			// If more resources types are added, this will need to be updated accordingly
@@ -5776,7 +5777,7 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 			fakeDiscovery.Fake.Resources = apiResources
 
 			dynClient := dynfake.NewSimpleDynamicClientWithCustomListKinds(
-				runtime.NewScheme(),
+				k8sruntime.NewScheme(),
 				map[schema.GroupVersionResource]string{
 					{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgsResource}:         pkgResource + "List",
 					{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgMetadatasResource}: pkgMetadataResource + "List",
@@ -5844,7 +5845,7 @@ func TestGetPackageRepositories(t *testing.T) {
 	testCases := []struct {
 		name               string
 		request            *v1alpha1.GetPackageRepositoriesRequest
-		existingObjects    []runtime.Object
+		existingObjects    []k8sruntime.Object
 		expectedResponse   []*v1alpha1.PackageRepository
 		expectedStatusCode codes.Code
 	}{
@@ -5856,7 +5857,7 @@ func TestGetPackageRepositories(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			existingObjects: []runtime.Object{
+			existingObjects: []k8sruntime.Object{
 				&packagingv1alpha1.PackageRepository{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       pkgRepositoryResource,
@@ -5913,9 +5914,9 @@ func TestGetPackageRepositories(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var unstructuredObjects []runtime.Object
+			var unstructuredObjects []k8sruntime.Object
 			for _, obj := range tc.existingObjects {
-				unstructuredContent, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+				unstructuredContent, _ := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
 				unstructuredObjects = append(unstructuredObjects, &unstructured.Unstructured{Object: unstructuredContent})
 			}
 
@@ -5924,7 +5925,7 @@ func TestGetPackageRepositories(t *testing.T) {
 				clientGetter: func(ctx context.Context, cluster string) (clientgetter.ClientInterfaces, error) {
 					return clientgetter.NewBuilder().
 						WithDynamic(dynfake.NewSimpleDynamicClientWithCustomListKinds(
-							runtime.NewScheme(),
+							k8sruntime.NewScheme(),
 							map[schema.GroupVersionResource]string{
 								{Group: packagingv1alpha1.SchemeGroupVersion.Group, Version: packagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgRepositoriesResource}: pkgRepositoryResource + "List",
 							},
@@ -6209,6 +6210,10 @@ kappController:
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// TODO(agamez): env vars and file paths should be handled properly for Windows operating system
+			if runtime.GOOS == "windows" {
+				t.Skip("Skipping in a Windows OS")
+			}
 			filename := ""
 			if tc.pluginYAMLConf != nil {
 				pluginJSONConf, err := yaml.YAMLToJSON(tc.pluginYAMLConf)

--- a/pkg/kube/kube_utils_test.go
+++ b/pkg/kube/kube_utils_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -344,7 +345,10 @@ func TestGetProxyConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
+			// TODO(agamez): env vars and file paths should be handled properly for Windows operating system
+			if runtime.GOOS == "windows" {
+				t.Skip("Skipping in a Windows OS")
+			}
 			// Set the env for the test ensuring to restore after.
 			originalValues := map[string]string{}
 			for _, key := range proxyVars {


### PR DESCRIPTION
### Description of the change

Since I am temporarily running a Windows system, I've noticed that some of our tests are not ready to run there (asserting non-existing error messages, dealing with files and env vars, etc...), so, even we decrease the test coverage when running tests on windows, at least, we won't get consistently failing tests anymore.

### Benefits

We will be able to run our test suite on Windows without false positives.

### Possible drawbacks

Less coverage on Windows.

### Applicable issues

N/A

### Additional information

N/A
