### PR TITLE
Add gosec to apprepository-controller

### DIFF
--- a/cmd/apprepository-controller/Dockerfile
+++ b/cmd/apprepository-controller/Dockerfile
@@ -9,6 +9,13 @@ COPY go.mod go.sum ./
 COPY pkg pkg
 COPY cmd cmd
 ARG VERSION
+
+ARG GOSEC_VERSION="2.12.0"
+RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v$GOSEC_VERSION
+
+# Run gosec to detect any security-related error at build time
+RUN gosec ./cmd/apprepository-controller/...
+
 # With the trick below, Go's build cache is kept between builds.
 # https://github.com/golang/go/issues/27719#issuecomment-514747274
 RUN --mount=type=cache,target=/go/pkg/mod \

--- a/cmd/apprepository-controller/server/controller.go
+++ b/cmd/apprepository-controller/server/controller.go
@@ -106,7 +106,11 @@ func NewController(
 	// Create event broadcaster
 	// Add apprepository-controller types to the default Kubernetes Scheme so
 	// Events can be logged for apprepository-controller types.
-	appreposcheme.AddToScheme(scheme.Scheme)
+	err := appreposcheme.AddToScheme(scheme.Scheme)
+	if err == nil {
+		return nil
+	}
+
 	log.Info("Creating event broadcaster")
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(log.Infof)

--- a/cmd/apprepository-controller/server/controller.go
+++ b/cmd/apprepository-controller/server/controller.go
@@ -107,7 +107,7 @@ func NewController(
 	// Add apprepository-controller types to the default Kubernetes Scheme so
 	// Events can be logged for apprepository-controller types.
 	err := appreposcheme.AddToScheme(scheme.Scheme)
-	if err == nil {
+	if err != nil {
 		return nil
 	}
 


### PR DESCRIPTION
### Description of the change

After reporting #4810 , I've added the linter just in the `apprepository-controller` code . 
The building is gonna fail now, but if we start fixing the issues, we will be, eventually, able to merge this PR.

### Benefits

Prevent new `gosec` issues.

### Possible drawbacks

N/A

### Applicable issues

- related #4810 

### Additional information

N/A