### PR TITLE
[pinniped-proxy] Create identity cert directly from x509.

### DIFF
--- a/cmd/pinniped-proxy/Cargo.lock
+++ b/cmd/pinniped-proxy/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+ "time",
  "winapi",
 ]
 
@@ -1012,6 +1013,7 @@ version = "0.0.0-devel"
 dependencies = [
  "anyhow",
  "base64",
+ "chrono",
  "http",
  "hyper",
  "hyper-tls",
@@ -1497,6 +1499,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/cmd/pinniped-proxy/Cargo.toml
+++ b/cmd/pinniped-proxy/Cargo.toml
@@ -13,6 +13,7 @@ build = "build.rs"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.13"
+chrono = "0.4"
 hyper = { version = "0.14", features = ["server"] }
 hyper-tls = "0.5"
 kube = { version = "0.73.0" }

--- a/cmd/pinniped-proxy/src/pinniped.rs
+++ b/cmd/pinniped-proxy/src/pinniped.rs
@@ -1,6 +1,5 @@
 // Copyright 2020-2022 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
-
 use std::convert::TryFrom;
 use std::env;
 
@@ -254,6 +253,7 @@ fn get_pinniped_login_api_group() -> String {
 mod tests {
     use super::*;
     use serial_test::serial;
+    use chrono::{Utc, TimeZone};
 
     const VALID_CERT_BASE64: &'static str = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJd01UQXlOakl6TXpBME5Wb1hEVE13TVRBeU5ESXpNekEwTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT1ZKCnFuOVBFZUp3UDRQYnI0cFo1ZjZKUmliOFZ5a2tOYjV2K1hzTVZER01aWGZLb293Y29IYjFwRWh5d0pzeDFiME4Kd2YvZ1JURi9maEgzT0drRnNQMlV2a0lHVytzNUlBd0sxMFRXYkN5VzAwT3lzVkdLcnl5bHNWcEhCWXBZRGJBcQpkdnQzc0FkcFJZaGlLZSs2NkVTL3dQNTdLV3g0SVdwZko0UGpyejh2NkJBWlptZ3o5ZzRCSFNMQkhpbTVFbTdYClBJTmpKL1RJTXFzVW1PR1ppUUNHR0ptRnQxZ21jQTd3eHZ0ZXg2ckkxSWdFNkh5NW10UzJ3NDZaMCtlVU1RSzgKSE9UdnI5aGFETnhJenVjbkduaFlCT2Z2U2VVaXNCR0pOUm5QbENydWx4b2NSZGI3N20rQUdzWW52QitNd2prVQpEbXNQTWZBelpSRHEwekhzcGEwQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFBWndybXJLa3FVaDJUYld2VHdwSWlOd0o1NzAKaU9lTVl2WWhNakZxTmt6Tk9OUW55c3lPd1laRGJFMDRrV3AxclRLNHVZaUh3NTJUc0cyelJsZ0QzMzNKaEtvUQpIVloyV1hUT3Z5U2RJaWl5bVpKM2N3d0p2T0lhMW5zZnhYY1NJakJnYnNzYXowMndpRCtlazRPdmlRZktjcXJpCnFQbWZabDZDSkk0NU1rd3JwTExFaTZkNVhGbkhDb3d4eklxQjBrUDhwOFlOaGJYWTNYY2JaNElvY2lMemRBamUKQ1l6NXFVSlBlSDJCcHNaM0JXNXRDbjcycGZYazVQUjlYOFRUTHh6aTA4SU9yYjgvRDB4Tnk3emQyMnVjNXM1bwoveXZIeEt6cXBiczVuRXJkT0JFVXNGWnBpUEhaVGc1dExmWlZ4TG00VjNTZzQwRWUyNFd6d09zaDNIOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=";
 
@@ -348,5 +348,93 @@ mod tests {
         let login_api_group = get_pinniped_login_api_group();
         assert_eq!(login_api_group, "login.concierge.foo.bar");
         Ok(())
+    }
+
+    // RSA cert and key generated using
+    // https://support.google.com/cloudidentity/answer/6342198?hl=en
+    const VALID_CERT_PEM: &'static str = "-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUBQl5lApAIWapfksb8y6nGWrvmWQwDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMjA2MDgwMjQ0NTdaFw0yMjA3
+MDgwMjQ0NTdaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQDKCpsDtZDgG7sgoMkTHFXfPEjJlfnWoDCWrC9DT3d7
+o36gOQrnXzfJvf8ySg6YWX0qbbMLL1kwfRTo2xlaQIed2N+JPLhKVsdAtl8wh0wx
+1ItgZQPzx5fdvjcBlcxWgxZovNwIv45Bsu3T2jh2qJmCXmq6Z/3Y8Kk+IGZvj8rT
+qZygRF9/UupVWFNUCTivQwB4mkjNxOvYYfJ1T0NidlfxIswXecn7JQzRApyTvwrh
+F4/pVXK4ZNy5U+ZrxJ5CLLMlng7FSeB2dBGTi1knaq9vtxwpXKM3ukvjoSq9lMu8
+Kfjs/W+V2g81ClvquOACel8D5+hgItpwLJRCkYuFvRSVAgMBAAGjUzBRMB0GA1Ud
+DgQWBBSDayGbQJejUul4VD0cHmNEFYKO7TAfBgNVHSMEGDAWgBSDayGbQJejUul4
+VD0cHmNEFYKO7TAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCQ
+Ypsr6ad4c0TBJsiCEaGCcWVtHAL2KqlGguhL+Ao69/VEI6Lg7UuMoBBGlAI6FAfQ
+XU+ndWsdY/3U8H2ZCpCP5muStqcYbj3ZNHxQhuNLQl/BL5wkr62nZ6M0sRrPDOXH
+xzv/gz4FwPlgO2Pxb1IwqkW1ZoSmU7lK+OJSFbaSsRVjClkoFT5gFxmKSauqzY+0
+BzItnYcwueDkUdgBvKPk4vDQ0NQEpGTOUHTXU6vh3Ioho38sQphNeNgEkTmz2UDk
+MOpW248fauBDkVOQi5AEWYiPG0KMGICk+Pg+gEdDCXrKMwGXN1ys9sxifOqIBFrz
+tGsw5ToC/b5hvjv96OYb
+-----END CERTIFICATE-----";
+
+    const VALID_KEY_PEM: &'static str = "-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDKCpsDtZDgG7sg
+oMkTHFXfPEjJlfnWoDCWrC9DT3d7o36gOQrnXzfJvf8ySg6YWX0qbbMLL1kwfRTo
+2xlaQIed2N+JPLhKVsdAtl8wh0wx1ItgZQPzx5fdvjcBlcxWgxZovNwIv45Bsu3T
+2jh2qJmCXmq6Z/3Y8Kk+IGZvj8rTqZygRF9/UupVWFNUCTivQwB4mkjNxOvYYfJ1
+T0NidlfxIswXecn7JQzRApyTvwrhF4/pVXK4ZNy5U+ZrxJ5CLLMlng7FSeB2dBGT
+i1knaq9vtxwpXKM3ukvjoSq9lMu8Kfjs/W+V2g81ClvquOACel8D5+hgItpwLJRC
+kYuFvRSVAgMBAAECggEANZ0w24Af7MiPFK52DUM0qmOF8TCCNukVW7ZfaF47F60g
+GgZpFVLYLAnmIYMzckw1AcBQhcRPx6U5mj0h8igzlLiLQRDC2r9CarK6edc9ae+7
++J11uggaDba/RAVrTv3EQZD0VsH2TwrbP5+l4h8FdWn2qnaUDzB1yM2yQSKIMThV
+UcnDCkDmlNw+o6rTYqi89uyagPOSdmXo+ebuvp5pu+fmQcRlCBGN3P40pS8t5EAe
+7wehYgOuJvbLawj8n/B7jVOmCY2dRtjBzeTLsrysvqtwoFq9m4qWsx2UwnfOMU4B
+XUY8EgA1meNjWZgZWLk2zEH/nqL7LIsqWd2Qr7x0dQKBgQDs0cwWxnxQq+Ku0tSy
+9HrNcNnk0+OULFDXEwkSfdIOJB5m2oeii1dgJ6TR7PGYfj1j9kIgQ1njmTVL8XgK
+QtjQgIyM0mVndnEW2T6U1eq4vwvLniCj/V73KGILjev2uuAP3VTXTEpZy9929Jkn
+7Lm46eAoxLJUrmKgaXYCUXMbtwKBgQDaZ7ikwLqtp9QBvn5UN996RD5Q57qjBov4
+sOV77cuhXfGJUoQnDBRryAcUdAUtNZZWiHLG4ovCGzuzIvzBUndTEPNAizGBmsep
+cpaysLwD450AjpmTAB7bSy1Xcj7hcSjl0Y9JIhATPH3iOUVnYFx8Cfk051BJtJCp
+r9zVkYoqEwKBgQDCM51IhAZH5Vyj/rJ7+i6GMGgO1Y/H37t/U9XZuyI5hHcF42jc
+66WAbaIkoEjSw5s2USiS6ohZMzdYirDkwUKpYPFhPdv4R1Gf6hD+3pl4XPqgRJEB
+yfJJfm1AimaZU1AQ0nETiTVjg+NB2n2KFv+KWwf+hqay+LpaT4F9jyt06wKBgDxR
+sRkvcV9Mnqzso4827y2hc2R823ry7+17TaXwgvDKNU8rzvvJxkoOMIZhlJxr1F2J
+yclMADVXuCE9ZHkwAWybndMRnlahHMubrisjzIl2b4Ib4CZNPjhqhtdD4kH5MsZm
+HiCgm7f0WQAFuTlXz7MiPgVybSYuDFYRD/ib/YCpAoGBAI4kCCy9yy3CCt8xKDes
+A1hAfFSMLKYFQgB5NGbJk6l/5qyUBmXUO/WJ/BzMi/RIGzp9w6HT3e2FAiS3jnMo
+fbMIp6gTs4+dKJM2o5YtCOQ4nAarWgNT5pRwo18C3/1FEhqRejBob2g9Kx9ymKwR
+mZu9A/ivt37pOQXm/HOX6tHB
+-----END PRIVATE KEY-----";
+
+    #[test]
+    fn test_identity_for_exchange() -> Result<()> {
+        let valid_credential: ClusterCredential = ClusterCredential {
+            client_certificate_data: String::from(VALID_CERT_PEM),
+            client_key_data: String::from(VALID_KEY_PEM),
+            expiration_timestamp: metav1::Time(Utc.timestamp(0, 0)),
+            token: Some(String::from("")),
+        };
+
+        let result = identity_for_exchange(&valid_credential);
+        match result {
+            Err(e) => anyhow::bail!("expected Ok, got {:#?}", e),
+            Ok(_) => {},
+        }
+
+        let cred_with_bad_cert = ClusterCredential {
+            client_certificate_data: String::from("foo"),
+            ..valid_credential.clone()
+        };
+
+        if identity_for_exchange(&cred_with_bad_cert).is_ok() {
+            anyhow::bail!("expected error");
+        }
+
+        let cred_with_bad_key = ClusterCredential {
+            client_key_data: String::from("foo"),
+            ..valid_credential.clone()
+        };
+
+        match identity_for_exchange(&cred_with_bad_key) {
+            Ok(_) => anyhow::bail!("expected error"),
+            Err(_) => Ok(()),
+        }
     }
 }

--- a/cmd/pinniped-proxy/src/pinniped.rs
+++ b/cmd/pinniped-proxy/src/pinniped.rs
@@ -15,7 +15,7 @@ use kube::{
 };
 use log::debug;
 use native_tls::Identity;
-use openssl::{pkcs12::Pkcs12, pkey::PKey, x509::X509};
+use openssl::{x509::X509};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use thiserror::Error;
@@ -125,25 +125,9 @@ pub async fn exchange_token_for_identity(
 }
 
 /// identity_for_exchange parses the JSON output of the credential exchange and returns the Identity.
-///
-/// Note: to create an identity, need to go via a pkcs12 currently.
-/// https://github.com/sfackler/rust-native-tls/issues/27#issuecomment-324262673
 fn identity_for_exchange(cred: &ClusterCredential) -> Result<Identity> {
-    let pkey = PKey::private_key_from_pem(cred.client_key_data.as_bytes())
-        .context("error creating private key from pem")?;
-    let x509 = X509::from_pem(cred.client_certificate_data.as_bytes())
-        .context("error creating x509 from pem")?;
-
-    let pkcs_cert = Pkcs12::builder()
-        .build("", "friendly-name", &pkey, &x509)
-        .context("Error building Pkcs12 from private key and x509")?;
-    let identity = Identity::from_pkcs12(
-        &pkcs_cert
-            .to_der()
-            .context("error creating der from pkcs12")?,
-        "",
-    )
-    .context("error creating identity from der-formatted pkcs12")?;
+    let identity = Identity::from_pkcs8(cred.client_certificate_data.as_bytes(), cred.client_key_data.as_bytes())
+        .context("error creating identity from x509")?;
     Ok(identity)
 }
 

--- a/script/makefiles/deploy-dev-for-pinniped.mk
+++ b/script/makefiles/deploy-dev-for-pinniped.mk
@@ -33,15 +33,17 @@ deploy-dependencies-for-pinniped: deploy-dex-for-pinniped deploy-openldap-for-pi
 		--from-literal=postgres-password=dev-only-fake-password
 
 deploy-pinniped:
-	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/v0.12.0/install-pinniped-concierge-crds.yaml
-	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/v0.12.0/install-pinniped-concierge.yaml
+	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/v0.17.0/install-pinniped-concierge-crds.yaml
+	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/v0.17.0/install-pinniped-concierge.yaml
 
 deploy-pinniped-additional:
-	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/v0.12.0/install-pinniped-concierge-crds.yaml
-	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/v0.12.0/install-pinniped-concierge.yaml
+	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/v0.17.0/install-pinniped-concierge-crds.yaml
+	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/v0.17.0/install-pinniped-concierge.yaml
 
 add-pinniped-jwt-authenticator:
 	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} apply -f ./site/content/docs/latest/reference/manifests/kubeapps-pinniped-jwt-authenticator.yaml
+
+add-pinniped-jwt-authenticator-additional:
 	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} apply -f ./site/content/docs/latest/reference/manifests/kubeapps-pinniped-jwt-authenticator.yaml
 
 delete-pinniped-jwt-authenticator:
