### PR TITLE
Enable fan-in of results for summaries from plugins.

### DIFF
--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages_fan_in.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages_fan_in.go
@@ -1,0 +1,218 @@
+// Copyright 2021-2022 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+package v1alpha1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	packages "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/paginate"
+)
+
+const CompleteToken = -1
+
+// summaryWithOffsets is the channel type for the results of the combined
+// core results after fanning in from the plugins.
+type summaryWithOffsets struct {
+	availablePackageSummary *packages.AvailablePackageSummary
+	categories              []string
+	nextItemOffsets         map[string]int
+	err                     error
+}
+
+// fanInAvailablePackageSummaries fans in the results from the separate plugins
+// to the return channel.
+//
+// Each plugin handles the request in a separate go-routine while this function
+// uses the fan-in pattern to merge those results, sending the next result back
+// down the return channel until the request is satisfied. Importantly, each
+// result is accompanied by the current next item offsets for each plugin so
+// that the caller can generate a next page token that is able to encode the
+// offsets for each plugin. The next request the begins each plugin where it
+// left off for the last.
+//
+// Plugins generally do not use snapshots of the actual data, so, similar to the
+// pagination of individual plugins, it will be possible that this returns
+// duplicates or missing data if data is added or removed between paginated
+// requests.
+func fanInAvailablePackageSummaries(ctx context.Context, pkgPlugins []pkgPluginWithServer, request *packages.GetAvailablePackageSummariesRequest) (<-chan summaryWithOffsets, error) {
+	summariesCh := make(chan summaryWithOffsets)
+
+	corePageSize := int(request.GetPaginationOptions().GetPageSize())
+	// We'll request a bit more than pageSize / n from each plugin. If the page
+	// size is 10 and we have 3 plugins, request 5 items from each to start.
+	pluginPageSize := corePageSize
+	if len(pkgPlugins) > 1 {
+		pluginPageSize = pluginPageSize / (len(pkgPlugins) - 1)
+	}
+
+	var pluginPageOffsets map[string]int
+	if request.GetPaginationOptions().GetPageToken() != "" {
+		err := json.Unmarshal([]byte(request.GetPaginationOptions().GetPageToken()), &pluginPageOffsets)
+		if err != nil {
+			return nil, fmt.Errorf("unable to unmarshal %q: %w", request.GetPaginationOptions().GetPageToken(), err)
+		}
+	}
+
+	fanInput := []<-chan *summaryWithOffset{}
+	for _, pluginWithSrv := range pkgPlugins {
+		// Importantly, each plugin needs its own request, with its on pagination
+		// options.
+		r := &packages.GetAvailablePackageSummariesRequest{
+			Context:       request.Context,
+			FilterOptions: request.FilterOptions,
+			PaginationOptions: &packages.PaginationOptions{
+				PageSize:  int32(pluginPageSize),
+				PageToken: fmt.Sprintf("%d", pluginPageOffsets[pluginWithSrv.plugin.Name]),
+			},
+		}
+
+		ch, err := sendAvailablePackageSummariesForPlugin(ctx, pluginWithSrv, r)
+		if err != nil {
+			return nil, err
+		}
+		fanInput = append(fanInput, ch)
+	}
+
+	// We now have a slice of channels for the fan-in and want a go routine that
+	// will ensure it sends the next (ordered) item from all channels down the
+	// channel.
+	go func() {
+		numSent := 0
+		offsets := map[string]int{}
+		nextItems := make([]*summaryWithOffset, len(fanInput))
+		for {
+			// Populate the empty next items from each channel.
+			for i, ch := range fanInput {
+				if nextItems[i] == nil {
+					// If the channel is closed, the value will remain nil.
+					ok := true
+					nextItems[i], ok = <-ch
+					if !ok {
+						// If the channel was closed, we reached the last item for that
+						// plugin. We need to recognise when all plugins have exhausted
+						// itemsoffsets
+						pluginName := pkgPlugins[i].plugin.Name
+						offsets[pluginName] = CompleteToken
+					}
+
+					if nextItems[i] != nil && nextItems[i].err != nil {
+						summariesCh <- summaryWithOffsets{
+							err: nextItems[i].err,
+						}
+						close(summariesCh)
+						return
+					}
+				}
+			}
+
+			// Choose the minimum by name and send it down the line.
+			// First find the first non-nil value as the min.
+			minIndex := -1
+			for i, s := range nextItems {
+				if s != nil {
+					minIndex = i
+					break
+				}
+			}
+
+			// If there is no non-nil value left, we're done.
+			if minIndex == -1 {
+				close(summariesCh)
+				return
+			}
+
+			// Otherwise, we find the minimum item of the next items from each channel.
+			for i, s := range nextItems {
+				if s != nil && s.availablePackageSummary.Name < nextItems[minIndex].availablePackageSummary.Name {
+					minIndex = i
+				}
+			}
+			pluginName := nextItems[minIndex].availablePackageSummary.GetAvailablePackageRef().GetPlugin().GetName()
+			offsets[pluginName] = nextItems[minIndex].nextItemOffset
+			summariesCh <- summaryWithOffsets{
+				availablePackageSummary: nextItems[minIndex].availablePackageSummary,
+				categories:              nextItems[minIndex].categories,
+				nextItemOffsets:         offsets,
+			}
+			// Ensure the item will get replaced on the next round.
+			nextItems[minIndex] = nil
+
+			numSent += 1
+			if numSent == corePageSize {
+				close(summariesCh)
+				return
+			}
+		}
+	}()
+
+	return summariesCh, nil
+}
+
+// summaryWithOffset is the channel type for the single result from a
+// single plugin.
+type summaryWithOffset struct {
+	availablePackageSummary *packages.AvailablePackageSummary
+	categories              []string
+	nextItemOffset          int
+	err                     error
+}
+
+// sendAvailablePackageSummariesForPlugin returns a channel and sends the
+// available package summaries returned by the plugin for the given request.
+func sendAvailablePackageSummariesForPlugin(ctx context.Context, pkgPlugin pkgPluginWithServer, request *packages.GetAvailablePackageSummariesRequest) (<-chan *summaryWithOffset, error) {
+	summaryCh := make(chan *summaryWithOffset)
+
+	itemOffset, err := paginate.ItemOffsetFromPageToken(request.GetPaginationOptions().GetPageToken())
+	if err != nil {
+		return nil, err
+	}
+
+	if itemOffset == -1 {
+		// This plugin was already exhausted during the last request. Nothing to do here.
+		close(summaryCh)
+		return summaryCh, nil
+	}
+
+	// Start a go func that requests the next page of summaries and sends them down the
+	// channel. Since the channel is blocking, further requests won't be issued until the
+	// previous response is drained. We could use a small buffer to request ahead as an
+	// improvement.
+	go func() {
+		for {
+			response, err := pkgPlugin.server.GetAvailablePackageSummaries(ctx, request)
+			if err != nil {
+				summaryCh <- &summaryWithOffset{err: err}
+				close(summaryCh)
+				return
+			}
+			categories := response.Categories
+			for _, summary := range response.AvailablePackageSummaries {
+				itemOffset = itemOffset + 1
+				summaryCh <- &summaryWithOffset{
+					availablePackageSummary: summary,
+					categories:              categories,
+					nextItemOffset:          itemOffset,
+				}
+				// We only need to send the categories once per response.
+				categories = nil
+			}
+			if response.GetNextPageToken() == "" {
+				close(summaryCh)
+				return
+			}
+			// We can sanity check here to be sure the next page token
+			// corresponds to the current value of itemOffset.
+			if fmt.Sprintf("%d", itemOffset) != response.GetNextPageToken() {
+				summaryCh <- &summaryWithOffset{
+					err: fmt.Errorf("inconsistent item offset: got: %q, expected: %d", response.GetNextPageToken(), itemOffset),
+				}
+			}
+			request.PaginationOptions.PageToken = response.GetNextPageToken()
+		}
+	}()
+
+	return summaryCh, nil
+}

