### PR TITLE
Add minor improvements prior to the repos UI

### DIFF
--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
@@ -46,7 +46,7 @@ func NewPackagesServer(pkgingPlugins []pluginsv1alpha1.PluginWithServer) (*packa
 			plugin: p.Plugin,
 			server: pkgsSrv,
 		}
-		log.Infof("Registered %v for core.packaging.v1alpha1 aggregation.", p.Plugin)
+		log.Infof("Registered %v for core.packaging.v1alpha1 packages aggregation.", p.Plugin)
 	}
 	return &packagesServer{
 		pluginsWithServers: pluginsWithServer,

--- a/cmd/kubeapps-apis/core/packages/v1alpha1/repositories.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/repositories.go
@@ -46,7 +46,7 @@ func NewRepositoriesServer(pkgingPlugins []pluginsv1alpha1.PluginWithServer) (*r
 			plugin: p.Plugin,
 			server: pkgsSrv,
 		}
-		log.Infof("Registered %v for core.packaging.v1alpha1 aggregation.", p.Plugin)
+		log.Infof("Registered %v for core.packaging.v1alpha1 repositories aggregation.", p.Plugin)
 	}
 	return &repositoriesServer{
 		pluginsWithServers: pluginsWithServer,

--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -231,7 +231,10 @@ describe("setNamespace", () => {
 
 describe("canCreate", () => {
   it("checks if it can create namespaces", async () => {
-    Kube.canI = jest.fn().mockReturnValue(true);
+    Kube.canI = jest.fn().mockReturnValue({
+      then: jest.fn(f => f(true)),
+      catch: jest.fn(f => f(false)),
+    });
     const expectedActions = [
       {
         type: getType(setAllowCreate),

--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -45,6 +45,7 @@ beforeEach(() => {
   spyOnUseDispatch = jest.spyOn(ReactRedux, "useDispatch").mockReturnValue(mockDispatch);
   Kube.canI = jest.fn().mockReturnValue({
     then: jest.fn(f => f(true)),
+    catch: jest.fn(f => f(false)),
   });
 });
 
@@ -126,6 +127,7 @@ context("when changing props", () => {
   it("should hide the all-namespace switch if the user doesn't have permissions", async () => {
     Kube.canI = jest.fn().mockReturnValue({
       then: jest.fn((f: any) => f(false)),
+      catch: jest.fn(f => f(false)),
     });
     const wrapper = mountWrapper(defaultStore, <AppList />);
     expect(wrapper.find("input[type='checkbox']")).not.toExist();

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -81,7 +81,9 @@ function AppList() {
   useEffect(() => {
     // In order to be able to list applications in all namespaces, it's necessary to be able
     // to list/get secrets in all of them.
-    Kube.canI(cluster, "", "secrets", "list", "").then(allowed => setCanSetAllNS(allowed));
+    Kube.canI(cluster, "", "secrets", "list", "")
+      .then(allowed => setCanSetAllNS(allowed))
+      ?.catch(() => setCanSetAllNS(false));
   }, [cluster]);
 
   useEffect(() => {

--- a/dashboard/src/components/AppView/CustomAppView/CustomAppView.test.tsx
+++ b/dashboard/src/components/AppView/CustomAppView/CustomAppView.test.tsx
@@ -4,6 +4,7 @@
 import {
   InstalledPackageDetail,
   AvailablePackageDetail,
+  ResourceRef,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 import CustomAppView from ".";
@@ -21,7 +22,7 @@ const defaultProps = {
     },
   } as InstalledPackageDetail,
   resourceRefs: {
-    ingresses: [],
+    ingresses: [] as ResourceRef[],
     deployments: [
       {
         cluster: "default",
@@ -31,10 +32,10 @@ const defaultProps = {
         namespaced: true,
         name: "ssh-server-example",
         namespace: "demo-namespace",
-      },
-    ],
-    statefulsets: [],
-    daemonsets: [],
+      } as ResourceRef,
+    ] as ResourceRef[],
+    statefulsets: [] as ResourceRef[],
+    daemonsets: [] as ResourceRef[],
     otherResources: [
       {
         cluster: "default",
@@ -44,8 +45,8 @@ const defaultProps = {
         namespaced: true,
         name: "ssh-server-example-root-pv-claim",
         namespace: "demo-namespace",
-      },
-    ],
+      } as ResourceRef,
+    ] as ResourceRef[],
     services: [
       {
         cluster: "default",
@@ -55,10 +56,10 @@ const defaultProps = {
         namespaced: true,
         name: "ssh-server-example",
         namespace: "demo-namespace",
-      },
-    ],
-    secrets: [],
-  } as unknown as IAppViewResourceRefs,
+      } as ResourceRef,
+    ] as ResourceRef[],
+    secrets: [] as ResourceRef[],
+  } as IAppViewResourceRefs,
   appDetails: {} as AvailablePackageDetail,
 };
 

--- a/dashboard/src/components/Catalog/CatalogItems.tsx
+++ b/dashboard/src/components/Catalog/CatalogItems.tsx
@@ -80,7 +80,13 @@ export default function CatalogItems({
       ? []
       : packageItems
           .concat(crdItems)
-          .sort((a, b) => (a.item.name.toLowerCase() > b.item.name.toLowerCase() ? 1 : -1));
+          .sort((a, b) =>
+            a.item.name.toLowerCase() > b.item.name.toLowerCase()
+              ? 1
+              : b.item.name.toLowerCase() > a.item.name.toLowerCase()
+              ? -1
+              : 0,
+          );
 
   if (hasFinishedFetching && sortedItems.length === 0) {
     return <p>No application matches the current filter.</p>;

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -34,6 +34,7 @@ beforeEach(() => {
   spyOnUseDispatch = jest.spyOn(ReactRedux, "useDispatch").mockReturnValue(mockDispatch);
   Kube.canI = jest.fn().mockReturnValue({
     then: jest.fn(f => f(true)),
+    catch: jest.fn(f => f(false)),
   });
 });
 
@@ -76,6 +77,7 @@ it("fetches repos from all namespaces (without kubeappsNamespace)", () => {
 it("should hide the all-namespace switch if the user doesn't have permissions", async () => {
   Kube.canI = jest.fn().mockReturnValue({
     then: jest.fn((f: any) => f(false)),
+    catch: jest.fn(f => f(false)),
   });
   const wrapper = mountWrapper(defaultStore, <AppRepoList />);
   expect(wrapper.find("input[type='checkbox']")).not.toExist();
@@ -162,6 +164,7 @@ describe("global and namespaced repositories", () => {
   it("shows the global repositories with the buttons deactivated if the current user is not allowed to modify them", () => {
     Kube.canI = jest.fn().mockReturnValue({
       then: jest.fn((f: any) => f(false)),
+      catch: jest.fn(f => f(false)),
     });
     const wrapper = mountWrapper(
       getStore({

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -85,16 +85,12 @@ function AppRepoList() {
   }, [allNS, currentNamespace]);
 
   useEffect(() => {
-    Kube.canI(cluster, "kubeapps.com", "apprepositories", "list", "").then(allowed =>
-      setCanSetAllNS(allowed),
-    );
-    Kube.canI(
-      kubeappsCluster,
-      "kubeapps.com",
-      "apprepositories",
-      "update",
-      globalReposNamespace,
-    ).then(allowed => setCanEditGlobalRepos(allowed));
+    Kube.canI(cluster, "kubeapps.com", "apprepositories", "list", "")
+      .then(allowed => setCanSetAllNS(allowed))
+      ?.catch(() => setCanSetAllNS(false));
+    Kube.canI(kubeappsCluster, "kubeapps.com", "apprepositories", "update", globalReposNamespace)
+      .then(allowed => setCanEditGlobalRepos(allowed))
+      ?.catch(() => setCanEditGlobalRepos(false));
   }, [cluster, kubeappsCluster, kubeappsNamespace, globalReposNamespace]);
 
   const globalRepos: IAppRepository[] = [];

--- a/dashboard/src/shared/KubeappsGrpcClient.test.ts
+++ b/dashboard/src/shared/KubeappsGrpcClient.test.ts
@@ -18,18 +18,26 @@ describe("kubeapps grpc client creation", () => {
     const serviceClients = [
       kubeappsGrpcClient.getPluginsServiceClientImpl(),
       kubeappsGrpcClient.getPackagesServiceClientImpl(),
+      kubeappsGrpcClient.getRepositoriesServiceClientImpl(),
+      kubeappsGrpcClient.getResourcesServiceClientImpl(),
     ];
     serviceClients.every(sc => expect(sc).not.toBeNull());
   });
 
   it("should create the clients for each plugin service", async () => {
     const kubeappsGrpcClient = new KubeappsGrpcClient(fakeEmpyTransport);
-    const serviceClients = [
+    const packagesServiceClients = [
       kubeappsGrpcClient.getHelmPackagesServiceClientImpl(),
       kubeappsGrpcClient.getKappControllerPackagesServiceClientImpl(),
       kubeappsGrpcClient.getFluxv2PackagesServiceClientImpl(),
     ];
-    serviceClients.every(sc => expect(sc).not.toBeNull());
+    const repositoriesServiceClients = [
+      kubeappsGrpcClient.getHelmRepositoriesServiceClientImpl(),
+      kubeappsGrpcClient.getKappControllerRepositoriesServiceClientImpl(),
+      kubeappsGrpcClient.getFluxV2RepositoriesServiceClientImpl(),
+    ];
+    packagesServiceClients.every(sc => expect(sc).not.toBeNull());
+    repositoriesServiceClients.every(sc => expect(sc).not.toBeNull());
   });
 });
 

--- a/dashboard/src/shared/KubeappsGrpcClient.ts
+++ b/dashboard/src/shared/KubeappsGrpcClient.ts
@@ -3,10 +3,20 @@
 
 import { grpc } from "@improbable-eng/grpc-web";
 import { PackagesServiceClientImpl } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
+import { RepositoriesServiceClientImpl } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
 import { PluginsServiceClientImpl } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
-import { FluxV2PackagesServiceClientImpl } from "gen/kubeappsapis/plugins/fluxv2/packages/v1alpha1/fluxv2";
-import { HelmPackagesServiceClientImpl } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
-import { KappControllerPackagesServiceClientImpl } from "gen/kubeappsapis/plugins/kapp_controller/packages/v1alpha1/kapp_controller";
+import {
+  FluxV2PackagesServiceClientImpl,
+  FluxV2RepositoriesServiceClientImpl,
+} from "gen/kubeappsapis/plugins/fluxv2/packages/v1alpha1/fluxv2";
+import {
+  HelmPackagesServiceClientImpl,
+  HelmRepositoriesServiceClientImpl,
+} from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
+import {
+  KappControllerPackagesServiceClientImpl,
+  KappControllerRepositoriesServiceClientImpl,
+} from "gen/kubeappsapis/plugins/kapp_controller/packages/v1alpha1/kapp_controller";
 import {
   GrpcWebImpl,
   ResourcesServiceClientImpl,
@@ -46,6 +56,10 @@ export class KubeappsGrpcClient {
     return new PackagesServiceClientImpl(this.getGrpcClient());
   }
 
+  public getRepositoriesServiceClientImpl() {
+    return new RepositoriesServiceClientImpl(this.getGrpcClient());
+  }
+
   public getPluginsServiceClientImpl() {
     return new PluginsServiceClientImpl(this.getGrpcClient());
   }
@@ -59,18 +73,30 @@ export class KubeappsGrpcClient {
     return new ResourcesServiceClientImpl(this.getGrpcClient(token));
   }
 
-  // Plugins (packages) APIs
+  // Plugins (packages/repositories) APIs
   // TODO(agamez): ideally, these clients should be loaded automatically from a list of configured plugins
+
+  // Helm
   public getHelmPackagesServiceClientImpl() {
     return new HelmPackagesServiceClientImpl(this.getGrpcClient());
   }
+  public getHelmRepositoriesServiceClientImpl() {
+    return new HelmRepositoriesServiceClientImpl(this.getGrpcClient());
+  }
 
+  // KappController
   public getKappControllerPackagesServiceClientImpl() {
     return new KappControllerPackagesServiceClientImpl(this.getGrpcClient());
   }
-
+  public getKappControllerRepositoriesServiceClientImpl() {
+    return new KappControllerRepositoriesServiceClientImpl(this.getGrpcClient());
+  }
+  // Fluxv2
   public getFluxv2PackagesServiceClientImpl() {
     return new FluxV2PackagesServiceClientImpl(this.getGrpcClient());
+  }
+  public getFluxV2RepositoriesServiceClientImpl() {
+    return new FluxV2RepositoriesServiceClientImpl(this.getGrpcClient());
   }
 }
 

--- a/dashboard/src/shared/utils.ts
+++ b/dashboard/src/shared/utils.ts
@@ -106,14 +106,18 @@ export function getPluginName(plugin?: Plugin | string) {
   }
 }
 
-export function getPluginPackageName(plugin?: Plugin | string) {
+export function getPluginPackageName(plugin?: Plugin | PluginNames | string) {
   // Temporary case while operators are not supported as kubeapps apis plugin
   if (typeof plugin === "string") {
     switch (plugin) {
       case "chart":
-        return "Helm Chart";
       case "helm":
+      case PluginNames.PACKAGES_HELM:
         return "Helm Chart";
+      case PluginNames.PACKAGES_FLUX:
+        return "Helm Chart via Flux";
+      case PluginNames.PACKAGES_KAPP:
+        return "Carvel Package";
       case "operator":
         return "Operator";
       default:


### PR DESCRIPTION
### Description of the change

As part of the work required for #4764, this prequel PR adds minor stuff that I can easily have taken apart from my ongoing changes. Namely:

- Related to the Repos UI:
    - Add more information to the core API logs 
    - Add more str cases in getPluginPackageName 
    - Add repos api clients to KubeappsGrpcClient 
- Minor unrelated improvements
    - Handle uncaught `canI` rejections 
    - Remove "as unknown" in some types 
    - Return 0 if equals in a sort function 

### Benefits

Subsequent PRs will have less code to review :P

### Possible drawbacks

N/A

### Applicable issues

- related #4764

### Additional information

The changes are pretty unrelated to the actual repos API things, as they are mainly improvements on other parts of the code.