@@ -53,13 +55,13 @@ delete-pinniped:
 	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} delete -f https://get.pinniped.dev/v0.7.0/install-pinniped-concierge.yaml
 
 deploy-dev-kubeapps-for-pinniped:
-	helm --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} install kubeapps ./chart/kubeapps --namespace kubeapps --create-namespace \
+	helm --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} upgrade --install kubeapps ./chart/kubeapps --namespace kubeapps --create-namespace \
 		--values ./site/content/docs/latest/reference/manifests/kubeapps-local-dev-values.yaml \
 		--set pinnipedProxy.enabled=true \
 		--values ./site/content/docs/latest/reference/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
 		--values ./site/content/docs/latest/reference/manifests/kubeapps-local-dev-additional-kind-cluster-for-pinniped.yaml
 
-deploy-dev-for-pinniped: deploy-dependencies-for-pinniped deploy-dev-kubeapps-for-pinniped deploy-pinniped-additional
+deploy-dev-for-pinniped: deploy-dependencies-for-pinniped deploy-dev-kubeapps-for-pinniped
 	@echo "\nYou can now simply open your browser at https://localhost/ to access Kubeapps!"
 	@echo "When logging in, you will be redirected to dex (with a self-signed cert) and can login with email as either of"
 	@echo "  kubeapps-operator@example.com:password"

