### PR TITLE
Updated Pinniped installation instructions

### DIFF
--- a/site/content/docs/latest/howto/OIDC/using-an-OIDC-provider-with-pinniped.md
+++ b/site/content/docs/latest/howto/OIDC/using-an-OIDC-provider-with-pinniped.md
@@ -4,10 +4,12 @@ The [Pinniped project](https://pinniped.dev/) exists to "Simplify user authentic
 
 ## Installing Pinniped
 
-Install Pinniped into a `pinniped-concierge` namespace on your cluster with:
+Install Pinniped on your cluster with:
 
 ```bash
-kubectl apply -f https://get.pinniped.dev/latest/install-pinniped-concierge.yaml
+kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/v0.18.0/install-pinniped-concierge-crds.yaml
+
+kubectl apply -f  https://github.com/vmware-tanzu/pinniped/releases/download/v0.18.0/install-pinniped-concierge.yaml
 ```
 
 ## Configure Pinniped to trust your OIDC identity provider


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

This PR fixes wrong instruction in the docs to install Pinniped in a cluster.

In [Using and OIDC provider with Pinniped](https://kubeapps.dev/docs/latest/howto/oidc/using-an-oidc-provider-with-pinniped/#installing-pinniped), the instructions to install Pinniped are wrong.

For example, the impersonation proxy did not exist with previous instructions, so:
`kubectl get credentialissuer -o json`  would return no resources (although the CRD did exist).

### Benefits

User following documentation will have a working Pinniped installation.

### Possible drawbacks

N/A

