### PR TITLE
Rename `App Repositories` to `Package Repositories`

### DIFF
--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -615,7 +615,7 @@ describe("pagination and package fetching", () => {
   });
 });
 
-describe("filters by application repository", () => {
+describe("filters by package repository", () => {
   const mockDispatch = jest.fn();
   let spyOnUseDispatch: jest.SpyInstance;
   let fetchRepos: jest.SpyInstance;

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -209,7 +209,7 @@ export default function Catalog() {
       .concat(flatten(csvs.map(c => getOperatorCategories(c)))),
   ).sort();
 
-  // We do not currently support app repositories on additional clusters.
+  // We do not currently support package repositories on additional clusters.
   const supportedCluster = cluster === kubeappsCluster;
   useEffect(() => {
     if (!supportedCluster || namespace === globalReposNamespace) {
@@ -374,11 +374,11 @@ export default function Catalog() {
           <CdsIcon shape="bundle" />
           <p>The current catalog is empty.</p>
           <p>
-            Manage your Helm Package Repositories in Kubeapps by visiting the App repositories
+            Manage your Package Repositories in Kubeapps by visiting the Package repositories
             configuration page.
           </p>
           <Link to={app.config.apprepositories(cluster, namespace)}>
-            <CdsButton>Manage App Repositories</CdsButton>
+            <CdsButton>Manage Package Repositories</CdsButton>
           </Link>
           <p>
             For help managing other packaging formats, such as Flux or Carvel, please refer to the{" "}
@@ -432,7 +432,7 @@ export default function Catalog() {
               )}
               {allRepos.length > 0 && (
                 <div className="filter-section">
-                  <label>Application Repository</label>
+                  <label>Package Repository</label>
                   <FilterGroup
                     name={filterNames.REPO}
                     options={allRepos}

--- a/dashboard/src/components/Catalog/PackageCatalogItem.tsx
+++ b/dashboard/src/components/Catalog/PackageCatalogItem.tsx
@@ -24,7 +24,7 @@ export default function PackageCatalogItem(props: IPackageCatalogItem) {
   // Get the pkg repository for the plugins that have one.
   // Assuming an identifier will always be like: "repo/pkgName"
   const splitIdentifier = availablePackageSummary.availablePackageRef?.identifier.split("/");
-  if (splitIdentifier && splitIdentifier?.length > 0) {
+  if (splitIdentifier && splitIdentifier?.length > 1) {
     pkgRepository = splitIdentifier[0];
   }
 

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
@@ -99,7 +99,7 @@ export function AppRepoAddButton({
         disabled={disabled}
         title={title}
       >
-        {primary ? <CdsIcon shape="plus-circle" /> : <></>} {text || "Add App Repository"}
+        {primary ? <CdsIcon shape="plus-circle" /> : <></>} {text || "Add Package Repository"}
       </CdsButton>
       {modalIsOpen && (
         <CdsModal size={"lg"} onCloseChange={closeModal}>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
@@ -614,8 +614,8 @@ export function AppRepoForm(props: IAppRepoFormProps) {
 
       {namespace === kubeappsNamespace && (
         <p>
-          <strong>NOTE:</strong> This App Repository will be created in the "{kubeappsNamespace}"
-          namespace and packages will be available in all namespaces for installation.
+          <strong>NOTE:</strong> This Package Repository will be created in the "{kubeappsNamespace}
+          " namespace and packages will be available in all namespaces for installation.
         </p>
       )}
       {validationError && (

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -148,7 +148,9 @@ describe("global and namespaced repositories", () => {
   it("shows a message if no global or namespaced repos exist", () => {
     const wrapper = mountWrapper(defaultStore, <AppRepoList />);
     expect(
-      wrapper.find("p").filterWhere(p => p.text().includes("There are no global Package Repositories")),
+      wrapper
+        .find("p")
+        .filterWhere(p => p.text().includes("There are no global Package Repositories")),
     ).toExist();
     expect(
       wrapper

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -99,7 +99,7 @@ it("shows a warning if the cluster is not the default one", () => {
     <AppRepoList />,
   );
   expect(wrapper.find(Alert)).toIncludeText(
-    "App Repositories are available on the default cluster only",
+    "Package Repositories can't be managed from this cluster",
   );
 });
 
@@ -148,12 +148,12 @@ describe("global and namespaced repositories", () => {
   it("shows a message if no global or namespaced repos exist", () => {
     const wrapper = mountWrapper(defaultStore, <AppRepoList />);
     expect(
-      wrapper.find("p").filterWhere(p => p.text().includes("No global repositories found")),
+      wrapper.find("p").filterWhere(p => p.text().includes("There are no global Package Repositories")),
     ).toExist();
     expect(
       wrapper
         .find("p")
-        .filterWhere(p => p.text().includes("The current namespace doesn't have any repositories")),
+        .filterWhere(p => p.text().includes("There are no namespaced Package Repositories")),
     ).toExist();
   });
 
@@ -184,7 +184,7 @@ describe("global and namespaced repositories", () => {
     expect(wrapper.find(AppRepoControl)).not.toExist();
     // The content related to namespaced repositories should exist
     expect(
-      wrapper.find("h3").filterWhere(h => h.text().includes("Namespace Repositories")),
+      wrapper.find("h3").filterWhere(h => h.text().includes("Namespaced Repositories")),
     ).toExist();
   });
 

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -40,7 +40,7 @@ function AppRepoList() {
   const [canEditGlobalRepos, setCanEditGlobalRepos] = useState(false);
   const [namespace, setNamespace] = useState(allNSQuery ? "" : currentNamespace);
 
-  // We do not currently support app repositories on additional clusters.
+  // We do not currently support package repositories on additional clusters.
   const supportedCluster = cluster === kubeappsCluster;
   // useCallback stores the reference to the function, not the function execution
   // so calling several times to refetchRepos would run the code inside, even
@@ -136,10 +136,10 @@ function AppRepoList() {
   return (
     <>
       <PageHeader
-        title="Application Repositories"
+        title="Package Repositories"
         buttons={[
           <AppRepoAddButton
-            title="Add an App Repository"
+            title="Add a Package Repository"
             key="add-repo-button"
             namespace={currentNamespace}
             kubeappsNamespace={globalReposNamespace}
@@ -161,17 +161,16 @@ function AppRepoList() {
       />
       {!supportedCluster ? (
         <Alert theme="warning">
-          <h5>App Repositories are available on the default cluster only</h5>
+          <h5>Package Repositories can't be managed from this cluster.</h5>
           <p>
-            Currently the multi-cluster support in Kubeapps supports AppRepositories on the default
-            cluster only.
+            Currently, the Package Repositories must be managed from the default cluster (the one on
+            which Kubeapps has been installed).
           </p>
           <p>
-            The catalog of packages from AppRepositories on the default cluster which are available
-            for all namespaces will be available on additional clusters also, but you can not
-            currently create a private AppRepository for a particular namespace of an additional
-            cluster. We may in the future support AppRepositories on additional clusters but for now
-            you will need to switch back to your default cluster.
+            Any <i>global</i> Package Repository defined in the default cluster can be later used
+            across any target cluster.
+            <br />
+            However, <i>namespaced</i> Package Repositories can only be used on the default cluster.
           </p>
         </Alert>
       ) : (
@@ -190,11 +189,11 @@ function AppRepoList() {
             <>
               <LoadingWrapper
                 className="margin-t-xxl"
-                loadingText="Fetching Application Repositories..."
+                loadingText="Fetching Package Repositories..."
                 loaded={!isFetchingElem.repositories}
               >
                 <h3>Global Repositories:</h3>
-                <p>Global repositories are available for all Kubeapps users.</p>
+                <p>Global Package Repositories are available for all Kubeapps users.</p>
                 {globalRepos.length ? (
                   <Table
                     valign="center"
@@ -202,14 +201,18 @@ function AppRepoList() {
                     data={getTableData(globalRepos, !canEditGlobalRepos)}
                   />
                 ) : (
-                  <p>No global repositories found.</p>
+                  <p>
+                    There are no <i>global</i> Package Repositories yet. Click on the "Add Package
+                    Repository" button to create one.
+                  </p>
                 )}
                 {namespace !== globalReposNamespace && (
                   <>
-                    <h3>Namespace Repositories: {namespace}</h3>
+                    <h3>Namespaced Repositories: {namespace}</h3>
                     <p>
-                      Namespaced Repositories are available in their namespace only. To switch to a
-                      different one, use the "Current Context" selector in the top navigation.
+                      Namespaced Package Repositories are available in their namespace only. To
+                      switch to a different one, use the "Current Context" selector in the top
+                      navigation.
                     </p>
                     {namespaceRepos.length ? (
                       <Table
@@ -219,8 +222,8 @@ function AppRepoList() {
                       />
                     ) : (
                       <p>
-                        The current namespace doesn't have any repositories. Click on the button
-                        "Add app repository" above to create the first one.
+                        There are no <i>namespaced</i> Package Repositories in the '{namespace}'
+                        namespace yet. Click on the "Add Package Repository" button to create one.
                       </p>
                     )}
                   </>

--- a/dashboard/src/components/Header/Menu.tsx
+++ b/dashboard/src/components/Header/Menu.tsx
@@ -80,7 +80,8 @@ function Menu({ clusters, appVersion, logout }: IContextSelectorProps) {
                 onClick={toggleOpen}
               >
                 <div className="dropdown-menu-item" role="menuitem">
-                  <CdsIcon solid={true} size="md" shape="library" /> <span>App Repositories</span>
+                  <CdsIcon solid={true} size="md" shape="library" />{" "}
+                  <span>Package Repositories</span>
                 </div>
               </Link>
               <div className="dropdown-divider" role="separator" />

--- a/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
+++ b/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
@@ -75,7 +75,7 @@ function SelectRepoForm({ cluster, namespace, app }: ISelectRepoFormProps) {
   return (
     <LoadingWrapper
       className="margin-t-xxl"
-      loadingText="Fetching Application Repositories..."
+      loadingText="Fetching Package Repositories..."
       loaded={!isFetching}
     >
       {fetchError && <Alert theme="danger">An error occurred: {fetchError.message}</Alert>}
@@ -84,7 +84,7 @@ function SelectRepoForm({ cluster, namespace, app }: ISelectRepoFormProps) {
           <h5>Repositories not found. </h5>
           Manage your repositories in Kubeapps by visiting the{" "}
           <Link to={url.app.config.apprepositories(cluster, namespace)}>
-            App repositories configuration
+            Package Repositories configuration
           </Link>{" "}
           page.
         </Alert>

--- a/integration/tests/main/02-create-package-repository.spec.js
+++ b/integration/tests/main/02-create-package-repository.spec.js
@@ -12,12 +12,12 @@ test("Create a new package repository successfully", async ({ page }) => {
 
   // Go to repos page
   await page.click(".dropdown.kubeapps-menu button.kubeapps-nav-link");
-  await page.click('a.dropdown-menu-link:has-text("App Repositories")');
+  await page.click('a.dropdown-menu-link:has-text("Package Repositories")');
   await page.waitForTimeout(3000);
 
   // Add new repo
-  console.log('Creating repository "my-repo"');
-  await page.click('cds-button:has-text("Add App Repository")');
+  console.log('Creating package repository "my-repo"');
+  await page.click('cds-button:has-text("Add Package Repository")');
   await page.fill("input#kubeapps-repo-name", "my-repo");
   await page.fill("input#kubeapps-repo-url", "https://charts.gitlab.io/");
   await page.click('cds-button:has-text("Install Repo")');

--- a/integration/tests/main/03-create-private-package-repository.spec.js
+++ b/integration/tests/main/03-create-private-package-repository.spec.js
@@ -23,9 +23,9 @@ test("Create a new private package repository successfully", async ({ page }) =>
   await page.waitForTimeout(3000);
 
   // Add new repo
-  await page.click('cds-button:has-text("Add App Repository")');
+  await page.click('cds-button:has-text("Add Package Repository")');
   const repoName = utils.getRandomName("my-repo");
-  console.log(`Creating repository "${repoName}"`);
+  console.log(`Creating package repository "${repoName}"`);
   await page.fill("input#kubeapps-repo-name", repoName);
   await page.fill("input#kubeapps-repo-url", "http://chartmuseum-chartmuseum.kubeapps:8080");
 

--- a/integration/tests/main/09-user-positive-installation.spec.js
+++ b/integration/tests/main/09-user-positive-installation.spec.js
@@ -25,8 +25,8 @@ test.describe("Limited user simple deployments", () => {
 
     // Add new repo
     const repoName = utils.getRandomName("repo-09");
-    console.log(`Creating repository "${repoName}"`);
-    await page.click('cds-button:has-text("Add App Repository")');
+    console.log(`Creating package repository "${repoName}"`);
+    await page.click('cds-button:has-text("Add Package Repository")');
     await page.fill("input#kubeapps-repo-name", repoName);
     await page.fill(
       "input#kubeapps-repo-url",


### PR DESCRIPTION
### Description of the change

Trivial PR just renaming the old "App repo" thing to something more aligned to our concept of "package".
This is a prequel PR, but can be safely merged into main.

### Benefits

More consistent naming.

### Possible drawbacks

N/A

### Applicable issues

- related #4764

### Additional information

Let's see if the CI agrees :P