--- a/site/content/docs/latest/reference/developer/pinniped-proxy.md
+++ b/site/content/docs/latest/reference/developer/pinniped-proxy.md
@@ -63,13 +63,13 @@ Next, follow the steps in [/docs/reference/developer/using-makefiles.md](../deve
 
 Next, replace `172.18.0.2` with the previous IP (and `172.18.0.3` with the next one) the following files: - [script/makefiles/deploy-dev.mk](https://github.com/vmware-tanzu/kubeapps/blob/main/script/makefiles/deploy-dev.mk) - [kubeapps-local-dev-additional-kind-cluster-for-pinniped.yaml](https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-local-dev-additional-kind-cluster-for-pinniped.yaml) - [kubeapps-local-dev-auth-proxy-values.yaml](https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-local-dev-auth-proxy-values.yaml) - [kubeapps-local-dev-dex-values.yaml](https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-local-dev-dex-values.yaml)
 
-### Launching the multi-cluster dev environment
+### Launching the dev environment
 
-- Run `make multi-cluster-kind-for-pinniped`.
+- Run `make cluster-kind-for-pinniped` or `make multi-cluster-kind-for-pinniped` for multi-cluster.
 - Update [https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-local-dev-additional-kind-cluster-for-pinniped.yaml](https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-local-dev-additional-kind-cluster-for-pinniped.yaml) copying the certificate-authority-data from the additional cluster (`~/.kube/kind-config-kubeapps-additional`) to the `certificate-authority-data` of the second cluster.
-- Run `make deploy-dev-for-pinniped`.
+- Run `make deploy-dev-for-pinniped` and additionally `make deploy-pinniped-additional` for multi-cluster.
 - Edit [https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-pinniped-jwt-authenticator.yaml](https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-pinniped-jwt-authenticator.yaml) with the `certificate-authority-data` from the main cluster (`~/.kube/kind-config-kubeapps`).
-- Run `make add-pinniped-jwt-authenticator`.
+- Run `make add-pinniped-jwt-authenticator` and additionally `make add-pinniped-jwt-authenticator-additional` for multi-cluster.
 - Open <https://localhost/> and login with `kubeapps-operator@example.com`/`password`
 
 > Note: make sure you are really copying `certificate-authority-data` and not the `client-certificate-data` or `client-certificate-data`. Otherwise, the setup will not work.


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Just a fly-by while getting setup with pinniped-proxy locally again, this PR does 3 things:

* Updates to use the latest pinniped version (0.17.0) in our dev environment
* Updates the dev environment targets to allow creating a single-cluster environment
* Simplifies the `identity_for_exchange` now that the underlying `native_tls::Identity` supports creating an identity cert directly from an x509.

### Benefits

Simpler code, easier dev env.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #2875

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

Although I've tested in real life, I'm keen to see if it's trivial to add a unit test for this also, so leaving in draft until I've tried.
