### PR TITLE
Add full-text search to the website

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -1,9 +1,9 @@
-baseURL: "https://kubeapps-dev.netlify.app/"
+baseURL: "https://kubeapps.dev/"
 languageCode: "en-us"
 title: "Kubeapps"
 theme: "template"
 outputs:
-  home: [ "HTML", "REDIRECTS" ]
+  home: ["HTML", "REDIRECTS"]
 pygmentsCodefences: true
 pygmentsStyle: "pygments"
 markup:
@@ -29,8 +29,10 @@ params:
   description: Kubeapps website
   docs_latest: latest
   docs_right_sidebar: true
-  docs_search: false
-  docs_search_api_key: api_key
+  docs_search: true
+  docs_search_app_id: 0HGZRK5XA0
+  docs_search_api_key: 8de7a24cc24afe13aca93276dd0cdbc7
+  docs_search_site_id: 7e0e2833-1d75-43f6-b006-632d359bb83b
   docs_search_index_name: index_name
   docs_versioning: true
   github_base_url: "https://github.com/vmware-tanzu/kubeapps"

--- a/site/content/community/_index.html
+++ b/site/content/community/_index.html
@@ -17,7 +17,10 @@ layout: section
       </div>
       <div class="content">
         <h3>
-          <a target="_blank" rel="noopener" href="https://github.com/vmware-tanzu/kubeapps/"
+          <a
+            target="_blank"
+            rel="noopener"
+            href="https://github.com/vmware-tanzu/kubeapps/"
             >Check out Github</a
           >
         </h3>
@@ -51,16 +54,22 @@ layout: section
     <div class="col">
       <div class="icon">
         <img alt="Slack logo" src="/img/slack.svg" />
-      </div>ration-planning.icsration-planning.ics
+      </div>
       <div class="content">
         <h3>
-          <a target="_blank" rel="noopener" href="https://kubernetes.slack.com/messages/kubeapps"
+          <a
+            target="_blank"
+            rel="noopener"
+            href="https://kubernetes.slack.com/messages/kubeapps"
             >Join our Slack channel</a
           >
         </h3>
         <p>
           Join the
-          <a target="_blank" rel="noopener" href="https://kubernetes.slack.com/messages/kubeapps"
+          <a
+            target="_blank"
+            rel="noopener"
+            href="https://kubernetes.slack.com/messages/kubeapps"
             >#kubeapps channel</a
           >
           on the Kubernetes Slack and talk to us and over 400 other community

--- a/site/themes/template/layouts/_default/baseof.html
+++ b/site/themes/template/layouts/_default/baseof.html
@@ -128,13 +128,15 @@
 	{{ partial "base-getting-started" . }}
 	{{ partial "base-footer" . }}
     {{ if .Site.Params.docs_search }}
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-    <script type="text/javascript"> docsearch({
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@algolia/algoliasearch-netlify-frontend@1/dist/algoliasearchNetlify.css" />
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@algolia/algoliasearch-netlify-frontend@1/dist/algoliasearchNetlify.js"></script>
+    <script type="text/javascript">
+      algoliasearchNetlify({
+        appId: '{{ .Site.Params.docs_search_app_id }}',
         apiKey: '{{ .Site.Params.docs_search_api_key }}',
-        indexName: '{{ .Site.Params.docs_search_index_name }}',
-        inputSelector: '.docsearch-input',
-        algoliaOptions: {'facetFilters': ["version:{{ .CurrentSection.Params.version }}"]},
-        debug: false // Set debug to true if you want to inspect the dropdown
+        siteId: '{{ .Site.Params.docs_search_site_id }}',
+        branch: 'main',
+        selector: 'div#search',
       });
     </script>
     {{ end }}

--- a/site/themes/template/layouts/_default/search.html
+++ b/site/themes/template/layouts/_default/search.html
@@ -1,10 +1,3 @@
 {{ if .Site.Params.docs_search }}
-    <form class="d-flex align-items-center">
-        <span class="algolia-autocomplete" style="position: relative; display: inline-block; direction: ltr;">
-        <input type="search" class="form-control docsearch-input" id="search-input" placeholder="Search..."
-                aria-label="Search for..." autocomplete="off" spellcheck="false" role="combobox"
-                aria-autocomplete="list" aria-expanded="false" aria-owns="algolia-autocomplete-listbox-0"
-                dir="auto" style="position: relative; vertical-align: top;">
-        </span>
-    </form>
+<div id="search"></div>
 {{ end }}


### PR DESCRIPTION
### Description of the change

This PR (plus the configuration already performed in the Algolia side) brings full-text search in our website.

+ squeezing some required changes now that we have the DNS poiting to https://kubeapps.dev (if redirected to .com, clear your cache)

### Benefits

Users will be able to perform full text queries to look up the docs 

### Possible drawbacks

The index is not being properly crawled/polished up, therefore the results are not the best ones.

### Applicable issues

- related #3953

### Additional information

![search](https://user-images.githubusercontent.com/11535726/171490267-895c3d71-b4d2-4e9a-81e0-11e583c3cb66.gif)

