### PR TITLE
Use k8s stable versions as per v1.22

### DIFF
--- a/cmd/apprepository-controller/artifacts/examples/crd.yaml
+++ b/cmd/apprepository-controller/artifacts/examples/crd.yaml
@@ -1,16 +1,117 @@
 # Copyright 2018-2022 the Kubeapps contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: apprepositories.kubeapps.com
 spec:
   group: kubeapps.com
-  version: v1alpha1
+  scope: Namespaced
   names:
     kind: AppRepository
     plural: apprepositories
     shortNames:
       - apprepos
-  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      storage: true
+      served: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required:
+                - type
+                - url
+              properties:
+                type:
+                  type: string
+                  enum: ["helm", "oci"]
+                url:
+                  type: string
+                description:
+                  type: string
+                auth:
+                  type: object
+                  properties:
+                    header:
+                      type: object
+                      required:
+                        - secretKeyRef
+                      properties:
+                        secretKeyRef:
+                          type: object
+                          required:
+                            - key
+                            - name
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                    customCA:
+                      type: object
+                      required:
+                        - secretKeyRef
+                      properties:
+                        secretKeyRef:
+                          type: object
+                          required:
+                            - key
+                            - name
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                dockerRegistrySecrets:
+                  type: array
+                  items:
+                    type: string
+                tlsInsecureSkipVerify:
+                  type: boolean
+                passCredentials:
+                  type: boolean
+                filterRule:
+                  type: object
+                  properties:
+                    jq:
+                      type: string
+                    variables:
+                      type: object
+                      additionalProperties:
+                        type: string
+                ociRepositories:
+                  type: array
+                  items:
+                    type: string
+                resyncRequests:
+                  type: integer
+                syncJobPodTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    spec:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                status:
+                  type: string
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          description: The type of this repository.
+          jsonPath: .spec.type
+        - name: URL
+          type: string
+          description: The URL of this repository.
+          jsonPath: .spec.url

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -89,13 +89,13 @@ const availablePackageDetail = {
 const resourceRefs = {
   configMap: { apiVersion: "v1", kind: "ConfigMap", name: "cm-one" } as ResourceRef,
   deployment: {
-    apiVersion: "apps/v1beta1",
+    apiVersion: "apps/v1",
     kind: "Deployment",
     name: "deployment-one",
   } as ResourceRef,
   service: { apiVersion: "v1", kind: "Service", name: "svc-one" } as ResourceRef,
   ingress: {
-    apiVersion: "extensions/v1beta1",
+    apiVersion: "extensions/v1",
     kind: "Ingress",
     name: "ingress-one",
   } as ResourceRef,
@@ -105,12 +105,12 @@ const resourceRefs = {
     name: "secret-one",
   } as ResourceRef,
   daemonset: {
-    apiVersion: "apps/v1beta1",
+    apiVersion: "apps/v1",
     kind: "DaemonSet",
     name: "daemonset-one",
   } as ResourceRef,
   statefulset: {
-    apiVersion: "apps/v1beta1",
+    apiVersion: "apps/v1",
     kind: "StatefulSet",
     name: "statefulset-one",
   } as ResourceRef,

--- a/dashboard/src/reducers/kube.ts
+++ b/dashboard/src/reducers/kube.ts
@@ -45,7 +45,7 @@ export const initialKinds = {
     plural: "horizontalpodautoscalers",
     namespaced: true,
   },
-  Ingress: { apiVersion: "extensions/v1beta1", plural: "ingresses", namespaced: true },
+  Ingress: { apiVersion: "extensions/v1", plural: "ingresses", namespaced: true },
   Job: { apiVersion: "batch/v1", plural: "jobs", namespaced: true },
   Lease: { apiVersion: "coordination.k8s.io/v1", plural: "leases", namespaced: true },
   LimitRange: { apiVersion: "v1", plural: "limitranges", namespaced: true },

--- a/pkg/agent/docker_secrets_postrenderer.go
+++ b/pkg/agent/docker_secrets_postrenderer.go
@@ -174,7 +174,7 @@ func (r *DockerSecretsPostRenderer) updatePodSpecWithPullSecrets(podSpec map[str
 		}
 		image, ok := container["image"].(string)
 		if !ok {
-			// NOTE: in https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+			// NOTE: in https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#container-v1-core
 			// the image is optional to allow higher level config management to default or override (such as
 			// deployments or statefulsets), but both only define pod templates which in turn define containers?
 			log.Errorf("pod spec container does not define an string image: %+v", container)
@@ -218,13 +218,13 @@ func getResourcePodSpec(kind string, resource map[string]interface{}) map[string
 		return getMapForKeys([]string{"spec"}, resource)
 	case "DaemonSet", "Deployment", "Job", "ReplicaSet", "ReplicationController", "StatefulSet":
 		// These resources all include a spec.template.spec PodSpec.
-		// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podtemplatespec-v1-core
+		// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podtemplatespec-v1-core
 		return getMapForKeys([]string{"spec", "template", "spec"}, resource)
 	case "PodTemplate":
 		return getMapForKeys([]string{"template", "spec"}, resource)
 	case "CronJob":
 		// A CronJob spec contains a jobTemplate:
-		// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#cronjobspec-v1beta1-batch
+		// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#cronjob-v1-batch
 		return getMapForKeys([]string{"spec", "jobTemplate", "spec", "template", "spec"}, resource)
 	}
 

--- a/site/content/docs/latest/howto/OIDC/OAuth2OIDC-oauth2-proxy.md
+++ b/site/content/docs/latest/howto/OIDC/OAuth2OIDC-oauth2-proxy.md
@@ -152,7 +152,7 @@ Once the proxy is in place and it's able to connect to the IdP we will need to e
 
 ```bash
 kubectl create -n $KUBEAPPS_NAMESPACE -f - -o yaml << EOF
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Ingress
 metadata:
   annotations:

--- a/site/content/docs/latest/reference/proposals/authentication-and-authorization.md
+++ b/site/content/docs/latest/reference/proposals/authentication-and-authorization.md
@@ -81,7 +81,7 @@ The Service Account can be created in any namespace, the above example uses _kub
 Then the Cluster Operator will need to create a set of RBAC roles and binding for the user. The Kubeapps documentation will need to define the set of roles for different features. For the purpose of this example, we will bind the Service Account to the _cluster-admin_ role.
 
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: johnsmith


### PR DESCRIPTION
### Description of the change

During the release process, I've noticed we have some old kubernetes resources versions out there. This PR is just to use the proper resource versions as per the current Kubernetes version 1.22.

### Benefits

We won't have any outdated (and potentially unsupported) group resource version in our examples and docs.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A