### PR TITLE
Add TLS support to the pinniped-proxy directly.

### DIFF
--- a/cmd/pinniped-proxy/Cargo.lock
+++ b/cmd/pinniped-proxy/Cargo.lock
@@ -1126,6 +1126,7 @@ dependencies = [
  "serial_test",
  "structopt",
  "thiserror",
+ "tls-listener",
  "tokio",
  "tokio-native-tls",
  "tokio-test",
@@ -1620,6 +1621,20 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tls-listener"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d4ff21187d434ac7709bfc7441ca88f63681247e5ad99f0f08c8c91ddc103d"
+dependencies = [
+ "futures-util",
+ "hyper",
+ "pin-project-lite",
+ "thiserror",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "tokio"

--- a/cmd/pinniped-proxy/Cargo.toml
+++ b/cmd/pinniped-proxy/Cargo.toml
@@ -28,6 +28,7 @@ pretty_env_logger = "0.4"
 reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tls-listener = { version = "0.5", features = ["native-tls", "hyper-h1"] }
 structopt = "0.3"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/cmd/pinniped-proxy/src/cli.rs
+++ b/cmd/pinniped-proxy/src/cli.rs
@@ -28,4 +28,18 @@ pub struct Options {
         help = "Specify the file path to the cert authority for the default api server https://kubernetes.default"
     )]
     pub default_ca_cert: String,
+    #[structopt(
+        long = "proxy-tls-cert",
+        env = "PINNIPED_PROXY_TLS_CERT",
+        default_value = "",
+        help = "Specify the file path to a PEM encoded TLS certificate. Providing the cert and key implies listening for TLS requests."
+    )]
+    pub proxy_tls_cert: String,
+    #[structopt(
+        long = "proxy-tls-cert-key",
+        env = "PINNIPED_PROXY_TLS_CERT_KEY",
+        default_value = "",
+        help = "Specify the file path to a PEM encoded TLS certificate key. Providing the cert and key implies listening for TLS requests."
+    )]
+    pub proxy_tls_cert_key: String,
 }