--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages_fan_in.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages_fan_in.go
@@ -58,7 +58,7 @@ func fanInAvailablePackageSummaries(ctx context.Context, pkgPlugins []pkgPluginW
 
 	fanInput := []<-chan *summaryWithOffset{}
 	for _, pluginWithSrv := range pkgPlugins {
-		// Importantly, each plugin needs its own request, with its on pagination
+		// Importantly, each plugin needs its own request, with its own pagination
 		// options.
 		r := &packages.GetAvailablePackageSummariesRequest{
 			Context:       request.Context,

--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages_test.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages_test.go
@@ -49,40 +49,40 @@ var ignoreUnexportedOpts = cmpopts.IgnoreUnexported(
 	plugins.Plugin{},
 )
 
-func makeDefaultTestPackagingPlugin(pluginName string) pkgPluginsWithServer {
+func makeDefaultTestPackagingPlugin(pluginName string) pkgPluginWithServer {
 	pluginDetails := &plugins.Plugin{Name: pluginName, Version: "v1alpha1"}
 	packagingPluginServer := &plugin_test.TestPackagingPluginServer{Plugin: pluginDetails}
 
 	packagingPluginServer.AvailablePackageSummaries = []*corev1.AvailablePackageSummary{
-		plugin_test.MakeAvailablePackageSummary("pkg-2", pluginDetails),
 		plugin_test.MakeAvailablePackageSummary("pkg-1", pluginDetails),
+		plugin_test.MakeAvailablePackageSummary("pkg-2", pluginDetails),
 	}
 	packagingPluginServer.AvailablePackageDetail = plugin_test.MakeAvailablePackageDetail("pkg-1", pluginDetails)
 	packagingPluginServer.InstalledPackageSummaries = []*corev1.InstalledPackageSummary{
-		plugin_test.MakeInstalledPackageSummary("pkg-2", pluginDetails),
 		plugin_test.MakeInstalledPackageSummary("pkg-1", pluginDetails),
+		plugin_test.MakeInstalledPackageSummary("pkg-2", pluginDetails),
 	}
 	packagingPluginServer.InstalledPackageDetail = plugin_test.MakeInstalledPackageDetail("pkg-1", pluginDetails)
 	packagingPluginServer.PackageAppVersions = []*corev1.PackageAppVersion{
 		plugin_test.MakePackageAppVersion(plugin_test.DefaultAppVersion, plugin_test.DefaultPkgUpdateVersion),
 		plugin_test.MakePackageAppVersion(plugin_test.DefaultAppVersion, plugin_test.DefaultPkgVersion),
 	}
-	packagingPluginServer.NextPageToken = "1"
+	packagingPluginServer.NextPageToken = ""
 	packagingPluginServer.Categories = []string{plugin_test.DefaultCategory}
 
-	return pkgPluginsWithServer{
+	return pkgPluginWithServer{
 		plugin: pluginDetails,
 		server: packagingPluginServer,
 	}
 }
 
-func makeOnlyStatusTestPackagingPlugin(pluginName string, statusCode codes.Code) pkgPluginsWithServer {
+func makeOnlyStatusTestPackagingPlugin(pluginName string, statusCode codes.Code) pkgPluginWithServer {
 	pluginDetails := &plugins.Plugin{Name: pluginName, Version: "v1alpha1"}
 	packagingPluginServer := &plugin_test.TestPackagingPluginServer{Plugin: pluginDetails}
 
 	packagingPluginServer.Status = statusCode
 
-	return pkgPluginsWithServer{
+	return pkgPluginWithServer{
 		plugin: pluginDetails,
 		server: packagingPluginServer,
 	}
@@ -91,14 +91,14 @@ func makeOnlyStatusTestPackagingPlugin(pluginName string, statusCode codes.Code)
 func TestGetAvailablePackageSummaries(t *testing.T) {
 	testCases := []struct {
 		name              string
-		configuredPlugins []pkgPluginsWithServer
+		configuredPlugins []pkgPluginWithServer
 		statusCode        codes.Code
 		request           *corev1.GetAvailablePackageSummariesRequest
 		expectedResponse  *corev1.GetAvailablePackageSummariesResponse
 	}{
 		{
 			name: "it should successfully call the core GetAvailablePackageSummaries operation",
-			configuredPlugins: []pkgPluginsWithServer{
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -121,8 +121,8 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 			statusCode: codes.OK,
 		},
 		{
-			name: "it should successfully call and paginate (first page) the core GetAvailablePackageSummaries operation",
-			configuredPlugins: []pkgPluginsWithServer{
+			name: "it should successfully call and paginate one page the core GetAvailablePackageSummaries operation",
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -131,21 +131,22 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
-				PaginationOptions: &corev1.PaginationOptions{PageToken: "0", PageSize: 1},
+				PaginationOptions: &corev1.PaginationOptions{PageSize: 2},
 			},
 
 			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
 				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
 					plugin_test.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin1.plugin),
+					plugin_test.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin2.plugin),
 				},
 				Categories:    []string{"cat-1"},
-				NextPageToken: "1",
+				NextPageToken: `{"mock1":1,"mock2":1}`,
 			},
 			statusCode: codes.OK,
 		},
 		{
-			name: "it should successfully call and paginate (proper PageSize) the core GetAvailablePackageSummaries operation",
-			configuredPlugins: []pkgPluginsWithServer{
+			name: "it should successfully call and paginate with proper PageSize the core GetAvailablePackageSummaries operation",
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -154,7 +155,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
-				PaginationOptions: &corev1.PaginationOptions{PageToken: "0", PageSize: 4},
+				PaginationOptions: &corev1.PaginationOptions{PageToken: "", PageSize: 3},
 			},
 
 			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
@@ -162,16 +163,15 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					plugin_test.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin1.plugin),
 					plugin_test.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin2.plugin),
 					plugin_test.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin1.plugin),
-					plugin_test.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin2.plugin),
 				},
 				Categories:    []string{"cat-1"},
-				NextPageToken: "1",
+				NextPageToken: `{"mock1":2,"mock2":1}`,
 			},
 			statusCode: codes.OK,
 		},
 		{
-			name: "it should successfully call and paginate (last page - 1) the core GetAvailablePackageSummaries operation",
-			configuredPlugins: []pkgPluginsWithServer{
+			name: "it should successfully call and paginate last page of the core GetAvailablePackageSummaries operation exhausting the results",
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -180,21 +180,20 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
-				PaginationOptions: &corev1.PaginationOptions{PageToken: "3", PageSize: 1},
+				PaginationOptions: &corev1.PaginationOptions{PageToken: `{"mock1":2,"mock2":1}`, PageSize: 2},
 			},
-
 			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
 				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
 					plugin_test.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin2.plugin),
 				},
 				Categories:    []string{"cat-1"},
