### PR TITLE
Add gosec to asset-syncer

### DIFF
--- a/cmd/asset-syncer/Dockerfile
+++ b/cmd/asset-syncer/Dockerfile
@@ -9,6 +9,13 @@ COPY go.mod go.sum ./
 COPY pkg pkg
 COPY cmd cmd
 ARG VERSION
+
+ARG GOSEC_VERSION="2.12.0"
+RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v$GOSEC_VERSION
+
+# Run gosec to detect any security-related error at build time
+RUN gosec ./cmd/asset-syncer/...
+
 # With the trick below, Go's build cache is kept between builds.
 # https://github.com/golang/go/issues/27719#issuecomment-514747274
 RUN --mount=type=cache,target=/go/pkg/mod \

--- a/cmd/asset-syncer/server/postgresql_utils.go
+++ b/cmd/asset-syncer/server/postgresql_utils.go
@@ -40,10 +40,12 @@ func newPGManager(config dbutils.Config, globalReposNamespace string) (assetMana
 // imported into the database as fast as possible. E.g. we want all icons for
 // charts before fetching readmes for each chart and version pair.
 func (m *postgresAssetManager) Sync(repo models.Repo, charts []models.Chart) error {
-	m.InitTables()
-
+	err := m.InitTables()
+	if err != nil {
+		return err
+	}
 	// Ensure the repo exists so FK constraints will be met.
-	_, err := m.EnsureRepoExists(repo.Namespace, repo.Name)
+	_, err = m.EnsureRepoExists(repo.Namespace, repo.Name)
 	if err != nil {
 		return err
 	}
@@ -61,7 +63,10 @@ func (m *postgresAssetManager) LastChecksum(repo models.Repo) string {
 	var lastChecksum string
 	row := m.DB.QueryRow(fmt.Sprintf("SELECT checksum FROM %s WHERE name = $1 AND namespace = $2", dbutils.RepositoryTable), repo.Name, repo.Namespace)
 	if row != nil {
-		row.Scan(&lastChecksum)
+		err := row.Scan(&lastChecksum)
+		if err != nil {
+			return ""
+		}
 	}
 	return lastChecksum
 }


### PR DESCRIPTION
### Description of the change

After reporting #4810 , I've added the linter just in the `asset-syncer` code . 
The building is gonna fail now, but if we start fixing the issues, we will be, eventually, able to merge this PR.

### Benefits

Prevent new `gosec` issues.

### Possible drawbacks

N/A

### Applicable issues

- related #4810 

### Additional information

N/A