### PR TITLE
Truncate cronjobs' names

### DIFF
--- a/cmd/apprepository-controller/server/controller.go
+++ b/cmd/apprepository-controller/server/controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/adler32"
 	"strconv"
 	"strings"
 	"time"
@@ -37,6 +38,11 @@ import (
 )
 
 const controllerAgentName = "apprepository-controller"
+
+// Although a k8s typical length is 63, some characters are appended from the cronjob
+// to its spawned jobs therefore restricting this limit up to 52
+// https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
+const MAX_CRONJOB_CHARS = 52
 
 const (
 	// SuccessSynced is used as part of the Event 'reason' when an AppRepository
@@ -271,7 +277,7 @@ func (c *Controller) syncHandler(key string) error {
 
 			// TODO: Workaround until the sync jobs are moved to the repoNamespace (#1647)
 			// Delete the cronjob in the Kubeapps namespace to avoid re-syncing the repository
-			err = c.kubeclientset.BatchV1beta1().CronJobs(c.conf.KubeappsNamespace).Delete(context.TODO(), cronJobName(namespace, name), metav1.DeleteOptions{})
+			err = c.kubeclientset.BatchV1beta1().CronJobs(c.conf.KubeappsNamespace).Delete(context.TODO(), cronJobName(namespace, name, false), metav1.DeleteOptions{})
 			if err != nil && !errors.IsNotFound(err) {
 				log.Errorf("Unable to delete sync cronjob: %v", err)
 				return err
@@ -282,7 +288,7 @@ func (c *Controller) syncHandler(key string) error {
 	}
 
 	// Get the cronjob with the same name as AppRepository
-	cronjobName := cronJobName(namespace, name)
+	cronjobName := cronJobName(namespace, name, false)
 	cronjob, err := c.cronjobsLister.CronJobs(c.conf.KubeappsNamespace).Get(cronjobName)
 	// If the resource doesn't exist, we'll create it
 	if errors.IsNotFound(err) {
@@ -414,7 +420,7 @@ func ownerReferencesForAppRepo(apprepo *apprepov1alpha1.AppRepository, childName
 func newCronJob(apprepo *apprepov1alpha1.AppRepository, config Config) *batchv1beta1.CronJob {
 	return &batchv1beta1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            cronJobName(apprepo.Namespace, apprepo.Name),
+			Name:            cronJobName(apprepo.Namespace, apprepo.Name, false),
 			OwnerReferences: ownerReferencesForAppRepo(apprepo, config.KubeappsNamespace),
 			Labels:          jobLabels(apprepo, config),
 			Annotations:     config.ParsedCustomAnnotations,
@@ -437,7 +443,7 @@ func newCronJob(apprepo *apprepov1alpha1.AppRepository, config Config) *batchv1b
 func newSyncJob(apprepo *apprepov1alpha1.AppRepository, config Config) *batchv1.Job {
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName:    cronJobName(apprepo.Namespace, apprepo.Name) + "-",
+			GenerateName:    cronJobName(apprepo.Namespace, apprepo.Name, true),
 			OwnerReferences: ownerReferencesForAppRepo(apprepo, config.KubeappsNamespace),
 			Annotations:     config.ParsedCustomLabels,
 			Labels:          config.ParsedCustomAnnotations,
@@ -510,7 +516,7 @@ func syncJobSpec(apprepo *apprepov1alpha1.AppRepository, config Config) batchv1.
 func newCleanupJob(kubeappsNamespace, repoNamespace, name string, config Config) *batchv1.Job {
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: deleteJobName(repoNamespace, name) + "-",
+			GenerateName: deleteJobName(repoNamespace, name),
 			Namespace:    kubeappsNamespace,
 			Annotations:  config.ParsedCustomAnnotations,
 			Labels:       config.ParsedCustomLabels,
@@ -580,13 +586,49 @@ func ttlLifetimeJobs(config Config) *int32 {
 }
 
 // cronJobName returns a unique name for the CronJob managed by an AppRepository
-func cronJobName(namespace, name string) string {
-	return fmt.Sprintf("apprepo-%s-sync-%s", namespace, name)
+func cronJobName(namespace, name string, addDash bool) string {
+	// the "apprepo--sync-" string has 14 chars, which leaves us 52-14=38 chars for the final name
+	maxNamesapceLength, rem := (MAX_CRONJOB_CHARS-14)/2, (MAX_CRONJOB_CHARS-14)%2
+	maxNameLength := maxNamesapceLength
+	if rem > 0 && !addDash {
+		maxNameLength++
+	}
+	truncatedName := fmt.Sprintf("apprepo-%s-sync-%s", truncateAndHashString(namespace, maxNamesapceLength), truncateAndHashString(name, maxNameLength))
+	if addDash {
+		truncatedName = fmt.Sprintf("%s-", truncatedName)
+	}
+	return truncatedName
 }
 
 // deleteJobName returns a unique name for the Job to cleanup AppRepository
 func deleteJobName(namespace, name string) string {
-	return fmt.Sprintf("apprepo-%s-cleanup-%s", namespace, name)
+	// the "apprepo--cleanup--" string has 18 chars, which leaves us 52-18=34 chars for the final name
+	maxNamesapceLength, rem := (MAX_CRONJOB_CHARS-18)/2, (MAX_CRONJOB_CHARS-18)%2
+	maxNameLength := maxNamesapceLength
+	if rem > 0 {
+		maxNameLength++
+	}
+
+	truncatedName := fmt.Sprintf("apprepo-%s-cleanup-%s-", truncateAndHashString(namespace, maxNamesapceLength), truncateAndHashString(name, maxNameLength))
+	return truncatedName
+}
+
+// truncateAndHashString truncates the string to a max length and hashes the rest of it
+// Ex: truncateAndHashString(aaaaaaaaaaaaaaaaaaaaaaaaaa,12) becomes "a-2067663226"
+func truncateAndHashString(name string, length int) string {
+	if len(name) > length {
+		if length < 11 {
+			return name[:length]
+		}
+		log.Warningf("Name %q exceedes %d characters (got %d)", name, length, len(name))
+		// max length chars, minus 10 chars (the adler32 hash returns up to 10 digits), minus 1 for the '-'
+		splitPoint := length - 11
+		part1 := name[:splitPoint]
+		part2 := name[splitPoint:]
+		hashedPart2 := fmt.Sprint(adler32.Checksum([]byte(part2)))
+		name = fmt.Sprintf("%s-%s", part1, hashedPart2)
+	}
+	return name
 }
 
 // apprepoSyncJobArgs returns a list of args for the sync container

--- a/cmd/apprepository-controller/server/controller_test.go
+++ b/cmd/apprepository-controller/server/controller_test.go
@@ -1745,49 +1745,49 @@ func TestCronJobName(t *testing.T) {
 	testCases := []struct {
 		name      string
 		namespace string
-		jonName   string
+		jobName   string
 		addDash   bool
 		expect    string
 	}{
 		{
 			name:      "short name",
 			namespace: "foo",
-			jonName:   "bar",
+			jobName:   "bar",
 			addDash:   false,
 			expect:    "apprepo-foo-sync-bar",
 		},
 		{
 			name:      "short name with dash",
 			namespace: "foo",
-			jonName:   "bar",
+			jobName:   "bar",
 			addDash:   true,
 			expect:    "apprepo-foo-sync-bar-",
 		},
 		{
 			name:      "max length name",
 			namespace: "foofoofoofoofoofoof",
-			jonName:   "barbarbarbarbarbarb",
+			jobName:   "barbarbarbarbarbarb",
 			addDash:   false,
 			expect:    "apprepo-foofoofoofoofoofoof-sync-barbarbarbarbarbarb",
 		},
 		{
 			name:      "max length name with dash",
 			namespace: "foofoofoofoofoofoof",
-			jonName:   "barbarbarbarbarbar",
+			jobName:   "barbarbarbarbarbar",
 			addDash:   true,
 			expect:    "apprepo-foofoofoofoofoofoof-sync-barbarbarbarbarbar-",
 		},
 		{
 			name:      "exceeding length name",
 			namespace: "foofoofoofoofoofoofoo",
-			jonName:   "barbarbarbarbarbarbar",
+			jobName:   "barbarbarbarbarbarbar",
 			addDash:   false,
 			expect:    "apprepo-foofoofo-645137792-sync-barbarba-620299591",
 		},
 		{
 			name:      "exceeding length name with dash",
 			namespace: "foofoofoofoofoofoofoofoo",
-			jonName:   "barbarbarbarbarbarbarbar",
+			jobName:   "barbarbarbarbarbarbarbar",
 			addDash:   true,
 			expect:    "apprepo-foofoofo-963839684-sync-barbarba-925369980-",
 		},
@@ -1795,7 +1795,7 @@ func TestCronJobName(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			res := cronJobName(tc.namespace, tc.jonName, tc.addDash)
+			res := cronJobName(tc.namespace, tc.jobName, tc.addDash)
 			if len(res) > MAX_CRONJOB_CHARS {
 				t.Errorf("expected length of truncated string to be <= %d, got %d", MAX_CRONJOB_CHARS, len(res))
 			}
@@ -1810,31 +1810,70 @@ func TestDeleteJobName(t *testing.T) {
 	testCases := []struct {
 		name      string
 		namespace string
-		jonName   string
+		jobName   string
 		expect    string
 	}{
 		{
 			name:      "short name",
 			namespace: "foo",
-			jonName:   "bar",
+			jobName:   "bar",
 			expect:    "apprepo-foo-cleanup-bar-",
 		},
 		{
 			name:      "max length name",
 			namespace: "foofoofoofoofoofo",
-			jonName:   "barbarbarbarbarba",
+			jobName:   "barbarbarbarbarba",
 			expect:    "apprepo-foofoofoofoofoofo-cleanup-barbarbarbarbarba-",
 		},
 		{
 			name:      "exceeding length name",
 			namespace: "foofoofoofoofoofoofoo",
-			jonName:   "barbarbarbarbarbarbar",
+			jobName:   "barbarbarbarbarbarbar",
 			expect:    "apprepo-foofoo-847382101-cleanup-barbar-805766666-",
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			res := deleteJobName(tc.namespace, tc.jonName)
+			res := deleteJobName(tc.namespace, tc.jobName)
+			if len(res) > MAX_CRONJOB_CHARS {
+				t.Errorf("expected length of truncated string to be <= %d, got %d", MAX_CRONJOB_CHARS, len(res))
+			}
+			if got, want := res, tc.expect; got != want {
+				t.Errorf("got: %s, want: %s", got, want)
+			}
+		})
+	}
+}
+
+func TestGenerateJobName(t *testing.T) {
+	testCases := []struct {
+		name      string
+		namespace string
+		jobName   string
+		pattern   string
+		addDash   bool
+		expect    string
+	}{
+		{
+			name:      "good patern",
+			namespace: "foo",
+			jobName:   "bar",
+			pattern:   "name: %s, namespace %s",
+			addDash:   false,
+			expect:    "name: foo, namespace bar",
+		},
+		{
+			name:      "good patern (with dash)",
+			namespace: "foo",
+			jobName:   "bar",
+			pattern:   "name: %s, namespace %s",
+			addDash:   true,
+			expect:    "name: foo, namespace bar-",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := generateJobName(tc.namespace, tc.jobName, tc.pattern, tc.addDash)
 			if len(res) > MAX_CRONJOB_CHARS {
 				t.Errorf("expected length of truncated string to be <= %d, got %d", MAX_CRONJOB_CHARS, len(res))
 			}

--- a/cmd/apprepository-controller/server/controller_test.go
+++ b/cmd/apprepository-controller/server/controller_test.go
@@ -247,7 +247,7 @@ func Test_newCronJob(t *testing.T) {
 			},
 			batchv1beta1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "apprepo-otherns-sync-my-charts-in-otherns",
+					Name: "apprepo-otherns-sync-my-chart-482411688",
 					Labels: map[string]string{
 						LabelRepoName:      "my-charts-in-otherns",
 						LabelRepoNamespace: "otherns",
@@ -1348,13 +1348,15 @@ func Test_newSyncJob(t *testing.T) {
 
 func Test_newCleanupJob(t *testing.T) {
 	tests := []struct {
-		name          string
-		repoName      string
-		repoNamespace string
-		expected      batchv1.Job
+		name              string
+		kubeappsNamespace string
+		repoName          string
+		repoNamespace     string
+		expected          batchv1.Job
 	}{
 		{
-			"my-charts",
+			"my-charts with",
+			"kubeapps",
 			"my-charts",
 			"kubeapps",
 			batchv1.Job{
@@ -1401,7 +1403,7 @@ func Test_newCleanupJob(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := newCleanupJob("kubeapps", tt.repoNamespace, tt.repoName, makeDefaultConfig())
+			result := newCleanupJob(tt.kubeappsNamespace, tt.repoNamespace, tt.repoName, makeDefaultConfig())
 			if got, want := tt.expected, *result; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}

--- a/cmd/apprepository-controller/server/controller_test.go
+++ b/cmd/apprepository-controller/server/controller_test.go
@@ -119,6 +119,88 @@ func Test_newCronJob(t *testing.T) {
 			},
 		},
 		{
+			"my-charts with long names",
+			"*/10 * * * *",
+			"",
+			&apprepov1alpha1.AppRepository{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AppRepository",
+					APIVersion: "kubeapps.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "a-really-long-long-long-long-but-valid-name-under-63-characters",
+					Namespace: "a-really-long-long-long-but-valid-namespace-under-63-characters",
+					Labels: map[string]string{
+						"name":       "a-really-long-long-long-long-but-valid-name-under-63-characters",
+						"created-by": "a-really-long-long-long-but-valid-namespace-under-63-characters",
+					},
+				},
+				Spec: apprepov1alpha1.AppRepositorySpec{
+					Type: "helm",
+					URL:  "https://charts.acme.com/a-really-long-long-long-long-but-valid-name-under-63-characters",
+				},
+			},
+			batchv1beta1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "apprepo-a-really-914363477-sync-a-really-839652390",
+					Labels: map[string]string{
+						LabelRepoName:      "a-really-long-long-long-long-but-valid-name-under-63-characters",
+						LabelRepoNamespace: "a-really-long-long-long-but-valid-namespace-under-63-characters",
+					},
+					Annotations: map[string]string{},
+				},
+				Spec: batchv1beta1.CronJobSpec{
+					Schedule:          "*/10 * * * *",
+					ConcurrencyPolicy: "Replace",
+					JobTemplate: batchv1beta1.JobTemplateSpec{
+						Spec: batchv1.JobSpec{
+							TTLSecondsAfterFinished: &defaultTTL,
+							Template: corev1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{
+										LabelRepoName:      "a-really-long-long-long-long-but-valid-name-under-63-characters",
+										LabelRepoNamespace: "a-really-long-long-long-but-valid-namespace-under-63-characters",
+									},
+									Annotations: map[string]string{},
+								},
+								Spec: corev1.PodSpec{
+									RestartPolicy: "OnFailure",
+									Containers: []corev1.Container{
+										{
+											Name:            "sync",
+											Image:           repoSyncImage,
+											ImagePullPolicy: "IfNotPresent",
+											Command:         []string{"/chart-repo"},
+											Args: []string{
+												"sync",
+												"--database-url=postgresql.kubeapps",
+												"--database-user=admin",
+												"--database-name=assets",
+												"--global-repos-namespace=kubeapps-global",
+												"--namespace=a-really-long-long-long-but-valid-namespace-under-63-characters",
+												"a-really-long-long-long-long-but-valid-name-under-63-characters",
+												"https://charts.acme.com/a-really-long-long-long-long-but-valid-name-under-63-characters",
+												"helm",
+											},
+											Env: []corev1.EnvVar{
+												{
+													Name: "DB_PASSWORD",
+													ValueFrom: &corev1.EnvVarSource{
+														SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+												},
+											},
+											VolumeMounts: nil,
+										},
+									},
+									Volumes: nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			"my-charts with auth, userAgent and crontab configuration",
 			"*/20 * * * *",
 			"kubeapps/v2.3",
@@ -398,6 +480,78 @@ func Test_newSyncJob(t *testing.T) {
 										"--namespace=kubeapps",
 										"my-charts",
 										"https://charts.acme.com/my-charts",
+										"helm",
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name: "DB_PASSWORD",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+										},
+									},
+									VolumeMounts: nil,
+								},
+							},
+							Volumes: nil,
+						},
+					},
+				},
+			},
+		},
+		{
+			"my-charts with long names",
+			"",
+			&apprepov1alpha1.AppRepository{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AppRepository",
+					APIVersion: "kubeapps.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "a-really-long-long-long-long-but-valid-name-under-63-characters",
+					Namespace: "a-really-long-long-long-but-valid-namespace-under-63-characters",
+					Labels: map[string]string{
+						"name":       "a-really-long-long-long-long-but-valid-name-under-63-characters",
+						"created-by": "a-really-long-long-long-but-valid-namespace-under-63-characters",
+					},
+				},
+				Spec: apprepov1alpha1.AppRepositorySpec{
+					Type: "helm",
+					URL:  "https://charts.acme.com/a-really-long-long-long-long-but-valid-name-under-63-characters",
+				},
+			},
+			batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "apprepo-a-really-914363477-sync-a-really-839652390-",
+					Annotations:  map[string]string{},
+					Labels:       map[string]string{},
+				},
+				Spec: batchv1.JobSpec{
+					TTLSecondsAfterFinished: &defaultTTL,
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								LabelRepoName:      "a-really-long-long-long-long-but-valid-name-under-63-characters",
+								LabelRepoNamespace: "a-really-long-long-long-but-valid-namespace-under-63-characters",
+							},
+							Annotations: map[string]string{},
+						},
+						Spec: corev1.PodSpec{
+							RestartPolicy: "OnFailure",
+							Containers: []corev1.Container{
+								{
+									Name:            "sync",
+									Image:           repoSyncImage,
+									ImagePullPolicy: "IfNotPresent",
+									Command:         []string{"/chart-repo"},
+									Args: []string{
+										"sync",
+										"--database-url=postgresql.kubeapps",
+										"--database-user=admin",
+										"--database-name=assets",
+										"--global-repos-namespace=kubeapps-global",
+										"--namespace=a-really-long-long-long-but-valid-namespace-under-63-characters",
+										"a-really-long-long-long-long-but-valid-name-under-63-characters",
+										"https://charts.acme.com/a-really-long-long-long-long-but-valid-name-under-63-characters",
 										"helm",
 									},
 									Env: []corev1.EnvVar{
@@ -1399,6 +1553,51 @@ func Test_newCleanupJob(t *testing.T) {
 				},
 			},
 		},
+		{
+			"my-charts with long names",
+			"kubeapps",
+			"a-really-long-long-long-long-but-valid-name-under-63-characters",
+			"a-really-long-long-long-but-valid-namespace-under-63-characters",
+			batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "apprepo-a-real-1762006330-cleanup-a-real-1687295243-",
+					Namespace:    "kubeapps",
+					Annotations:  map[string]string{},
+					Labels:       map[string]string{},
+				},
+				Spec: batchv1.JobSpec{
+					TTLSecondsAfterFinished: &defaultTTL,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							RestartPolicy: "Never",
+							Containers: []corev1.Container{
+								{
+									Name:            "delete",
+									Image:           repoSyncImage,
+									ImagePullPolicy: "IfNotPresent",
+									Command:         []string{"/chart-repo"},
+									Args: []string{
+										"delete",
+										"a-really-long-long-long-long-but-valid-name-under-63-characters",
+										"--namespace=a-really-long-long-long-but-valid-namespace-under-63-characters",
+										"--database-url=postgresql.kubeapps",
+										"--database-user=admin",
+										"--database-name=assets",
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name: "DB_PASSWORD",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1464,6 +1663,183 @@ func TestObjectBelongsTo(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got, want := objectBelongsTo(tc.object, tc.parent), tc.expect; got != want {
 				t.Errorf("got: %t, want: %t", got, want)
+			}
+		})
+	}
+}
+
+func TestTruncateAndHashString(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  string
+		length int
+		expect string
+	}{
+		{
+			name:   "empty string",
+			input:  "",
+			length: 5,
+			expect: "",
+		},
+		{
+			name:   "0 length",
+			input:  "",
+			length: 0,
+			expect: "",
+		},
+		{
+			name:   "string under the max length",
+			input:  "1234",
+			length: 5,
+			expect: "1234",
+		},
+		{
+			name:   "string that fits in the max length",
+			input:  "12345",
+			length: 5,
+			expect: "12345",
+		},
+		{
+			name:   "long string whose exceeding part gets truncated but not hashed if length < 11",
+			input:  "123456789",
+			length: 5,
+			expect: "12345",
+		},
+		{
+			name:   "long string whose exceeding part gets truncated and hashed",
+			input:  "1234567891234",
+			length: 12,
+			expect: "1-269222519",
+		},
+		{
+			name:   "string under the 52-chars length",
+			input:  "aaa",
+			length: 52,
+			expect: "aaa",
+		},
+		{
+			name:   "string that fits in the 52-chars length",
+			input:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			length: 52,
+			expect: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		{
+			name:   "long string whose exceeding part gets truncated and hashed",
+			input:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaExceedingLongName",
+			length: 52,
+			expect: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-2604272329",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := truncateAndHashString(tc.input, tc.length)
+			if got, want := res, tc.expect; got != want {
+				t.Errorf("got: %s, want: %s", got, want)
+			}
+		})
+	}
+}
+
+func TestCronJobName(t *testing.T) {
+	testCases := []struct {
+		name      string
+		namespace string
+		jonName   string
+		addDash   bool
+		expect    string
+	}{
+		{
+			name:      "short name",
+			namespace: "foo",
+			jonName:   "bar",
+			addDash:   false,
+			expect:    "apprepo-foo-sync-bar",
+		},
+		{
+			name:      "short name with dash",
+			namespace: "foo",
+			jonName:   "bar",
+			addDash:   true,
+			expect:    "apprepo-foo-sync-bar-",
+		},
+		{
+			name:      "max length name",
+			namespace: "foofoofoofoofoofoof",
+			jonName:   "barbarbarbarbarbarb",
+			addDash:   false,
+			expect:    "apprepo-foofoofoofoofoofoof-sync-barbarbarbarbarbarb",
+		},
+		{
+			name:      "max length name with dash",
+			namespace: "foofoofoofoofoofoof",
+			jonName:   "barbarbarbarbarbar",
+			addDash:   true,
+			expect:    "apprepo-foofoofoofoofoofoof-sync-barbarbarbarbarbar-",
+		},
+		{
+			name:      "exceeding length name",
+			namespace: "foofoofoofoofoofoofoo",
+			jonName:   "barbarbarbarbarbarbar",
+			addDash:   false,
+			expect:    "apprepo-foofoofo-645137792-sync-barbarba-620299591",
+		},
+		{
+			name:      "exceeding length name with dash",
+			namespace: "foofoofoofoofoofoofoofoo",
+			jonName:   "barbarbarbarbarbarbarbar",
+			addDash:   true,
+			expect:    "apprepo-foofoofo-963839684-sync-barbarba-925369980-",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := cronJobName(tc.namespace, tc.jonName, tc.addDash)
+			if len(res) > MAX_CRONJOB_CHARS {
+				t.Errorf("expected length of truncated string to be <= %d, got %d", MAX_CRONJOB_CHARS, len(res))
+			}
+			if got, want := res, tc.expect; got != want {
+				t.Errorf("got: %s, want: %s", got, want)
+			}
+		})
+	}
+}
+
+func TestDeleteJobName(t *testing.T) {
+	testCases := []struct {
+		name      string
+		namespace string
+		jonName   string
+		expect    string
+	}{
+		{
+			name:      "short name",
+			namespace: "foo",
+			jonName:   "bar",
+			expect:    "apprepo-foo-cleanup-bar-",
+		},
+		{
+			name:      "max length name",
+			namespace: "foofoofoofoofoofo",
+			jonName:   "barbarbarbarbarba",
+			expect:    "apprepo-foofoofoofoofoofo-cleanup-barbarbarbarbarba-",
+		},
+		{
+			name:      "exceeding length name",
+			namespace: "foofoofoofoofoofoofoo",
+			jonName:   "barbarbarbarbarbarbar",
+			expect:    "apprepo-foofoo-847382101-cleanup-barbar-805766666-",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := deleteJobName(tc.namespace, tc.jonName)
+			if len(res) > MAX_CRONJOB_CHARS {
+				t.Errorf("expected length of truncated string to be <= %d, got %d", MAX_CRONJOB_CHARS, len(res))
+			}
+			if got, want := res, tc.expect; got != want {
+				t.Errorf("got: %s, want: %s", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of the change

This PR addresses #4061 by truncating (+hashing) a cronjob name up to its 52-chars limit. The rationale has been:

Our cronjob's names have: 1) a fixed part `apprepo--cleanup--` and `apprepo--sync-`; 2) a namespace name; 3) a job name.
Whereas we don't want to change anything from 1), 2) and 3) can, on their own, have up to 63 characters. So, in theory, until now, we can exceed the 126 characters... far distant from the 52-chars limit.

So, in this PR I'm truncating both 2) and 3), but, in order to avoid name collisions, a hashing function is applied if possible. After having a look at some hashing functions producing short checksums, two main options were `fletcher` and `adler` in their 32-bit version. Having compared the chances of a collision [1] and given they both produces similar results, I went with `adler-32`, which is integrated in the go standard libs.

The hashes are up to 32 bits ints (unsigned), that is 2^32: the max number has up to 10 digits.

Considering all of this, each cronjob's name and namespace get truncated if they exceed the MAX_LENGTH/2 (that is 52/2 chars) and hashed so that we can still avoid (best effort, not guaranteed) collisions.

[1] https://www.zlib.net/maxino06_fletcher-adler.pdf


### Benefits

No more jobs silently failing anymore!

### Possible drawbacks

N/A

### Applicable issues

- fixes #4061 

### Additional information

Currently, we are giving the same amount of characters to both the namespace and job name. We could change it or use another approach to distribute the available remaining characters, but, I don't really think it is worthwhile.

IRL test:

```console
k get cronjob -n kubeapps 
NAME                                       SCHEDULE       SUSPEND   ACTIVE   LAST SCHEDULE   AGE
apprepo-default-sync-bitnami               */10 * * * *   False     1        6s              5m8s
apprepo-default-sync-thisisab-2213025484-27556480   0/1           11s        11s
apprepo-default-sync-thisisab-2213025484-29cbg      0/1           57s        57s

k get cronjob -n kubeapps 
NAME                                       SCHEDULE       SUSPEND   ACTIVE   LAST SCHEDULE   AGE
apprepo-default-sync-bitnami */10 * * * *   False     1        28s             5m30s
apprepo-default-sync-thisisab-2213025484   */10 * * * *   False     1        28s             73s
````

**Edit**: marked as a draft, as CI failed and I still have to debug what's the reason.