### PR TITLE
Don't reset catalog on first render.

### DIFF
--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -210,7 +210,18 @@ export default function Catalog() {
   }, [dispatch, cluster, namespace, featureFlags]);
 
   // detect changes in cluster/ns/repos/search and reset the current package list
+  // Note: useEffect is called on every render - the initial render and any
+  // re-renders due to updates. As a result, without maintaining some state
+  // of an initial render, every effect is always called when the component
+  // first renders. To avoid resetting the catalog every render, we ensure
+  // this reset effect is only run when the dependencies *change*, not during
+  // the initial render.
+  const initialRender = React.useRef(true);
   useEffect(() => {
+    if (initialRender.current) {
+      initialRender.current = false;
+      return;
+    }
     setPageNum(0);
     dispatch(actions.availablepackages.resetAvailablePackageSummaries());
     dispatch(actions.availablepackages.resetSelectedAvailablePackageDetail());

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -104,6 +104,29 @@ export default function Catalog() {
 
   const csvs = operators.csvs;
 
+  // Only one search filter can be set
+  const searchFilter = filters[filterNames.SEARCH]?.toString().replace(tmpStrRegex, ",") || "";
+  const reposFilter = filters[filterNames.REPO]?.join(",") || "";
+
+  // Detect changes in cluster/ns/repos/search and reset the current package
+  // list Note: useEffect is called on every render - the initial render and any
+  // re-renders due to updates. Additionally, any cleanup function returned by
+  // an effect is run prior to re-running the effect as well as on unmount.
+  // https://reactjs.org/docs/hooks-effect.html#example-using-hooks-1
+  // Therefore the reset effect below only has a cleanup function so that we a)
+  // don't reset when the component is initially rendered, and b) do reset
+  // whenever the effect is re-triggered or the component unmounted.
+  useEffect(() => {
+    // Ensure that when this component is unmounted, we remove any catalog state
+    // so that it is reloaded cleanly for the given inputs next time it is
+    // loaded.
+    return function cleanup() {
+      setPageNum(0);
+      dispatch(actions.availablepackages.resetAvailablePackageSummaries());
+      dispatch(actions.availablepackages.resetSelectedAvailablePackageDetail());
+    };
+  }, [dispatch, cluster, namespace, reposFilter, searchFilter]);
+
   useEffect(() => {
     const propsFilter = qs.parse(location.search, { ignoreQueryPrefix: true });
     const newFilters = {};
@@ -117,9 +140,6 @@ export default function Catalog() {
     });
   }, [location.search]);
 
-  // Only one search filter can be set
-  const searchFilter = filters[filterNames.SEARCH]?.toString().replace(tmpStrRegex, ",") || "";
-  const reposFilter = filters[filterNames.REPO]?.join(",") || "";
   useEffect(() => {
     if (hasFinishedFetching) {
       return;
@@ -208,24 +228,6 @@ export default function Catalog() {
       dispatch(actions.operators.getCSVs(cluster, namespace));
     }
   }, [dispatch, cluster, namespace, featureFlags]);
-
-  // detect changes in cluster/ns/repos/search and reset the current package list
-  // Note: useEffect is called on every render - the initial render and any
-  // re-renders due to updates. As a result, without maintaining some state
-  // of an initial render, every effect is always called when the component
-  // first renders. To avoid resetting the catalog every render, we ensure
-  // this reset effect is only run when the dependencies *change*, not during
-  // the initial render.
-  const initialRender = React.useRef(true);
-  useEffect(() => {
-    if (initialRender.current) {
-      initialRender.current = false;
-      return;
-    }
-    setPageNum(0);
-    dispatch(actions.availablepackages.resetAvailablePackageSummaries());
-    dispatch(actions.availablepackages.resetSelectedAvailablePackageDetail());
-  }, [dispatch, cluster, namespace, reposFilter, searchFilter]);
 
   const setSearchFilter = (searchTerm: string) => {
     const newFilters = {

--- a/dashboard/src/reducers/availablepackages.test.ts
+++ b/dashboard/src/reducers/availablepackages.test.ts
@@ -99,17 +99,46 @@ describe("packageReducer", () => {
     });
   });
 
-  it("single receiveAvailablePackageSummaries (first page) should be returned", () => {
-    const state = packageReducer(undefined, {
-      type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
-      payload: {
-        response: {
-          availablePackageSummaries: [availablePackageSummary1],
-          nextPageToken,
-          categories: ["foo"],
-        },
-      } as IReceivePackagesActionPayload,
+  it("ignores a receiveAvailablePackageSummaries when not fetching (ie. after a reset)", () => {
+    const state = packageReducer(
+      {
+        ...initialState,
+        isFetching: false,
+      },
+      {
+        type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
+        payload: {
+          response: {
+            availablePackageSummaries: [availablePackageSummary1],
+            nextPageToken,
+            categories: ["foo"],
+          },
+        } as IReceivePackagesActionPayload,
+      },
+    );
+    expect(state).toEqual({
+      ...initialState,
+      isFetching: false,
     });
+  });
+
+  it("single receiveAvailablePackageSummaries (first page) should be returned", () => {
+    const state = packageReducer(
+      {
+        ...initialState,
+        isFetching: true,
+      },
+      {
+        type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
+        payload: {
+          response: {
+            availablePackageSummaries: [availablePackageSummary1],
+            nextPageToken,
+            categories: ["foo"],
+          },
+        } as IReceivePackagesActionPayload,
+      },
+    );
     expect(state).toEqual({
       ...initialState,
       isFetching: false,
@@ -122,7 +151,10 @@ describe("packageReducer", () => {
 
   it("single receiveAvailablePackageSummaries (middle page) having visited the previous ones should be ignored", () => {
     const state = packageReducer(
-      { ...initialState },
+      {
+        ...initialState,
+        isFetching: true,
+      },
       {
         type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
         payload: {
@@ -146,7 +178,10 @@ describe("packageReducer", () => {
 
   it("single receiveAvailablePackageSummaries (middle page) not visiting the previous ones should be ignored", () => {
     const state = packageReducer(
-      { ...initialState },
+      {
+        ...initialState,
+        isFetching: true,
+      },
       {
         type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
         payload: {
@@ -172,6 +207,7 @@ describe("packageReducer", () => {
     const state = packageReducer(
       {
         ...initialState,
+        isFetching: true,
       },
       {
         type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
@@ -194,26 +230,38 @@ describe("packageReducer", () => {
   });
 
   it("two receiveAvailablePackageSummaries should add items (no dups)", () => {
-    const state1 = packageReducer(undefined, {
-      type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
-      payload: {
-        response: {
-          availablePackageSummaries: [availablePackageSummary1],
-          nextPageToken,
-          categories: ["foo"],
-        },
-      } as IReceivePackagesActionPayload,
-    });
-    const state2 = packageReducer(state1, {
-      type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
-      payload: {
-        response: {
-          availablePackageSummaries: [availablePackageSummary2],
-          nextPageToken: "",
-          categories: ["foo"],
-        },
-      } as IReceivePackagesActionPayload,
-    });
+    const state1 = packageReducer(
+      {
+        ...initialState,
+        isFetching: true,
+      },
+      {
+        type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
+        payload: {
+          response: {
+            availablePackageSummaries: [availablePackageSummary1],
+            nextPageToken,
+            categories: ["foo"],
+          },
+        } as IReceivePackagesActionPayload,
+      },
+    );
+    const state2 = packageReducer(
+      {
+        ...state1,
+        isFetching: true,
+      },
+      {
+        type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
+        payload: {
+          response: {
+            availablePackageSummaries: [availablePackageSummary2],
+            nextPageToken: "",
+            categories: ["foo"],
+          },
+        } as IReceivePackagesActionPayload,
+      },
+    );
     expect(state2).toEqual({
       ...initialState,
       isFetching: false,
@@ -316,17 +364,23 @@ describe("packageReducer", () => {
   // TODO(agamez): check whether or not we really want to filter out duplicates. If so, add some deleted tests back
 
   it("two receiveAvailablePackageSummaries and then createErrorPackage", () => {
-    const state1 = packageReducer(undefined, {
-      type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
-      payload: {
-        response: {
-          availablePackageSummaries: [availablePackageSummary1],
-          nextPageToken,
-          categories: ["foo"],
-        },
-        paginationToken: currentPageToken,
-      } as IReceivePackagesActionPayload,
-    });
+    const state1 = packageReducer(
+      {
+        ...initialState,
+        isFetching: true,
+      },
+      {
+        type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
+        payload: {
+          response: {
+            availablePackageSummaries: [availablePackageSummary1],
+            nextPageToken,
+            categories: ["foo"],
+          },
+          paginationToken: currentPageToken,
+        } as IReceivePackagesActionPayload,
+      },
+    );
     const state2 = packageReducer(state1, {
       type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
       payload: {
@@ -351,16 +405,22 @@ describe("packageReducer", () => {
   });
 
   it("clears errors after clearErrorPackage", () => {
-    const state1 = packageReducer(undefined, {
-      type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
-      payload: {
-        response: {
-          availablePackageSummaries: [availablePackageSummary1],
-          nextPageToken,
-          categories: ["foo"],
-        },
-      } as IReceivePackagesActionPayload,
-    });
+    const state1 = packageReducer(
+      {
+        ...initialState,
+        isFetching: true,
+      },
+      {
+        type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
+        payload: {
+          response: {
+            availablePackageSummaries: [availablePackageSummary1],
+            nextPageToken,
+            categories: ["foo"],
+          },
+        } as IReceivePackagesActionPayload,
+      },
+    );
     const state2 = packageReducer(state1, {
       type: getType(actions.availablepackages.createErrorPackage) as any,
     });

--- a/dashboard/src/reducers/availablepackages.ts
+++ b/dashboard/src/reducers/availablepackages.ts
@@ -68,6 +68,12 @@ const packageReducer = (
     case getType(actions.availablepackages.requestSelectedAvailablePackageVersions):
       return { ...state, isFetching: true };
     case getType(actions.availablepackages.receiveAvailablePackageSummaries): {
+      // If there has been a call to reset the state since the request was
+      // issued, we ignore the received available package summaries until
+      // a new request is issued.
+      if (!state.isFetching) {
+        return state;
+      }
       // Note that the same condition identifies *before* we've fetched
       // the first page and *after* we've fetched the last page. In both
       // cases, the nextPageToken is empty. Since we have just fetched a
@@ -107,6 +113,7 @@ const packageReducer = (
       return {
         ...state,
         hasFinishedFetching: false,
+        isFetching: false,
         items: [],
         nextPageToken: "",
       };


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This change is to fix an issue that I've identified as part of #4694, where we have a tension between global redux state and local state.

The issue is that:
- We currently use global redux state, so if you navigate to the catalog and then navigate away, the state of the catalog is retained (items, last token etc.)
- When you navigate back to the catalog, an initial request goes off to fetch the available package summaries, followed by another effect to reset the state

Two possible approaches:

1. Update the reset effect so that it is only run when a dependency changes (not on the initial render) - this is what's done here, but it means we'd also need to reset the state separately when the namespace is changed outside of the component (may be ok). The downside is that it moves us toward global state, where as I think we want to move away from it.
2. Ensure that the state is reset when the component is unmounted. This would be more inline with moving towards non-global state, but doesn't quite work either OOTB, because requests are in flight, so it resets the state as you move away from the component, but then a response comes back from the API and is handled updating the redux state *after* the reset. So to avoid this, I'd update the reducer so that it doesn't update the state if `isFetching` is false (makes sense).

So I'm leaning towards (2). ~~WDYT?~~ I've updated the PR to do 2. It now resets the state when the component is unmounted and does not update the state when subsequent available package summary responses are received (without being requested, ie. after a reset).

Tested with #4694 and it works perfectly, with paginated results never getting confused.

### Benefits

<!-- What benefits will be realized by the code change? -->

Ensures that (a) we don't send off requests for available package summaries with differing (pagination) state, and (b) we are one step closer to converting the component away from global redux state.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3399 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
