### PR TITLE
Update chart to support TLS for pinniped-proxy

### DIFF
--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -474,6 +474,8 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `pinnipedProxy.defaultAuthenticatorType`              | Specify the (default) authenticator type                                                     | `JWTAuthenticator`        |
 | `pinnipedProxy.defaultAuthenticatorName`              | Specify the (default) authenticator name                                                     | `jwt-authenticator`       |
 | `pinnipedProxy.defaultPinnipedAPISuffix`              | Specify the (default) API suffix                                                             | `pinniped.dev`            |
+| `pinnipedProxy.TLSSecret`                             | Specify an optional TLS secret with which to proxy requests                                  | `""`                      |
+| `pinnipedProxy.CACert`                                | Specify the TLS CA cert config map which                                                     | `""`                      |
 | `pinnipedProxy.lifecycleHooks`                        | for the Pinniped Proxy container(s) to automate configuration before or after startup        | `{}`                      |
 | `pinnipedProxy.command`                               | Override default container command (useful when using custom images)                         | `[]`                      |
 | `pinnipedProxy.args`                                  | Override default container args (useful when using custom images)                            | `[]`                      |

--- a/chart/kubeapps/templates/frontend/deployment.yaml
+++ b/chart/kubeapps/templates/frontend/deployment.yaml
@@ -236,6 +236,10 @@ spec:
           {{- else }}
           command:
             - pinniped-proxy
