### PR TITLE
Add expired value cache.

### DIFF
--- a/cmd/pinniped-proxy/Cargo.lock
+++ b/cmd/pinniped-proxy/Cargo.lock
@@ -59,6 +59,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async_once"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce4f10ea3abcd6617873bae9f91d1c5332b4a778bd9ce34d0cd517474c1de82"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +126,42 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cached"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aadf76ddea74bab35ebeb8f1eb115b9bc04eaee42d8acc0d5f477dee6b176c9a"
+dependencies = [
+ "async-trait",
+ "async_once",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "futures",
+ "hashbrown 0.12.1",
+ "lazy_static",
+ "once_cell",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bce0f37f9b77c6b93cdf3f060c89adca303d2ab052cacb3c3d1ab543e8cecd2f"
+dependencies = [
+ "cached_proc_macro_types",
+ "darling 0.13.4",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "cc"
@@ -169,12 +222,36 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.1",
+ "darling_macro 0.14.1",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
 ]
 
 [[package]]
@@ -193,11 +270,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.1",
  "quote",
  "syn",
 ]
@@ -428,6 +516,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "hashbrown"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,7 +679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -723,7 +817,7 @@ version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb405f0d39181acbfdc7c79e3fc095330c9b6465ab50aeb662d762e53b662f1"
 dependencies = [
- "darling",
+ "darling 0.14.1",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -1013,6 +1107,7 @@ version = "0.0.0-devel"
 dependencies = [
  "anyhow",
  "base64",
+ "cached",
  "chrono",
  "http",
  "hyper",

--- a/cmd/pinniped-proxy/Cargo.toml
+++ b/cmd/pinniped-proxy/Cargo.toml
@@ -13,6 +13,7 @@ build = "build.rs"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.13"
+cached = "0.34"
 chrono = "0.4"
 hyper = { version = "0.14", features = ["server"] }
 hyper-tls = "0.5"

--- a/cmd/pinniped-proxy/src/expired_value_cache.rs
+++ b/cmd/pinniped-proxy/src/expired_value_cache.rs
@@ -1,0 +1,207 @@
+// Copyright 2020-2022 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use cached::Cached;
+
+pub trait Expired {
+    fn has_expired(&self) -> bool;
+}
+
+// Implement our ExpiredValueCache which uses the returned values own
+// trait to determine whether it has expired, rather than a set timestamp.
+struct ExpiredValueCache<K: Hash + Eq, V: Expired> {
+    store: HashMap<K, V>,
+    capacity: usize,
+    hits: u64,
+    misses: u64,
+}
+impl<K: Hash + Eq, V: Expired> ExpiredValueCache<K, V> {
+    pub fn with_capacity(size: usize) -> ExpiredValueCache<K, V> {
+        ExpiredValueCache {
+            store: HashMap::with_capacity(size),
+            capacity: size,
+            hits: 0,
+            misses: 0,
+        }
+    }
+}
+
+impl<K: Hash + Eq, V: Expired> Cached<K, V> for ExpiredValueCache<K, V> {
+    fn cache_get(&mut self, k: &K) -> Option<&V> {
+        let optv = self.store.get(k);
+        // If it has expired, delete the cached entry and return none.
+        match optv {
+            Some(v) => {
+                if v.has_expired() {
+                    self.cache_remove(k);
+                    self.misses += 1;
+                    return None;
+                }
+            },
+            None => {
+                self.misses += 1;
+                return None
+            },
+        }
+        // We cannot simply return optv here because the ownership of the value
+        // moved to the self.cache_remove(k), so optv cannot be referenced after
+        // that line.
+        self.hits += 1;
+        self.store.get(k)
+    }
+
+    fn cache_get_mut(&mut self, k: &K) -> Option<&mut V> {
+        let optv = self.store.get(k);
+        // If it has expired, delete the cached entry and return none.
+        match optv {
+            Some(v) => {
+                if v.has_expired() {
+                    self.cache_remove(k);
+                    self.misses += 1;
+                    return None;
+                }
+            },
+            None => {
+                self.misses += 1;
+                return None
+            }
+        }
+        self.hits += 1;
+        self.store.get_mut(k)
+    }
+
+    fn cache_get_or_set_with<F: FnOnce() -> V>(&mut self, k: K, f: F) -> &mut V {
+        self.store.entry(k).or_insert_with(f)
+    }
+    fn cache_set(&mut self, k: K, v: V) -> Option<V> {
+        self.store.insert(k, v)
+    }
+    fn cache_remove(&mut self, k: &K) -> Option<V> {
+        self.store.remove(k)
+    }
+    fn cache_clear(&mut self) {
+        self.store.clear();
+    }
+    fn cache_reset(&mut self) {
+        self.store = HashMap::with_capacity(self.capacity);
+    }
+    fn cache_size(&self) -> usize {
+        self.store.len()
+    }
+    fn cache_hits(&self) -> Option<u64> {
+        Some(self.hits)
+    }
+    fn cache_misses(&self) -> Option<u64> {
+        Some(self.misses)
+    }
+    fn cache_reset_metrics(&mut self) {
+        self.misses = 0;
+        self.hits = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[derive(Clone)]
+    pub struct NewsArticle {
+        slug: String,
+        is_expired: bool,
+    }
+
+    impl Expired for NewsArticle {
+        fn has_expired(&self) -> bool {
+            self.is_expired
+        }
+    }
+
+    const EXPIRED_SLUG: &str = "expired_slug";
+    const UNEXPIRED_SLUG: &str = "unexpired_slug";
+
+    cached_result! {
+        EXPIRED_VALUE_CACHE: ExpiredValueCache<String, NewsArticle> = ExpiredValueCache::with_capacity(3);
+        fn fetch_article(slug: String) -> Result<NewsArticle, ()> = {
+            match slug.as_str() {
+                EXPIRED_SLUG => Ok(NewsArticle {
+                    slug: String::from(EXPIRED_SLUG),
+                    is_expired: true,
+                }),
+                UNEXPIRED_SLUG => Ok(NewsArticle {
+                    slug: String::from(UNEXPIRED_SLUG),
+                    is_expired: false,
+                }),
+                _ => Err(())
+            }
+        }
+    }
+
+    #[test]
+    #[serial(cachetest)]
+    fn test_expired_article_returned_with_miss() {
+        {
+            let mut cache = EXPIRED_VALUE_CACHE.lock().unwrap();
+            cache.cache_reset();
+            cache.cache_reset_metrics();
+        }
+        let expired_article = fetch_article(EXPIRED_SLUG.to_string());
+
+        assert!(expired_article.is_ok());
+        assert_eq!(EXPIRED_SLUG, expired_article.unwrap().slug.as_str());
+
+        // The article was fetched due to a cache miss and the result cached.
+        {
+            let cache = EXPIRED_VALUE_CACHE.lock().unwrap();
+            assert_eq!(1, cache.cache_size());
+            assert_eq!(cache.cache_hits(), Some(0));
+            assert_eq!(cache.cache_misses(), Some(1));
+        }
+
+        let _ = fetch_article(EXPIRED_SLUG.to_string());
+
+        // The article was fetched again as it had expired.
+        {
+            let cache = EXPIRED_VALUE_CACHE.lock().unwrap();
+            assert_eq!(1, cache.cache_size());
+            assert_eq!(cache.cache_hits(), Some(0));
+            assert_eq!(cache.cache_misses(), Some(2));
+        }
+    }
+
+    #[test]
+    #[serial(cachetest)]
+    fn test_unexpired_article_returned_with_hit() {
+        {
+            let mut cache = EXPIRED_VALUE_CACHE.lock().unwrap();
+            cache.cache_reset();
+            cache.cache_reset_metrics();
+        }
+        let unexpired_article = fetch_article(UNEXPIRED_SLUG.to_string());
+
+        assert!(unexpired_article.is_ok());
+        assert_eq!(UNEXPIRED_SLUG, unexpired_article.unwrap().slug.as_str());
+
+        // The article was fetched due to a cache miss and the result cached.
+        {
+            let cache = EXPIRED_VALUE_CACHE.lock().unwrap();
+            assert_eq!(1, cache.cache_size());
+            assert_eq!(cache.cache_hits(), Some(0));
+            assert_eq!(cache.cache_misses(), Some(1));
+        }
+
+        let cached_article = fetch_article(UNEXPIRED_SLUG.to_string());
+        assert!(cached_article.is_ok());
+        assert_eq!(UNEXPIRED_SLUG, cached_article.unwrap().slug.as_str());
+
+        // The article was not fetched but returned as a hit from the cache.
+        {
+            let cache = EXPIRED_VALUE_CACHE.lock().unwrap();
+            assert_eq!(1, cache.cache_size());
+            assert_eq!(cache.cache_hits(), Some(1));
+            assert_eq!(cache.cache_misses(), Some(1));
+        }
+    }
+}

--- a/cmd/pinniped-proxy/src/expired_value_cache.rs
+++ b/cmd/pinniped-proxy/src/expired_value_cache.rs
@@ -1,5 +1,10 @@
 // Copyright 2020-2022 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
+
+// NOTE: This may be better in the upstream cached repository. I've created
+// an issue to check with the author, otherwise it can stay here or I may
+// spin it off to a separate crate.
+// https://github.com/jaemk/cached/issues/115
 use std::collections::HashMap;
 use std::hash::Hash;
 

--- a/cmd/pinniped-proxy/src/main.rs
+++ b/cmd/pinniped-proxy/src/main.rs
@@ -1,8 +1,5 @@
 // Copyright 2020-2022 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
-#[macro_use]
-extern crate cached;
-
 use std::convert::Infallible;
 use std::fs;
 

--- a/cmd/pinniped-proxy/src/main.rs
+++ b/cmd/pinniped-proxy/src/main.rs
@@ -1,5 +1,6 @@
 // Copyright 2020-2022 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
+
 use std::convert::Infallible;
 use std::fs;
 

--- a/cmd/pinniped-proxy/src/main.rs
+++ b/cmd/pinniped-proxy/src/main.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2022 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
+#[macro_use]
+extern crate cached;
 
 use std::convert::Infallible;
 use std::fs;
@@ -14,6 +16,7 @@ use structopt::StructOpt;
 
 // Ensure the root crate is aware of the child modules.
 mod cli;
+mod expired_value_cache;
 mod https;
 mod logging;
 mod pinniped;


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Adds an implementation of the [cached trait](https://docs.rs/cached/latest/cached/trait.Cached.html) that allows a cached value to determine if it has expired or not. If it has expired when fetched from the cache, it is removed.

### Benefits

<!-- What benefits will be realized by the code change? -->

We can use this for caching the pinniped `ClusterCredential` rather than fetching it for every user request.

### Possible drawbacks

<!-- Describe any known limitations with your change -->


### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #2875

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
