### PR TITLE
Fix logo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="../img/logo.png" width="40" align="left"> Kubeapps
+# <img src="site/content/docs/latest/img/logo.png" width="40" align="left"> Kubeapps
 
 [![CircleCI](https://circleci.com/gh/vmware-tanzu/kubeapps/tree/main.svg?style=svg)](https://circleci.com/gh/vmware-tanzu/kubeapps/tree/main)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/7e0e2833-1d75-43f6-b006-632d359bb83b/deploy-status)](https://app.netlify.com/sites/kubeapps-dev/deploys)


### PR DESCRIPTION
### Description of the change

Quick PR to fix the URL of Kubeapps logo in the `README.md` file.

Currently it is looking like this:

<img width="439" alt="imagen" src="https://user-images.githubusercontent.com/67455978/168806742-7d9c5a5b-b709-4805-9247-5934f36bcec7.png">

