### PR TITLE
Add fix for Helm charts versions ordering

### DIFF
--- a/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go
@@ -342,6 +342,27 @@ func TestPackageAppVersionsSummary(t *testing.T) {
 				Minor: 0,
 				Patch: 0},
 		},
+		{
+			name: "it includes latest versions in right order",
+			chart_versions: []models.ChartVersion{
+				{Version: "6.1.3", AppVersion: DefaultAppVersion},
+				{Version: "6.0.0", AppVersion: DefaultAppVersion},
+				{Version: "6.0.3", AppVersion: DefaultAppVersion},
+				{Version: "6.1.6", AppVersion: DefaultAppVersion},
+				{Version: "5.2.1", AppVersion: DefaultAppVersion},
+				{Version: "6.1.4", AppVersion: DefaultAppVersion},
+				{Version: "6.1.5", AppVersion: DefaultAppVersion},
+			},
+			version_summary: []*corev1.PackageAppVersion{
+				{PkgVersion: "6.1.6", AppVersion: DefaultAppVersion},
+				{PkgVersion: "6.1.5", AppVersion: DefaultAppVersion},
+				{PkgVersion: "6.1.4", AppVersion: DefaultAppVersion},
+				{PkgVersion: "6.0.3", AppVersion: DefaultAppVersion},
+				{PkgVersion: "6.0.0", AppVersion: DefaultAppVersion},
+				{PkgVersion: "5.2.1", AppVersion: DefaultAppVersion},
+			},
+			input_versions_in_summary: GetDefaultVersionsInSummary(),
+		},
 	}
 
 	opts := cmpopts.IgnoreUnexported(corev1.PackageAppVersion{})

--- a/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go
@@ -343,7 +343,7 @@ func TestPackageAppVersionsSummary(t *testing.T) {
 				Patch: 0},
 		},
 		{
-			name: "it includes latest versions in right order",
+			name: "it includes latest versions ordered (descending) by package version",
 			chart_versions: []models.ChartVersion{
 				{Version: "6.1.3", AppVersion: DefaultAppVersion},
 				{Version: "6.0.0", AppVersion: DefaultAppVersion},


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

This bugfix tackles the issue of `GetAvailablePackageVersions` in Helm direct plugin not returning the correct versions list when the input versions are not ordered.

We had all input values in our tests correctly sorted, which might not be the case on runtime.
[See here.](https://github.com/vmware-tanzu/kubeapps/blob/main/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go#L31)

Solution done here is to sort versions first thing in [PackageAppVersionsSummary](https://github.com/vmware-tanzu/kubeapps/blob/main/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils.go#L57).

### Benefits

Versions returned by `GetAvailablePackageVersions` should be correct now.

### Possible drawbacks

Solution modifies `pkgutils.PackageAppVersionsSummary` function, which applies to Flux plugin as well, although it should not break anything.

### Applicable issues

- fixes #4950
