### PR TITLE
Update the token-auth example for getting-started.

### DIFF
--- a/script/makefiles/cluster-kind.mk
+++ b/script/makefiles/cluster-kind.mk
@@ -6,7 +6,7 @@
 KUBE ?= ${HOME}/.kube
 CLUSTER_NAME ?= kubeapps
 ADDITIONAL_CLUSTER_NAME ?= kubeapps-additional
-IMAGE ?= kindest/node:v1.24.0
+IMAGE ?= kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
 
 CLUSTER_CONFIG = ${KUBE}/kind-config-${CLUSTER_NAME}
 ADDITIONAL_CLUSTER_CONFIG = ${KUBE}/kind-config-${ADDITIONAL_CLUSTER_NAME}

--- a/script/makefiles/cluster-kind.mk
+++ b/script/makefiles/cluster-kind.mk
@@ -6,6 +6,7 @@
 KUBE ?= ${HOME}/.kube
 CLUSTER_NAME ?= kubeapps
 ADDITIONAL_CLUSTER_NAME ?= kubeapps-additional
+IMAGE ?= kindest/node:v1.24.0
 
 CLUSTER_CONFIG = ${KUBE}/kind-config-${CLUSTER_NAME}
 ADDITIONAL_CLUSTER_CONFIG = ${KUBE}/kind-config-${ADDITIONAL_CLUSTER_NAME}
@@ -14,6 +15,7 @@ ADDITIONAL_CLUSTER_CONFIG = ${KUBE}/kind-config-${ADDITIONAL_CLUSTER_NAME}
 # but is sufficient for the pod to be created so that we can copy the certs below.
 ${CLUSTER_CONFIG}:
 	kind create cluster \
+		--image ${IMAGE} \
 		--kubeconfig ${CLUSTER_CONFIG} \
 		--name ${CLUSTER_NAME} \
 		--config=./site/content/docs/latest/reference/manifests/kubeapps-local-dev-apiserver-config.yaml \

--- a/site/themes/template/layouts/partials/use-cases.html
+++ b/site/themes/template/layouts/partials/use-cases.html
@@ -68,7 +68,22 @@
 
       <div class="home-snippet">
         {{ highlight `
-    kubectl get --namespace default secret $(kubectl get --namespace default serviceaccount kubeapps-operator -o jsonpath='{range.secrets[*]}{.name}{"\n"}{end}' | grep kubeapps-operator-token) -o jsonpath='{.data.token}' -o go-template='{{.data.token | base64decode}}' && echo
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: kubeapps-operator-token
+      namespace: default
+      annotations:
+        kubernetes.io/service-account.name: kubeapps-operator
+    type: kubernetes.io/service-account-token
+    EOF
+    ` "" "" }}
+      </div>
+
+      <div class="home-snippet">
+        {{ highlight `
+    kubectl get --namespace default secret kubeapps-operator-token -o jsonpath='{.data.token}' -o go-template='{{.data.token | base64decode}}' && echo
         ` "" "" }}
       </div>
     </div>


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

With 1.24, token secrets are not created automatically for a service account. Updated our getting started to create the secret with the required annotation to be populated with a valid token, and update the instructions to just get that token (more simple anyway).

Verified this works both with k8s 1.24 and 1.21 .

### Benefits

<!-- What benefits will be realized by the code change? -->
Avoid confusion with token auth moving forward as more people use 1.24


### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #4763

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
