### PR TITLE
Fix typo in md

### DIFF
--- a/site/content/docs/latest/reference/developer/release-process.md
+++ b/site/content/docs/latest/reference/developer/release-process.md
@@ -22,7 +22,7 @@ For building the [development container images](https://hub.docker.com/u/kubeapp
   - [\_/rust](https://hub.docker.com/_/rust) for building the binary.
   - [bitnami/minideb](https://hub.docker.com/r/bitnami/minideb) for running it.
 
-In some images, some build-time linters are used (e.g., `buf` linter, etc.). When updating the base container image, these linters (namely, `BUF_VERSION` - [source]((https://github.com/bufbuild/buf/releases/))) _should_ be updated to the latest minor/patch version.
+In some images, some build-time linters are used (e.g., `buf` linter, etc.). When updating the base container image, these linters (namely, `BUF_VERSION` - [source](https://github.com/bufbuild/buf/releases/)) _should_ be updated to the latest minor/patch version.
 
 > As part of this release process, these image tags _must_ be updated to the latest minor/patch version. In case of a major version, the change _should_ be tracked in a separate PR.
 > **Note**: as the official container images are those being created by Bitnami, we _should_ ensure that we are using the same major version as they are using.


### PR DESCRIPTION
### Description of the change

Yesterday I wrongly merged #4911 with a typo (double brackets) in an md file. This was preventing the website from being rendered. I assumed it was a transient error... sorry, my bad 😅 

### Benefits

Netlify checks will work again

### Possible drawbacks

N/A

### Applicable issues

N/A
### Additional information

N/A
