### PR TITLE
Specifiy the mininum k8s version in the chart

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -2,6 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 appVersion: DEVEL
+kubeVersion: ">=1.21"
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/script/chart-template-test.sh
+++ b/script/chart-template-test.sh
@@ -12,7 +12,7 @@ CHART_DIR=$ROOT_DIR/chart/kubeapps/
 
 # Remove the kubeVersion field as it would fail otherwise as there isn't any k8s cluster
 # when running this command from the CI
-sed -i.bk -e "s/kubeVersion.*//g" chart/kubeapps/ "${CHART_DIR}Chart.yaml"
+sed -i.bk -e "s/kubeVersion.*//g" "${CHART_DIR}Chart.yaml"
 
 helm dep up "${CHART_DIR}"
 

--- a/script/chart-template-test.sh
+++ b/script/chart-template-test.sh
@@ -10,6 +10,10 @@ set -o pipefail
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null && pwd)
 CHART_DIR=$ROOT_DIR/chart/kubeapps/
 
+# Remove the kubeVersion field as it would fail otherwise as there isn't any k8s cluster
+# when running this command from the CI
+sed -i.bk -e "s/kubeVersion.*//g" chart/kubeapps/ "${CHART_DIR}Chart.yaml"
+
 helm dep up "${CHART_DIR}"
 
 # test with the minium supported helm version


### PR DESCRIPTION
### Description of the change

I wasn't aware that Helm allows setting the minimum k8s version until people from Content team just told me. In our case, we are relying on certain resource versions (especially, cronjobs `v1` instead of `v1beta`, see #3846) and, when we update them, we are not backward compatible. 

### Benefits

We will be clear about the version we do support.

### Possible drawbacks

Users won't be able to install Kubeapps on unsupported versions, which might be not ok in some cases (people working on old k8s versions not using those old resource versions, for instance, just using the flux or carvel plugin instead of the helm one).

### Applicable issues

N/A

### Additional information

Happy to close the PR if we don't really like the outcome as described above.