### PR TITLE
Remove temporary cmd arg for assetsvc

### DIFF
--- a/cmd/kubeops/cmd/root.go
+++ b/cmd/kubeops/cmd/root.go
@@ -52,12 +52,7 @@ func init() {
 	setFlags(rootCmd)
 }
 
-// TODO(agamez): remove this after the v2.4.6 release
-var assetsvcurlDeprecated string
-
 func setFlags(c *cobra.Command) {
-	// TODO(agamez): remove 'assetsvc-url' after the v2.4.6 release
-	c.Flags().StringVar(&assetsvcurlDeprecated, "assetsvc-url", "", "(DEPRECATED)")
 	c.Flags().StringVar(&serveOpts.HelmDriverArg, "helm-driver", "", "which Helm driver type to use")
 	c.Flags().IntVar(&serveOpts.ListLimit, "list-max", 256, "maximum number of releases to fetch")
 	c.Flags().StringVar(&serveOpts.UserAgentComment, "user-agent-comment", "", "UserAgent comment used during outbound requests")


### PR DESCRIPTION
### Description of the change

When triggering the release, we noticed some failures in the "upgrade chart" test case due to some assetsvc-related params being still used. We decided to postpone the removal until de v2.4.6 was out.
This PR is simply removing this unused cmd argument.

### Benefits

No more assetsvc-related code.

### Possible drawbacks

N/A

### Applicable issues

- related #4936

### Additional information

CI will fail unless Bitnami releases the new chart version :S 