### PR TITLE
New deployment timeout for Operators

### DIFF
--- a/integration/tests/operators/06-operator-deployment.spec.js
+++ b/integration/tests/operators/06-operator-deployment.spec.js
@@ -24,7 +24,7 @@ test("Deploys an Operator", async ({ page }) => {
   await page.click('cds-button:has-text("Deploy")');
 
   // Wait for operators to be deployed
-  await page.waitForTimeout(10000);
+  await page.waitForTimeout(utils.getDeploymentTimeout());
 
   // Wait for the operator to be ready to be used
   await page.click('a.nav-link:has-text("Catalog")');


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

Simply set global deployment timeout for test when deploying an operator.
Reasoning behind is that e2e tests where randomly failing due to operator not yet ready when the test continued after the waiting timeout.

Did 10 runs on CircleCI that can be checked [here](https://app.circleci.com/pipelines/github/vmware-tanzu/kubeapps?branch=4832-operators-e2e-tests&filter=all). None of those failed.

### Benefits

E2E test should not fail, at least not that often.

### Possible drawbacks

E2E may take a little more time, but due to operators being deployed actually.

### Applicable issues

- fixes #4832

