### PR TITLE
Remove unnecesary extra margin-top

### DIFF
--- a/dashboard/src/components/Layout/Layout.scss
+++ b/dashboard/src/components/Layout/Layout.scss
@@ -207,6 +207,10 @@
   border: 2px solid var(--cds-alias-object-border-color, #f1f1f1);
   margin: 0.625em 0;
   font-family: monospace;
+
+  p:first-child {
+    margin-top: 0;
+  }
 }
 
 .after-readme-button {


### PR DESCRIPTION
### Description of the change

As reported by @dud225, we were adding an extra margin in the installation notes box. This PR is to remove it.

### Benefits

> _(installation notes)_ to be absolutely perfect 

😛 

### Possible drawbacks

N/A

### Applicable issues

- related #4395

### Additional information

Before:
![image](https://user-images.githubusercontent.com/11535726/172833736-13f0a51c-111d-45ac-968b-fb230de4aa4d.png)

After:

![image](https://user-images.githubusercontent.com/11535726/172833515-7efe6597-55f1-45bc-ac77-a7dfca11ade0.png)