+            {{- if .Values.pinnipedProxy.TLSSecret }}
+            - --proxy-tls-cert=/etc/pinniped-tls/tls.crt
+            - --proxy-tls-cert-key=/etc/pinniped-tls/tls.key
+            {{- end }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
@@ -274,9 +278,15 @@ spec:
           {{- if .Values.pinnipedProxy.resources }}
           resources: {{- toYaml .Values.pinnipedProxy.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.pinnipedProxy.extraVolumeMounts }}
-          volumeMounts: {{- include "common.tplvalues.render" (dict "value" .Values.pinnipedProxy.extraVolumeMounts "context" $) | nindent 12 }}
-          {{- end }}
+          volumeMounts:
+            {{- if .Values.pinnipedProxy.TLSSecret }}
+            - name: pinniped-tls-secret
+              mountPath: "/etc/pinniped-tls"
+              readOnly: true
+            {{- end }}
+            {{- if .Values.pinnipedProxy.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.pinnipedProxy.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
         {{- end }}
         {{- if .Values.frontend.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.frontend.sidecars "context" $) | nindent 8 }}
@@ -285,6 +295,11 @@ spec:
         - name: vhost
           configMap:
             name: {{ template "kubeapps.frontend-config.fullname" . }}
+        {{- if .Values.pinnipedProxy.TLSSecret }}
+        - name: pinniped-tls-secret
+          secret:
+            secretName: {{ .Values.pinnipedProxy.TLSSecret }}
+        {{- end }}
         {{- if .Values.frontend.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.frontend.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -103,7 +103,10 @@ spec:
             - --plugin-config-path=/config/kubeapps-apis/plugins.conf
             {{- end }}
             {{- if .Values.pinnipedProxy.enabled }}
-            - --pinniped-proxy-url={{ printf "http://%s.%s:%d" (include "kubeapps.pinniped-proxy.fullname" .) .Release.Namespace (int .Values.pinnipedProxy.service.ports.pinnipedProxy) }}
+            - --pinniped-proxy-url={{ printf "http%s://%s.%s:%d" (eq .Values.pinnipedProxy.CACert "" | ternary "" "s") (include "kubeapps.pinniped-proxy.fullname" .) .Release.Namespace (int .Values.pinnipedProxy.service.ports.pinnipedProxy) }}
+            {{- if .Values.pinnipedProxy.CACert }}
+            - --pinniped-proxy-ca-cert=/etc/pinniped-proxy-tls/ca.crt
+            {{- end }}
             {{- end }}
             - --global-repos-namespace={{ include "kubeapps.globalReposNamespace" . }}
             {{- if .Values.kubeappsapis.qps }}
@@ -209,6 +212,10 @@ spec:
             - name: plugins-config
               mountPath: /config/kubeapps-apis
           {{- end }}
+          {{- if .Values.pinnipedProxy.CACert }}
+            - name: pinniped-proxy-ca-cert
+              mountPath: /etc/pinniped-proxy-tls
+          {{- end }}
           {{- if .Values.kubeappsapis.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -227,6 +234,11 @@ spec:
         - name: plugins-config
           configMap:
             name: {{ template "kubeapps.kubeappsapis.fullname" . }}-configmap
+      {{- end }}
+      {{- if .Values.pinnipedProxy.CACert }}
+        - name: pinniped-proxy-ca-cert
+          configMap:
+            name: {{ .Values.pinnipedProxy.CACert }}
       {{- end }}
       {{- if .Values.kubeappsapis.extraVolumes }}
       {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.extraVolumes "context" $) | nindent 8 }}

--- a/chart/kubeapps/templates/kubeops/deployment.yaml
+++ b/chart/kubeapps/templates/kubeops/deployment.yaml
@@ -93,7 +93,10 @@ spec:
             - --clusters-config-path=/config/clusters.conf
             {{- end }}
             {{- if .Values.pinnipedProxy.enabled }}
-            - --pinniped-proxy-url={{ printf "http://%s.%s:%d" (include "kubeapps.pinniped-proxy.fullname" .) .Release.Namespace (int .Values.pinnipedProxy.service.ports.pinnipedProxy) }}
+            - --pinniped-proxy-url={{ printf "http%s://%s.%s:%d" (eq .Values.pinnipedProxy.CACert "" | ternary "" "s") (include "kubeapps.pinniped-proxy.fullname" .) .Release.Namespace (int .Values.pinnipedProxy.service.ports.pinnipedProxy) }}
+            {{- if .Values.pinnipedProxy.CACert }}
+            - --pinniped-proxy-ca-cert=/etc/pinniped-proxy-tls/ca.crt
+            {{- end }}
             {{- end }}
             {{- if .Values.kubeops.burst }}
             - --burst={{ .Values.kubeops.burst }}
@@ -171,6 +174,10 @@ spec:
             {{- if .Values.kubeops.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.kubeops.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
+            {{- if .Values.pinnipedProxy.CACert }}
+            - name: pinniped-proxy-ca-cert
+              mountPath: /etc/pinniped-proxy-tls
+            {{- end }}
         {{- if .Values.kubeops.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.kubeops.sidecars "context" $) | trim | nindent 8 }}
         {{- end }}
@@ -181,6 +188,11 @@ spec:
             name: {{ template "kubeapps.clusters-config.fullname" . }}
         - name: ca-certs
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.pinnipedProxy.CACert }}
+        - name: pinniped-proxy-ca-cert
+          configMap:
+            name: {{ .Values.pinnipedProxy.CACert }}
         {{- end }}
         {{- if .Values.kubeops.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.kubeops.extraVolumes "context" $) | nindent 8 }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1581,6 +1581,10 @@ pinnipedProxy:
   ## @param pinnipedProxy.defaultPinnipedAPISuffix Specify the (default) API suffix
   ##
   defaultPinnipedAPISuffix: pinniped.dev
+  ## @param pinnipedProxy.TLSSecret Specify an optional TLS secret with which to proxy requests
+  TLSSecret: ""
+  ## @param pinnipedProxy.CACert Specify the TLS CA cert which clients of pinniped proxy should use with tls requests
+  CACert: ""
   ## @param pinnipedProxy.lifecycleHooks for the Pinniped Proxy container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1582,8 +1582,12 @@ pinnipedProxy:
   ##
   defaultPinnipedAPISuffix: pinniped.dev
   ## @param pinnipedProxy.TLSSecret Specify an optional TLS secret with which to proxy requests
+  ##
   TLSSecret: ""
-  ## @param pinnipedProxy.CACert Specify the TLS CA cert which clients of pinniped proxy should use with tls requests
+  ## @param pinnipedProxy.CACert Specify the TLS CA cert config map which
+  ## clients of pinniped proxy should use with tls requests. This config map
+  ## must contain a ca.crt key with the CA cert content as the value.
+  ##
   CACert: ""
   ## @param pinnipedProxy.lifecycleHooks for the Pinniped Proxy container(s) to automate configuration before or after startup
   ##

--- a/site/content/docs/latest/howto/OIDC/using-an-OIDC-provider-with-pinniped.md
+++ b/site/content/docs/latest/howto/OIDC/using-an-OIDC-provider-with-pinniped.md
@@ -118,6 +118,36 @@ clusters:
       enabled: true
 ```
 
+### Running the Pinniped Proxy service over TLS
+
+By default, the pinniped-proxy service is an http service, with requests from the kubeapps-apis backend transmitted in clear text to the proxy (all within the cluster). If you are using pinniped-proxy in a secure environment where you want to minimize internal clear-text communication of credentials, you can optionally choose to configure the pinniped-proxy service to accept TLS connections only.
+
+You will need to provide a TLS certificate and key for the internal host name of the pinniped-proxy service, as well as a certificate authority for the clients of the pinniped-proxy service to use.
+
+For example, if you have the development tool [mkcert](https://github.com/FiloSottile/mkcert), you can generate the TLS certificate and key and then create the Kubernetes TLS secret with:
+
+```console
+mkcert kubeapps-internal-pinniped-proxy.kubeapps
+
+kubectl -n kubeapps create secret tls pinniped-proxy-tls --cert kubeapps-internal-pinniped-proxy.kubeapps.pem --key kubeapps-internal-pinniped-proxy.kubeapps-key.pem
+```
+
+Then create a `ConfigMap` with the certificate authority:
+
+```console
+kubectl create configmap -n kubeapps pinniped-proxy-ca --from-file ca.crt=$HOME/.local/share/mkcert/rootCA.pem
+```
+
+and finally configure Kubeapps' `pinniped-proxy` service to use TLS and the backend clients of `pinniped-proxy` to use the CA cert by adding the following to your chart configuration:
+
+```yaml
+pinnipedProxy:
+  tlsSecret: pinniped-proxy-tls
+  CACert: pinniped-proxy-ca
+```
+
+Note that this does not eliminate internal clear-text communication of credentials within the cluster because currently the `oauth2-proxy` service communicates with the `kubeapps-apis` backend over http with the user `id_token` in the headers.
+
 ## Debugging auth failures when using OIDC
 
 For general OIDC issues, have a look at [this OIDC debugging guide](./OAuth2OIDC-debugging.md).


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Following on from #4958, this PR updates the kubeapps chart to:
 - supply the pinniped-proxy service with the tls cert and key, when the secret is specified
 - supply the clients of pinniped-proxy (kubeappsapis, and currently still kubeops) with the related CA cert.

### Benefits

<!-- What benefits will be realized by the code change? -->

The pinniped-proxy service can run as a TLS web service, when configured so.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #2268 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