-				NextPageToken: "4",
+				NextPageToken: "",
 			},
 			statusCode: codes.OK,
 		},
 		{
-			name: "it should successfully call and paginate (last page) the core GetAvailablePackageSummaries operation",
-			configuredPlugins: []pkgPluginsWithServer{
+			name: "it should successfully call and paginate the last page of the core GetAvailablePackageSummaries operation without exhausting the results",
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -203,21 +202,20 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
-				PaginationOptions: &corev1.PaginationOptions{PageToken: "3", PageSize: 1},
+				PaginationOptions: &corev1.PaginationOptions{PageToken: `{"mock1":2,"mock2":1}`, PageSize: 1},
 			},
-
 			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
 				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
 					plugin_test.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin2.plugin),
 				},
 				Categories:    []string{"cat-1"},
-				NextPageToken: "4",
+				NextPageToken: `{"mock1":-1,"mock2":2}`,
 			},
 			statusCode: codes.OK,
 		},
 		{
-			name: "it should successfully call and paginate (last page + 1) the core GetAvailablePackageSummaries operation",
-			configuredPlugins: []pkgPluginsWithServer{
+			name: "it should successfully call and paginate beyond the last page of the core GetAvailablePackageSummaries operation when not exhausted",
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -226,19 +224,22 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
-				PaginationOptions: &corev1.PaginationOptions{PageToken: "4", PageSize: 1},
+				PaginationOptions: &corev1.PaginationOptions{
+					PageToken: `{"mock1":-1,"mock2":2}`,
+					PageSize:  1,
+				},
 			},
 
 			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
 				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{},
-				Categories:                []string{"cat-1"},
+				Categories:                []string{},
 				NextPageToken:             "",
 			},
 			statusCode: codes.OK,
 		},
 		{
-			name: "it should fail when calling the core GetAvailablePackageSummaries operation when the package is not present in a plugin",
-			configuredPlugins: []pkgPluginsWithServer{
+			name: "it should fail when calling the core GetAvailablePackageSummaries operation when the plugin returns a 404 for the api call",
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
@@ -254,28 +255,6 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 				Categories:                []string{""},
 			},
 			statusCode: codes.NotFound,
-		},
-		{
-			name: "it should defer to the plugin pagination and sorting for a single plugin",
-			configuredPlugins: []pkgPluginsWithServer{
-				mockedPackagingPlugin1,
-			},
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
-					Cluster:   "",
-					Namespace: globalPackagingNamespace,
-				},
-			},
-
-			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
-				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
-					plugin_test.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin1.plugin),
-					plugin_test.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin1.plugin),
-				},
-				Categories:    []string{"cat-1"},
-				NextPageToken: "1",
-			},
-			statusCode: codes.OK,
 		},
 	}
 
