### PR TITLE
Use `remark-breaks` instead of a css `pre-wrap`

### DIFF
--- a/cmd/kubeapps-apis/docs/kubeapps-apis.swagger.json
+++ b/cmd/kubeapps-apis/docs/kubeapps-apis.swagger.json
@@ -4785,7 +4785,7 @@
     }
   ],
   "externalDocs": {
-    "description": "Kuebapps GitHub repository",
+    "description": "Kubeapps GitHub repository",
     "url": "https://github.com/vmware-tanzu/kubeapps"
   }
 }

--- a/cmd/kubeapps-apis/proto/kubeappsapis/apidocs/v1alpha1/apidocs.proto
+++ b/cmd/kubeapps-apis/proto/kubeappsapis/apidocs/v1alpha1/apidocs.proto
@@ -25,7 +25,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
 		};
 	};
 	external_docs: {
-		description: "Kuebapps GitHub repository";
+		description: "Kubeapps GitHub repository";
 		url: "https://github.com/vmware-tanzu/kubeapps";
 	}
 	schemes: HTTP;

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -67,6 +67,7 @@
     "redux": "^4.2.0",
     "redux-devtools-extension": "^2.13.9",
     "redux-thunk": "^2.4.1",
+    "remark-breaks": "^3.0.2",
     "remark-gfm": "^3.0.1",
     "rxjs": "^7.5.5",
     "swagger-ui-react": "^4.11.1",
@@ -131,7 +132,7 @@
       "!src/**/*.d.ts"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!@cds|@clr|@lit|bail|ccount|character-entities|comma-separated-tokens|decode-named-character-reference|escape-string-regexp|hast-util-whitespace|is-plain-obj|lit|lodash-es|markdown-table|mdast-util-definitions|mdast-util-find-and-replace|mdast-util-from-markdown|mdast-util-gfm|mdast-util-gfm-autolink-literal|mdast-util-to-hast|mdast-util-to-markdown|mdast-util-to-string|micromark|micromark-core-commonmark|parse-entities|property-information|ramda|react-markdown|react-markdown|react-syntax-highlighter|remark-gfm|remark-parse|remark-rehype|space-separated-tokens|swagger-client|swagger-ui-react|trough|unified|unist-builder|unist-util-generated|unist-util-is|unist-util-position|unist-util-stringify-position|unist-util-visit|unist-util-visit-parents|util-find-and-replace|vfile|vfile-message|.*css)"
+      "node_modules/(?!@cds|@clr|@lit|bail|ccount|character-entities|comma-separated-tokens|decode-named-character-reference|escape-string-regexp|hast-util-whitespace|is-plain-obj|lit|lodash-es|markdown-table|mdast-util-definitions|mdast-util-find-and-replace|mdast-util-from-markdown|mdast-util-gfm|mdast-util-gfm-autolink-literal|mdast-util-to-hast|mdast-util-to-markdown|mdast-util-to-string|micromark|micromark-core-commonmark|parse-entities|property-information|ramda|react-markdown|react-markdown|react-syntax-highlighter|remark-breaks|remark-gfm|remark-parse|remark-rehype|space-separated-tokens|swagger-client|swagger-ui-react|trough|unified|unist-builder|unist-util-generated|unist-util-is|unist-util-position|unist-util-stringify-position|unist-util-visit|unist-util-visit-parents|util-find-and-replace|vfile|vfile-message|.*css)"
     ]
   },
   "browserslist": {

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -6,7 +6,7 @@
   <head> </head>
 
   <body>
-    <!-- Hey you! interested in Kuebapps, have a look and contribute at https://github.com/vmware-tanzu/kubeapps -->
+    <!-- Hey you! interested in Kubeapps, have a look and contribute at https://github.com/vmware-tanzu/kubeapps -->
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
   </body>

--- a/dashboard/src/components/AppView/AppNotes/AppNotes.tsx
+++ b/dashboard/src/components/AppView/AppNotes/AppNotes.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import ReactMarkdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import HeadingRenderer from "../../MarkdownRenderer/HeadingRenderer";
 import LinkRenderer from "../../MarkdownRenderer/LinkRenderer";
@@ -19,7 +20,7 @@ function AppNotes(props: IAppNotesProps) {
       <h3 className="section-title">{title ? title : "Installation Notes"}</h3>
       <div className="application-notes">
         <ReactMarkdown
-          remarkPlugins={[remarkGfm]}
+          remarkPlugins={[remarkGfm, remarkBreaks]}
           components={{
             h1: HeadingRenderer,
             h2: HeadingRenderer,

--- a/dashboard/src/components/Layout/Layout.scss
+++ b/dashboard/src/components/Layout/Layout.scss
@@ -207,7 +207,6 @@
   border: 2px solid var(--cds-alias-object-border-color, #f1f1f1);
   margin: 0.625em 0;
   font-family: monospace;
-  white-space: pre-wrap;
 }
 
 .after-readme-button {

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -12567,6 +12567,15 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remark-breaks@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/remark-breaks/-/remark-breaks-3.0.2.tgz#f466b9d3474d7323146c0149fc1496dabadd908e"
+  integrity sha512-x96YDJ9X+Ry0/JNZFKfr1hpcAKvGYWfUTszxY9RbxKEqq6uzPPoLCuHdZsLPZZUdAv3nCROyc7FPrQLWr2rxyw==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    unified "^10.0.0"
+    unist-util-visit "^4.0.0"
+
 remark-gfm@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-3.0.1.tgz#0b180f095e3036545e9dddac0e8df3fa5cfee54f"


### PR DESCRIPTION
### Description of the change

In https://github.com/vmware-tanzu/kubeapps/pull/4143 we added markdown rendering to the app notes, but it resulted in a wrong hanling of the break-lines, as @dud225 described at https://github.com/vmware-tanzu/kubeapps/issues/4395.

In https://github.com/remarkjs/react-markdown/issues/278#issuecomment-971909964 I saw using `remark-breaks` could make the trick for us. Therefore, this PR is just removing the old way to handle the word wrapping using css and replacing it instead with this remark plugin.

### Benefits

Better handling of the break-lines.

### Possible drawbacks

N/A

### Applicable issues

- fixes #4395

### Additional information

See [my comment ](https://github.com/vmware-tanzu/kubeapps/issues/4395#issuecomment-1134804347) with examples and pics.

_Squeezing some typo-fxing in here :P_