### PR TITLE
Ensure Helm plugin includes plugin detail in installed ref.

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -498,6 +498,7 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 	for i, r := range releases {
 		installedPkgSummaries[i] = installedPkgSummaryFromRelease(r)
 		installedPkgSummaries[i].InstalledPackageRef.Context.Cluster = cluster
+		installedPkgSummaries[i].InstalledPackageRef.Plugin = GetPluginDetail()
 	}
 
 	// Fill in the latest package version for each.

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -1320,6 +1320,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 								Namespace: "namespace-1",
 							},
 							Identifier: "my-release-1",
+							Plugin:     GetPluginDetail(),
 						},
 						Name:    "my-release-1",
 						IconUrl: "https://example.com/icon.png",
@@ -1347,6 +1348,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 								Namespace: "namespace-1",
 							},
 							Identifier: "my-release-3",
+							Plugin:     GetPluginDetail(),
 						},
 						Name:    "my-release-3",
 						IconUrl: "https://example.com/icon.png",
@@ -1408,6 +1410,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 								Namespace: "namespace-1",
 							},
 							Identifier: "my-release-1",
+							Plugin:     GetPluginDetail(),
 						},
 						Name:    "my-release-1",
 						IconUrl: "https://example.com/icon.png",
@@ -1435,6 +1438,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 								Namespace: "namespace-2",
 							},
 							Identifier: "my-release-2",
+							Plugin:     GetPluginDetail(),
 						},
 						Name:    "my-release-2",
 						IconUrl: "https://example.com/icon.png",
@@ -1462,6 +1466,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 								Namespace: "namespace-3",
 							},
 							Identifier: "my-release-3",
+							Plugin:     GetPluginDetail(),
 						},
 						Name:    "my-release-3",
 						IconUrl: "https://example.com/icon.png",
@@ -1526,6 +1531,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 								Namespace: "namespace-1",
 							},
 							Identifier: "my-release-1",
+							Plugin:     GetPluginDetail(),
 						},
 						Name:    "my-release-1",
 						IconUrl: "https://example.com/icon.png",
@@ -1553,6 +1559,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 								Namespace: "namespace-2",
 							},
 							Identifier: "my-release-2",
+							Plugin:     GetPluginDetail(),
 						},
 						Name:    "my-release-2",
 						IconUrl: "https://example.com/icon.png",
@@ -1619,6 +1626,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 								Namespace: "namespace-3",
 							},
 							Identifier: "my-release-3",
+							Plugin:     GetPluginDetail(),
 						},
 						Name:    "my-release-3",
 						IconUrl: "https://example.com/icon.png",
@@ -1667,6 +1675,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 								Namespace: "namespace-1",
 							},
 							Identifier: "my-release-1",
+							Plugin:     GetPluginDetail(),
 						},
 						Name:    "my-release-1",
 						IconUrl: "https://example.com/icon.png",
@@ -1714,7 +1723,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 				return
 			}
 
-			opts := cmpopts.IgnoreUnexported(corev1.GetInstalledPackageSummariesResponse{}, corev1.InstalledPackageSummary{}, corev1.InstalledPackageReference{}, corev1.Context{}, corev1.VersionReference{}, corev1.InstalledPackageStatus{}, corev1.PackageAppVersion{})
+			opts := cmpopts.IgnoreUnexported(corev1.GetInstalledPackageSummariesResponse{}, corev1.InstalledPackageSummary{}, corev1.InstalledPackageReference{}, corev1.Context{}, corev1.VersionReference{}, corev1.InstalledPackageStatus{}, corev1.PackageAppVersion{}, plugins.Plugin{})
 			if got, want := response, tc.expectedResponse; !cmp.Equal(want, got, opts) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, opts))
 			}


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Small prequel to #4719 which is failing CI with:

![test-failed-1](https://user-images.githubusercontent.com/497518/168949286-b6e2eec2-edaf-412f-9da3-a422e47f5299.png)

The reason is that, in that PR, when updating the `GetInstalledPackageSummaries` core handler, I did not replace the code which explicitly set the plugin detail for each result if it wasn't set by the plugin, because I thought surely the plugins do this.

Turns out the helm plugin wasn't while the flux and carvel plugins are. So made sense to update the Helm plugiin to be the consistent.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

CI will pass for #4719, core plugin doesn't need to add data and is simpler.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3399

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