--- a/cmd/pinniped-proxy/src/main.rs
+++ b/cmd/pinniped-proxy/src/main.rs
@@ -35,11 +35,14 @@ async fn main() -> Result<()> {
     let addr = ([0, 0, 0, 0], opt.port).into();
 
     let with_tls = opt.proxy_tls_cert != "" && opt.proxy_tls_cert_key != "";
+    if !with_tls && (opt.proxy_tls_cert != "" || opt.proxy_tls_cert_key != "") {
+        panic!("If configuring TLS support, you must set both --proxy-tls-cert and --proxy-tls-cert-key");
+    }
 
     // Run the server for ever. If it returns with an error, return the
     // result, otherwise, if it completes, we return Ok.
     if with_tls {
-        info!("Configuring with TLS cert {} and key {}", opt.proxy_tls_cert, opt.proxy_tls_cert_key);
+        info!("Configuring with TLS cert filepath {} and key filepath {}", opt.proxy_tls_cert, opt.proxy_tls_cert_key);
         // For every incoming connection, we make a new hyper `Service` to handle
         // all incoming HTTP requests on that connection. This is done by passing a
         // closure to the hyper `make_service_fn` which returns our custom `make_svc`

--- a/cmd/pinniped-proxy/src/main.rs
+++ b/cmd/pinniped-proxy/src/main.rs
@@ -8,9 +8,11 @@ use anyhow::{Context, Result};
 use hyper::{
     service::{make_service_fn, service_fn},
     Server,
+    server::conn::AddrIncoming,
 };
 use log::info;
 use structopt::StructOpt;
+use tls_listener::TlsListener;
 
 // Ensure the root crate is aware of the child modules.
 mod cli;
@@ -19,6 +21,8 @@ mod https;
 mod logging;
 mod pinniped;
 mod service;
+mod tls_config;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     pretty_env_logger::init();
@@ -28,34 +32,51 @@ async fn main() -> Result<()> {
     let default_ca_data = fs::read_to_string(opt.default_ca_cert.clone())
         .with_context(|| format!("unable to load default-ca-cert at {}", opt.default_ca_cert))?;
 
-    // For every incoming connection, we make a new hyper `Service` to handle
-    // all incoming HTTP requests on that connection. This is done by passing a
-    // closure to the hyper `make_service_fn` which returns our custom `make_svc`
-    // function that can be used for each connection.
-    let make_svc = make_service_fn(|_conn| {
-        let default_ca_data = default_ca_data.clone();
-        // The closure just returns an async block that runs a service to handle
-        // all requests for the connection.
-        async {
-            // `service_fn` is a helper from the hyper crate which converts a
-            // function that returns a Response into a `Service`. We pass a
-            // closure to service_fn here so we can pass the default certificate
-            // authority data.
-            Ok::<_, Infallible>(service_fn(move |req| {
-                service::proxy(req, default_ca_data.clone().into_bytes())
-            }))
-        }
-    });
-
     let addr = ([0, 0, 0, 0], opt.port).into();
 
-    let server = Server::bind(&addr).serve(make_svc);
-
-    info!("Listening on http://{}", addr);
+    let with_tls = opt.proxy_tls_cert != "" && opt.proxy_tls_cert_key != "";
 
     // Run the server for ever. If it returns with an error, return the
     // result, otherwise, if it completes, we return Ok.
-    server.await?;
+    if with_tls {
+        // For every incoming connection, we make a new hyper `Service` to handle
+        // all incoming HTTP requests on that connection. This is done by passing a
+        // closure to the hyper `make_service_fn` which returns our custom `make_svc`
+        // function that can be used for each connection.
+        // The closure just returns an async block that runs a service to handle
+        // all requests for the connection.
+        // `service_fn` is a helper from the hyper crate which converts a
+        // function that returns a Response into a `Service`. We pass a closure
+        // to service_fn here so we can pass the default certificate authority
+        // data.
+        let make_svc = make_service_fn(|_conn| {
+            let default_ca_data = default_ca_data.clone();
+            async {
+                Ok::<_, Infallible>(service_fn(move |req| {
+                    service::proxy(req, default_ca_data.clone().into_bytes())
+                }))
+            }
+        });
+
+        let incoming = TlsListener::new(tls_config::tls_acceptor(opt.proxy_tls_cert, opt.proxy_tls_cert_key)?, AddrIncoming::bind(&addr)?);
+        let server = Server::builder(incoming).serve(make_svc);
+        info!("Listening on https://{}", addr);
+        server.await?;
+    } else {
+        // The make_svc function needs to be defined in this scope as the
+        // compiler uses a different type for the non-tls version.
+        let make_svc = make_service_fn(|_conn| {
+            let default_ca_data = default_ca_data.clone();
+            async {
+                Ok::<_, Infallible>(service_fn(move |req| {
+                    service::proxy(req, default_ca_data.clone().into_bytes())
+                }))
+            }
+        });
+        let server = Server::bind(&addr).serve(make_svc);
+        info!("Listening on http://{}", addr);
+        server.await?;
+    }
 
     Ok(())
 }

--- a/cmd/pinniped-proxy/src/tls_config.rs
+++ b/cmd/pinniped-proxy/src/tls_config.rs
@@ -1,5 +1,6 @@
-// Copyright 2020-2022 the Kubeapps contributors.
+// Copyright 2022 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
+
 use tokio_native_tls::native_tls::{Identity, TlsAcceptor};
 use anyhow::Result;
 use std::fs;

--- a/cmd/pinniped-proxy/src/tls_config.rs
+++ b/cmd/pinniped-proxy/src/tls_config.rs
@@ -1,0 +1,13 @@
+// Copyright 2020-2022 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+use tokio_native_tls::native_tls::{Identity, TlsAcceptor};
+use anyhow::Result;
+use std::fs;
+
+pub fn tls_acceptor(cert_file: String, key_file: String) -> Result<tokio_native_tls::TlsAcceptor> {
+    let identity = Identity::from_pkcs8(
+        fs::read_to_string(cert_file).expect("Unable to read cert file as PKCS#8 PEM").as_bytes(),
+        fs::read_to_string(key_file).expect("Unable to read key file as PKCS#8 PEM").as_bytes()
+    )?;
+    Ok(TlsAcceptor::builder(identity).build()?.into())
+}


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

After playing around with different options, this appears to be the simplest way to add tls support to pinniped-proxy without breaking the existing non-tls setup.

I'm leaving this as a draft until I figure out how TLS on the related service will interact with this. After that, it should just be updating the api server to be able to trust the cert, then the related chart changes.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
