### PR TITLE
Add plugin name to the cards in the installed pkgs view

### DIFF
--- a/dashboard/src/components/AppList/AppListItem.test.tsx
+++ b/dashboard/src/components/AppList/AppListItem.test.tsx
@@ -57,6 +57,8 @@ it("renders an app item", () => {
     } as InstalledPackageReference),
     tag1Class: "label-success",
     tag1Content: "installed",
+    tag2Class: "label-info-secondary",
+    tag2Content: "my.plugin",
     title: defaultProps.app.name,
   });
 });

--- a/dashboard/src/components/AppList/AppListItem.tsx
+++ b/dashboard/src/components/AppList/AppListItem.tsx
@@ -3,7 +3,7 @@
 
 import Tooltip from "components/js/Tooltip";
 import { InstalledPackageSummary } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
-import { getAppStatusLabel, getPluginIcon } from "shared/utils";
+import { getAppStatusLabel, getPluginIcon, getPluginName } from "shared/utils";
 import placeholder from "../../placeholder.png";
 import * as url from "../../shared/url";
 import InfoCard from "../InfoCard/InfoCard";
@@ -59,6 +59,8 @@ function AppListItem(props: IAppListItemProps) {
     <></>
   );
 
+  const pkgPluginName = getPluginName(app.installedPackageRef?.plugin);
+
   return app?.installedPackageRef ? (
     <InfoCard
       key={app.installedPackageRef?.identifier}
@@ -80,6 +82,8 @@ function AppListItem(props: IAppListItemProps) {
       description={app.shortDescription}
       tag1Content={appStatus}
       tag1Class={appReady ? "label-success" : "label-warning"}
+      tag2Content={pkgPluginName}
+      tag2Class={"label-info-secondary"}
       tooltip={tooltip}
       bgIcon={getPluginIcon(app.installedPackageRef?.plugin)}
     />


### PR DESCRIPTION
### Description of the change

Simple PR just adding the plugin name to the installed package summaries view as we were doing for the catalog view.

### Benefits

More consistent view with the catalog.

### Possible drawbacks

N/A

### Applicable issues

- fixes #4727

### Additional information

Perhaps worth adding a test case? I'll look into it tomorrow.

![image](https://user-images.githubusercontent.com/11535726/169169716-6fb55b7d-d0e9-4a52-bc0b-e242314fc27d.png)