@@ -302,14 +281,14 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 func TestGetAvailablePackageDetail(t *testing.T) {
 	testCases := []struct {
 		name              string
-		configuredPlugins []pkgPluginsWithServer
+		configuredPlugins []pkgPluginWithServer
 		statusCode        codes.Code
 		request           *corev1.GetAvailablePackageDetailRequest
 		expectedResponse  *corev1.GetAvailablePackageDetailResponse
 	}{
 		{
 			name: "it should successfully call the core GetAvailablePackageDetail operation",
-			configuredPlugins: []pkgPluginsWithServer{
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -332,7 +311,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 		},
 		{
 			name: "it should fail when calling the core GetAvailablePackageDetail operation when the package is not present in a plugin",
-			configuredPlugins: []pkgPluginsWithServer{
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
@@ -376,14 +355,14 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 func TestGetInstalledPackageSummaries(t *testing.T) {
 	testCases := []struct {
 		name              string
-		configuredPlugins []pkgPluginsWithServer
+		configuredPlugins []pkgPluginWithServer
 		statusCode        codes.Code
 		request           *corev1.GetInstalledPackageSummariesRequest
 		expectedResponse  *corev1.GetInstalledPackageSummariesResponse
 	}{
 		{
 			name: "it should successfully call the core GetInstalledPackageSummaries operation",
-			configuredPlugins: []pkgPluginsWithServer{
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -406,7 +385,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it should fail when calling the core GetInstalledPackageSummaries operation when the package is not present in a plugin",
-			configuredPlugins: []pkgPluginsWithServer{
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
@@ -447,14 +426,14 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 func TestGetInstalledPackageDetail(t *testing.T) {
 	testCases := []struct {
 		name              string
-		configuredPlugins []pkgPluginsWithServer
+		configuredPlugins []pkgPluginWithServer
 		statusCode        codes.Code
 		request           *corev1.GetInstalledPackageDetailRequest
 		expectedResponse  *corev1.GetInstalledPackageDetailResponse
 	}{
 		{
 			name: "it should successfully call the core GetInstalledPackageDetail operation",
-			configuredPlugins: []pkgPluginsWithServer{
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -476,7 +455,7 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 		},
 		{
 			name: "it should fail when calling the core GetInstalledPackageDetail operation when the package is not present in a plugin",
-			configuredPlugins: []pkgPluginsWithServer{
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
@@ -519,14 +498,14 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 func TestGetAvailablePackageVersions(t *testing.T) {
 	testCases := []struct {
 		name              string
-		configuredPlugins []pkgPluginsWithServer
+		configuredPlugins []pkgPluginWithServer
 		statusCode        codes.Code
 		request           *corev1.GetAvailablePackageVersionsRequest
 		expectedResponse  *corev1.GetAvailablePackageVersionsResponse
 	}{
 		{
 			name: "it should successfully call the core GetAvailablePackageVersions operation",
-			configuredPlugins: []pkgPluginsWithServer{
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -551,7 +530,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 		},
 		{
 			name: "it should fail when calling the core GetAvailablePackageVersions operation when the package is not present in a plugin",
-			configuredPlugins: []pkgPluginsWithServer{
+			configuredPlugins: []pkgPluginWithServer{
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
@@ -661,9 +640,9 @@ func TestCreateInstalledPackage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			configuredPluginServers := []pkgPluginsWithServer{}
+			configuredPluginServers := []pkgPluginWithServer{}
 			for _, p := range tc.configuredPlugins {
-				configuredPluginServers = append(configuredPluginServers, pkgPluginsWithServer{
+				configuredPluginServers = append(configuredPluginServers, pkgPluginWithServer{
 					plugin: p,
 					server: plugin_test.TestPackagingPluginServer{Plugin: p},
 				})
@@ -742,9 +721,9 @@ func TestUpdateInstalledPackage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			configuredPluginServers := []pkgPluginsWithServer{}
+			configuredPluginServers := []pkgPluginWithServer{}
 			for _, p := range tc.configuredPlugins {
-				configuredPluginServers = append(configuredPluginServers, pkgPluginsWithServer{
+				configuredPluginServers = append(configuredPluginServers, pkgPluginWithServer{
 					plugin: p,
 					server: plugin_test.TestPackagingPluginServer{Plugin: p},
 				})
@@ -815,9 +794,9 @@ func TestDeleteInstalledPackage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			configuredPluginServers := []pkgPluginsWithServer{}
+			configuredPluginServers := []pkgPluginWithServer{}
 			for _, p := range tc.configuredPlugins {
-				configuredPluginServers = append(configuredPluginServers, pkgPluginsWithServer{
+				configuredPluginServers = append(configuredPluginServers, pkgPluginWithServer{
 					plugin: p,
 					server: plugin_test.TestPackagingPluginServer{Plugin: p},
 				})
@@ -900,7 +879,7 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			server := &packagesServer{
-				pluginsWithServers: []pkgPluginsWithServer{
+				pluginsWithServers: []pkgPluginWithServer{
 					{
 						plugin: installedPlugin,
 						server: &plugin_test.TestPackagingPluginServer{

--- a/cmd/kubeapps-apis/plugin_test/mock_plugin.go
+++ b/cmd/kubeapps-apis/plugin_test/mock_plugin.go
@@ -5,9 +5,11 @@ package plugin_test
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	plugins "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/paginate"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -37,10 +39,21 @@ func (s TestPackagingPluginServer) GetAvailablePackageSummaries(ctx context.Cont
 	if s.Status != codes.OK {
 		return nil, status.Errorf(s.Status, "Non-OK response")
 	}
+	itemOffset, err := paginate.ItemOffsetFromPageToken(request.PaginationOptions.GetPageToken())
+	if err != nil {
+		return nil, err
+	}
+	summaries := s.AvailablePackageSummaries[itemOffset:]
+	pageSize := int(request.PaginationOptions.GetPageSize())
+	nextPageToken := ""
+	if pageSize > 0 && pageSize < len(summaries) {
+		summaries = summaries[:pageSize]
+		nextPageToken = fmt.Sprintf("%d", itemOffset+pageSize)
+	}
 	return &corev1.GetAvailablePackageSummariesResponse{
-		AvailablePackageSummaries: s.AvailablePackageSummaries,
+		AvailablePackageSummaries: summaries,
 		Categories:                s.Categories,
-		NextPageToken:             s.NextPageToken,
+		NextPageToken:             nextPageToken,
 	}, nil
 }
 

--- a/cmd/kubeapps-apis/plugins/pkg/paginate/paginate.go
+++ b/cmd/kubeapps-apis/plugins/pkg/paginate/paginate.go
@@ -21,7 +21,7 @@ func PageOffsetFromPageToken(pageToken string) (int, error) {
 	if pageToken == "" {
 		return 0, nil
 	}
-	offset, err := strconv.ParseUint(pageToken, 10, 0)
+	offset, err := strconv.ParseInt(pageToken, 10, 0)
 	if err != nil {
 		return 0, status.Errorf(codes.InvalidArgument, "unable to interpret page token %q: %v",
 			pageToken, err)


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Updates the core plugin's GetAvailablePackageSummaries so that it outputs ordered results from multiple configured plugins.

It does this by deferring to a new helper function `fanInAvailablePackageSummaries()`. See inline comments for details.

Example of paginated responses coming back with combined, ordered results of Helm and Carvel packages:

![combined-pagination](https://user-images.githubusercontent.com/497518/167988509-278e0b61-068a-4983-b0d7-361e163914a8.png)

### Benefits

We can paginate aggregated results on the core packages `GetAvailablePackageSummaries` end point. 

### Possible drawbacks

<!-- Describe any known limitations with your change -->
Currently two issues I need to fix:

1. ~~Currently, it returns the combined results correctly for the first 70 results (helm + carvel), until, it seems, when it hits a streak where the whole page is from one plugin only, it then does not include the other plugins offset in the result, so that plugin begins again~~ (fixed)

2. When navigating away from the catalog, we're not resetting the next page token in the state so when returning, it fetches initially from the previous offsets, but then the dashboard also resets the state, and so there are multiple responses coming back, confusing the count.

I'll fix 2 in a separate PR so this can be reviewed as is (but not yet landed).

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3399 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
