### PR TITLE
Add check for interval in Helm Repository API

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
@@ -51,6 +51,10 @@ func (s *Server) newRepo(ctx context.Context, repo *HelmRepository) (*corev1.Pac
 	if repo.repoType == "" || !slices.Contains(ValidRepoTypes, repo.repoType) {
 		return nil, status.Errorf(codes.InvalidArgument, "repository type [%s] not supported", repo.repoType)
 	}
+	// Helm repositories do not support intervals for reconciliation by now
+	if repo.interval > 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "interval is not supported for Helm repositories")
+	}
 	typedClient, err := s.clientGetter.Typed(ctx, repo.cluster)
 	if err != nil {
 		return nil, err
@@ -249,6 +253,10 @@ func (s *Server) updateRepo(ctx context.Context, repo *HelmRepository) (*corev1.
 	}
 	if repo.name.Name == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "repository name may not be empty")
+	}
+	// Helm repositories do not support intervals for reconciliation by now
+	if repo.interval > 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "interval is not supported for Helm repositories")
 	}
 	typedClient, err := s.clientGetter.Typed(ctx, repo.cluster)
 	if err != nil {

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
@@ -176,6 +176,18 @@ func TestAddPackageRepository(t *testing.T) {
 			statusCode: codes.InvalidArgument,
 		},
 		{
+			name: "check that interval is not used",
+			request: &corev1.AddPackageRepositoryRequest{
+				Name:            "bar",
+				Context:         &corev1.Context{Namespace: "foo", Cluster: KubeappsCluster},
+				Type:            "helm",
+				Url:             "http://example.com",
+				NamespaceScoped: true,
+				Interval:        1,
+			},
+			statusCode: codes.InvalidArgument,
+		},
+		{
 			name:             "simple add package repository scenario (HELM)",
 			request:          addRepoReqSimple("helm"),
 			expectedResponse: addRepoExpectedResp,
@@ -788,6 +800,14 @@ func TestUpdatePackageRepository(t *testing.T) {
 			name: "validate url",
 			requestCustomizer: func(request *corev1.UpdatePackageRepositoryRequest) *corev1.UpdatePackageRepositoryRequest {
 				request.Url = ""
+				return request
+			},
+			expectedStatusCode: codes.InvalidArgument,
+		},
+		{
+			name: "check that interval is not used",
+			requestCustomizer: func(request *corev1.UpdatePackageRepositoryRequest) *corev1.UpdatePackageRepositoryRequest {
+				request.Interval = 1
 				return request
 			},
 			expectedStatusCode: codes.InvalidArgument,


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

New repositories API adds field `interval` when adding/updating a repo.
It is not possible to map that field to any field in the existing CR `AppRepository`, and `syncJobPodTemplate` is not used anymore.

This PR adds a check for the Helm plugin to return error when `interval` has been specified.

### Benefits

Interval data posted to the API will not be swallowed and will produce an error.

### Possible drawbacks

N/A

### Applicable issues

None
