### PR TITLE
Updates core installed pkg summary handler for pagination.

### DIFF
--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages_fan_in.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages_fan_in.go
@@ -13,9 +13,27 @@ import (
 
 const CompleteToken = -1
 
-// summaryWithOffsets is the channel type for the results of the combined
+func getPluginPageOffsets(po *packages.PaginationOptions, numPlugins int) (map[string]int, int, error) {
+	corePageSize := int(po.GetPageSize())
+	// We'll request a bit more than pageSize / n from each plugin. If the page
+	// size is 10 and we have 3 plugins, request 5 items from each to start.
+	pluginPageSize := corePageSize
+	if numPlugins > 1 {
+		pluginPageSize = pluginPageSize / (numPlugins - 1)
+	}
+	pluginPageOffsets := map[string]int{}
+	if po.GetPageToken() != "" {
+		err := json.Unmarshal([]byte(po.GetPageToken()), &pluginPageOffsets)
+		if err != nil {
+			return nil, 0, fmt.Errorf("unable to unmarshal %q: %w", po.GetPageToken(), err)
+		}
+	}
+	return pluginPageOffsets, pluginPageSize, nil
+}
+
+// availableSummaryWithOffsets is the channel type for the results of the combined
 // core results after fanning in from the plugins.
-type summaryWithOffsets struct {
+type availableSummaryWithOffsets struct {
 	availablePackageSummary *packages.AvailablePackageSummary
 	categories              []string
 	nextItemOffsets         map[string]int
@@ -37,26 +55,15 @@ type summaryWithOffsets struct {
 // pagination of individual plugins, it will be possible that this returns
 // duplicates or missing data if data is added or removed between paginated
 // requests.
-func fanInAvailablePackageSummaries(ctx context.Context, pkgPlugins []pkgPluginWithServer, request *packages.GetAvailablePackageSummariesRequest) (<-chan summaryWithOffsets, error) {
-	summariesCh := make(chan summaryWithOffsets)
+func fanInAvailablePackageSummaries(ctx context.Context, pkgPlugins []pkgPluginWithServer, request *packages.GetAvailablePackageSummariesRequest) (<-chan availableSummaryWithOffsets, error) {
+	summariesCh := make(chan availableSummaryWithOffsets)
 
-	corePageSize := int(request.GetPaginationOptions().GetPageSize())
-	// We'll request a bit more than pageSize / n from each plugin. If the page
-	// size is 10 and we have 3 plugins, request 5 items from each to start.
-	pluginPageSize := corePageSize
-	if len(pkgPlugins) > 1 {
-		pluginPageSize = pluginPageSize / (len(pkgPlugins) - 1)
+	pluginPageOffsets, pluginPageSize, err := getPluginPageOffsets(request.GetPaginationOptions(), len(pkgPlugins))
+	if err != nil {
+		return nil, err
 	}
 
-	pluginPageOffsets := map[string]int{}
-	if request.GetPaginationOptions().GetPageToken() != "" {
-		err := json.Unmarshal([]byte(request.GetPaginationOptions().GetPageToken()), &pluginPageOffsets)
-		if err != nil {
-			return nil, fmt.Errorf("unable to unmarshal %q: %w", request.GetPaginationOptions().GetPageToken(), err)
-		}
-	}
-
-	fanInput := []<-chan *summaryWithOffset{}
+	fanInput := []<-chan *availableSummaryWithOffset{}
 	for _, pluginWithSrv := range pkgPlugins {
 		// Importantly, each plugin needs its own request, with its own pagination
 		// options.
@@ -81,7 +88,7 @@ func fanInAvailablePackageSummaries(ctx context.Context, pkgPlugins []pkgPluginW
 	// channel.
 	go func() {
 		numSent := 0
-		nextItems := make([]*summaryWithOffset, len(fanInput))
+		nextItems := make([]*availableSummaryWithOffset, len(fanInput))
 		for {
 			// Populate the empty next items from each channel.
 			for i, ch := range fanInput {
@@ -98,7 +105,7 @@ func fanInAvailablePackageSummaries(ctx context.Context, pkgPlugins []pkgPluginW
 					}
 
 					if nextItems[i] != nil && nextItems[i].err != nil {
-						summariesCh <- summaryWithOffsets{
+						summariesCh <- availableSummaryWithOffsets{
 							err: nextItems[i].err,
 						}
 						close(summariesCh)
@@ -125,13 +132,13 @@ func fanInAvailablePackageSummaries(ctx context.Context, pkgPlugins []pkgPluginW
 
 			// Otherwise, we find the minimum item of the next items from each channel.
 			for i, s := range nextItems {
-				if s != nil && s.availablePackageSummary.Name < nextItems[minIndex].availablePackageSummary.Name {
+				if s != nil && s.availablePackageSummary.GetName() < nextItems[minIndex].availablePackageSummary.GetName() {
 					minIndex = i
 				}
 			}
 			pluginName := nextItems[minIndex].availablePackageSummary.GetAvailablePackageRef().GetPlugin().GetName()
 			pluginPageOffsets[pluginName] = nextItems[minIndex].nextItemOffset
-			summariesCh <- summaryWithOffsets{
+			summariesCh <- availableSummaryWithOffsets{
 				availablePackageSummary: nextItems[minIndex].availablePackageSummary,
 				categories:              nextItems[minIndex].categories,
 				nextItemOffsets:         pluginPageOffsets,
@@ -140,7 +147,7 @@ func fanInAvailablePackageSummaries(ctx context.Context, pkgPlugins []pkgPluginW
 			nextItems[minIndex] = nil
 
 			numSent += 1
-			if numSent == corePageSize {
+			if numSent == int(request.GetPaginationOptions().GetPageSize()) {
 				close(summariesCh)
 				return
 			}
@@ -150,9 +157,9 @@ func fanInAvailablePackageSummaries(ctx context.Context, pkgPlugins []pkgPluginW
 	return summariesCh, nil
 }
 
-// summaryWithOffset is the channel type for the single result from a
+// availableSummaryWithOffset is the channel type for the single result from a
 // single plugin.
-type summaryWithOffset struct {
+type availableSummaryWithOffset struct {
 	availablePackageSummary *packages.AvailablePackageSummary
 	categories              []string
 	nextItemOffset          int
@@ -161,8 +168,8 @@ type summaryWithOffset struct {
 
 // sendAvailablePackageSummariesForPlugin returns a channel and sends the
 // available package summaries returned by the plugin for the given request.
-func sendAvailablePackageSummariesForPlugin(ctx context.Context, pkgPlugin pkgPluginWithServer, request *packages.GetAvailablePackageSummariesRequest) (<-chan *summaryWithOffset, error) {
-	summaryCh := make(chan *summaryWithOffset)
+func sendAvailablePackageSummariesForPlugin(ctx context.Context, pkgPlugin pkgPluginWithServer, request *packages.GetAvailablePackageSummariesRequest) (<-chan *availableSummaryWithOffset, error) {
+	summaryCh := make(chan *availableSummaryWithOffset)
 
 	itemOffset, err := paginate.ItemOffsetFromPageToken(request.GetPaginationOptions().GetPageToken())
 	if err != nil {
@@ -183,14 +190,14 @@ func sendAvailablePackageSummariesForPlugin(ctx context.Context, pkgPlugin pkgPl
 		for {
 			response, err := pkgPlugin.server.GetAvailablePackageSummaries(ctx, request)
 			if err != nil {
-				summaryCh <- &summaryWithOffset{err: err}
+				summaryCh <- &availableSummaryWithOffset{err: err}
 				close(summaryCh)
 				return
 			}
 			categories := response.Categories
 			for _, summary := range response.AvailablePackageSummaries {
 				itemOffset = itemOffset + 1
-				summaryCh <- &summaryWithOffset{
+				summaryCh <- &availableSummaryWithOffset{
 					availablePackageSummary: summary,
 					categories:              categories,
 					nextItemOffset:          itemOffset,
@@ -205,7 +212,195 @@ func sendAvailablePackageSummariesForPlugin(ctx context.Context, pkgPlugin pkgPl
 			// We can sanity check here to be sure the next page token
 			// corresponds to the current value of itemOffset.
 			if fmt.Sprintf("%d", itemOffset) != response.GetNextPageToken() {
-				summaryCh <- &summaryWithOffset{
+				summaryCh <- &availableSummaryWithOffset{
+					err: fmt.Errorf("inconsistent item offset: got: %q, expected: %d", response.GetNextPageToken(), itemOffset),
+				}
+			}
+			request.PaginationOptions.PageToken = response.GetNextPageToken()
+		}
+	}()
+
+	return summaryCh, nil
+}
+
+// TODO(minelson): See if we can reduce the duplication of functionality
+// here for available vs installed package summaries using generics and/or
+// interfaces.
+
+// installedSummaryWithOffsets is the channel type for the results of the combined
+// core results after fanning in from the plugins.
+type installedSummaryWithOffsets struct {
+	installedPackageSummary *packages.InstalledPackageSummary
+	nextItemOffsets         map[string]int
+	err                     error
+}
+
+// fanInInstalledPackageSummaries fans in the results from the separate plugins
+// to the return channel.
+//
+// Each plugin handles the request in a separate go-routine while this function
+// uses the fan-in pattern to merge those results, sending the next result back
+// down the return channel until the request is satisfied. Importantly, each
+// result is accompanied by the current next item offsets for each plugin so
+// that the caller can generate a next page token that is able to encode the
+// offsets for each plugin. The next request the begins each plugin where it
+// left off for the last.
+//
+// Plugins generally do not use snapshots of the actual data, so, similar to the
+// pagination of individual plugins, it will be possible that this returns
+// duplicates or missing data if data is added or removed between paginated
+// requests.
+func fanInInstalledPackageSummaries(ctx context.Context, pkgPlugins []pkgPluginWithServer, request *packages.GetInstalledPackageSummariesRequest) (<-chan installedSummaryWithOffsets, error) {
+	summariesCh := make(chan installedSummaryWithOffsets)
+
+	pluginPageOffsets, pluginPageSize, err := getPluginPageOffsets(request.GetPaginationOptions(), len(pkgPlugins))
+	if err != nil {
+		return nil, err
+	}
+
+	fanInput := []<-chan *installedSummaryWithOffset{}
+	for _, pluginWithSrv := range pkgPlugins {
+		// Importantly, each plugin needs its own request, with its own pagination
+		// options.
+		r := &packages.GetInstalledPackageSummariesRequest{
+			Context: request.Context,
+			PaginationOptions: &packages.PaginationOptions{
+				PageSize:  int32(pluginPageSize),
+				PageToken: fmt.Sprintf("%d", pluginPageOffsets[pluginWithSrv.plugin.Name]),
+			},
+		}
+
+		ch, err := sendInstalledPackageSummariesForPlugin(ctx, pluginWithSrv, r)
+		if err != nil {
+			return nil, err
+		}
+		fanInput = append(fanInput, ch)
+	}
+
+	// We now have a slice of channels for the fan-in and want a go routine that
+	// will ensure it sends the next (ordered) item from all channels down the
+	// channel.
+	go func() {
+		numSent := 0
+		nextItems := make([]*installedSummaryWithOffset, len(fanInput))
+		for {
+			// Populate the empty next items from each channel.
+			for i, ch := range fanInput {
+				if nextItems[i] == nil {
+					// If the channel is closed, the value will remain nil.
+					ok := true
+					nextItems[i], ok = <-ch
+					if !ok {
+						// If the channel was closed, we reached the last item for that
+						// plugin. We need to recognise when all plugins have exhausted
+						// itemsoffsets
+						pluginName := pkgPlugins[i].plugin.Name
+						pluginPageOffsets[pluginName] = CompleteToken
+					}
+
+					if nextItems[i] != nil && nextItems[i].err != nil {
+						summariesCh <- installedSummaryWithOffsets{
+							err: nextItems[i].err,
+						}
+						close(summariesCh)
+						return
+					}
+				}
+			}
+
+			// Choose the minimum by name and send it down the line.
+			// First find the first non-nil value as the min.
+			minIndex := -1
+			for i, s := range nextItems {
+				if s != nil {
+					minIndex = i
+					break
+				}
+			}
+
+			// If there is no non-nil value left, we're done.
+			if minIndex == -1 {
+				close(summariesCh)
+				return
+			}
+
+			// Otherwise, we find the minimum item of the next items from each channel.
+			for i, s := range nextItems {
+				if s != nil && s.installedPackageSummary.GetName() < nextItems[minIndex].installedPackageSummary.GetName() {
+					minIndex = i
+				}
+			}
+			pluginName := nextItems[minIndex].installedPackageSummary.GetInstalledPackageRef().GetPlugin().GetName()
+			pluginPageOffsets[pluginName] = nextItems[minIndex].nextItemOffset
+			summariesCh <- installedSummaryWithOffsets{
+				installedPackageSummary: nextItems[minIndex].installedPackageSummary,
+				nextItemOffsets:         pluginPageOffsets,
+			}
+			// Ensure the item will get replaced on the next round.
+			nextItems[minIndex] = nil
+
+			numSent += 1
+			if numSent == int(request.GetPaginationOptions().GetPageSize()) {
+				close(summariesCh)
+				return
+			}
+		}
+	}()
+
+	return summariesCh, nil
+}
+
+// installedSummaryWithOffset is the channel type for the single result from a
+// single plugin.
+type installedSummaryWithOffset struct {
+	installedPackageSummary *packages.InstalledPackageSummary
+	nextItemOffset          int
+	err                     error
+}
+
+// sendInstalledPackageSummariesForPlugin returns a channel and sends the
+// available package summaries returned by the plugin for the given request.
+func sendInstalledPackageSummariesForPlugin(ctx context.Context, pkgPlugin pkgPluginWithServer, request *packages.GetInstalledPackageSummariesRequest) (<-chan *installedSummaryWithOffset, error) {
+	summaryCh := make(chan *installedSummaryWithOffset)
+
+	itemOffset, err := paginate.ItemOffsetFromPageToken(request.GetPaginationOptions().GetPageToken())
+	if err != nil {
+		return nil, err
+	}
+
+	if itemOffset == -1 {
+		// This plugin was already exhausted during the last request. Nothing to do here.
+		close(summaryCh)
+		return summaryCh, nil
+	}
+
+	// Start a go func that requests the next page of summaries and sends them down the
+	// channel. Since the channel is blocking, further requests won't be issued until the
+	// previous response is drained. We could use a small buffer to request ahead as an
+	// improvement.
+	go func() {
+		for {
+			response, err := pkgPlugin.server.GetInstalledPackageSummaries(ctx, request)
+			if err != nil {
+				summaryCh <- &installedSummaryWithOffset{err: err}
+				close(summaryCh)
+				return
+			}
+			for _, summary := range response.InstalledPackageSummaries {
+				itemOffset = itemOffset + 1
+				summaryCh <- &installedSummaryWithOffset{
+					installedPackageSummary: summary,
+					nextItemOffset:          itemOffset,
+				}
+			}
+			if response.GetNextPageToken() == "" {
+				close(summaryCh)
+				return
+			}
+			// We can sanity check here to be sure the next page token
+			// corresponds to the current value of itemOffset.
+			if fmt.Sprintf("%d", itemOffset) != response.GetNextPageToken() {
+				summaryCh <- &installedSummaryWithOffset{
 					err: fmt.Errorf("inconsistent item offset: got: %q, expected: %d", response.GetNextPageToken(), itemOffset),
 				}
 			}

--- a/dashboard/src/shared/InstalledPackage.ts
+++ b/dashboard/src/shared/InstalledPackage.ts
@@ -26,12 +26,12 @@ export class InstalledPackage {
   public static async GetInstalledPackageSummaries(
     cluster: string,
     namespace?: string,
-    page?: number,
+    pageToken?: string,
     size?: number,
   ) {
     return await this.coreClient().GetInstalledPackageSummaries({
       context: { cluster: cluster, namespace: namespace },
-      paginationOptions: { pageSize: size || 0, pageToken: page?.toString() || "0" },
+      paginationOptions: { pageSize: size || 0, pageToken: pageToken || "" },
     });
   }
 


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Follows on from #4694 , applying the same functionality to the core `GetInstalledPackageSummaries` handler.

~~It does not yet work, because the dashboard client is currently assuming knowledge of the pagination token, so I need to do a separate PR for the dashboard to remove that assumption for `GetInstalledPackageSummaries`, as I did earlier for the available packages in the dashboard (hence being a draft).~~ EDIT: it ended up only requiring a 2-line change to the dashboard so I've just included it in this PR.

Works to display correlated installed package summaries:
![installed-apps](https://user-images.githubusercontent.com/497518/168940221-d2e4c388-cdb5-4d8f-a979-a2183eab210a.png)


### Benefits

<!-- What benefits will be realized by the code change? -->

Core pagination for multiple plugins will display installed packages in order efficiently.


### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3399 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

I did play a little with generics at first but couldn't yet see a useful way to re-use the functionality due to (a) small differences between the responses - available package summaries including categories, for example, and (b) the inability to define a shared interface because go doesn't let you add functions to a struct from another package (and I'm not sure whether we want to add them to the generated packages). Either way, I've left a TODO for us to do this in the future if we want.