### PR TITLE
Redact db password when logging configuration.

### DIFF
--- a/cmd/asset-syncer/cmd/root.go
+++ b/cmd/asset-syncer/cmd/root.go
@@ -29,7 +29,9 @@ func newRootCmd() *cobra.Command {
 		Short: "Asset Synchronization utility",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			serveOpts.UserAgent = server.GetUserAgent(version, serveOpts.UserAgentComment)
-			log.Infof("asset-syncer has been configured with: %#v", serveOpts)
+			serveOptsCopy := serveOpts
+			serveOptsCopy.DatabasePassword = "REDACTED"
+			log.Infof("asset-syncer has been configured with: %#v", serveOptsCopy)
 		},
 		Version: "devel",
 	}


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Just noticed this while working on https://github.com/bitnami/charts/pull/10392 . Looks like it crept in when we added the extra logging message of the config, not realising it included the config (#3450)


### Benefits

<!-- What benefits will be realized by the code change? -->

Don't log db password.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
