### PR TITLE
Add gosec to kubeops

### DIFF
--- a/cmd/kubeops/Dockerfile
+++ b/cmd/kubeops/Dockerfile
@@ -9,6 +9,13 @@ COPY go.mod go.sum ./
 COPY pkg pkg
 COPY cmd cmd
 ARG VERSION
+
+ARG GOSEC_VERSION="2.12.0"
+RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v$GOSEC_VERSION
+
+# Run gosec to detect any security-related error at build time
+RUN gosec ./cmd/kubeops/...
+
 # With the trick below, Go's build cache is kept between builds.
 # https://github.com/golang/go/issues/27719#issuecomment-514747274
 RUN --mount=type=cache,target=/go/pkg/mod \

--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -312,5 +312,8 @@ func DeleteRelease(cfg Config, w http.ResponseWriter, req *http.Request, params 
 		return
 	}
 	w.Header().Set("Status-Code", "200")
-	w.Write([]byte("OK"))
+	_, err = w.Write([]byte("OK"))
+	if err != nil {
+		return
+	}
 }

--- a/cmd/kubeops/internal/httphandler/http-handler.go
+++ b/cmd/kubeops/internal/httphandler/http-handler.go
@@ -45,7 +45,10 @@ func JSONError(w http.ResponseWriter, err interface{}, code int) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(code)
-	json.NewEncoder(w).Encode(err)
+	e := json.NewEncoder(w).Encode(err)
+	if e != nil {
+		return
+	}
 }
 
 func returnK8sError(err error, action string, resource string, w http.ResponseWriter) {
@@ -119,7 +122,10 @@ func ListAppRepositories(handler kube.AuthHandler) func(w http.ResponseWriter, r
 			JSONError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		w.Write(responseBody)
+		_, err = w.Write(responseBody)
+		if err != nil {
+			return
+		}
 	}
 }
 
@@ -149,7 +155,10 @@ func CreateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter, r
 			JSONError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		w.Write(responseBody)
+		_, err = w.Write(responseBody)
+		if err != nil {
+			return
+		}
 	}
 }
 
@@ -179,7 +188,10 @@ func UpdateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter, r
 			JSONError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		w.Write(responseBody)
+		_, err = w.Write(responseBody)
+		if err != nil {
+			return
+		}
 	}
 }
 
@@ -210,7 +222,10 @@ func RefreshAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter, 
 			JSONError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		w.Write(responseBody)
+		_, err = w.Write(responseBody)
+		if err != nil {
+			return
+		}
 	}
 }
 
@@ -236,7 +251,10 @@ func ValidateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter,
 			JSONError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		w.Write(responseBody)
+		_, err = w.Write(responseBody)
+		if err != nil {
+			return
+		}
 	}
 }
 
@@ -306,7 +324,10 @@ func GetAppRepository(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, 
 			JSONError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		w.Write(responseBody)
+		_, err = w.Write(responseBody)
+		if err != nil {
+			return
+		}
 	}
 }
 
@@ -342,7 +363,10 @@ func GetNamespaces(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, req
 			JSONError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		w.Write(responseBody)
+		_, err = w.Write(responseBody)
+		if err != nil {
+			return
+		}
 	}
 }
 
@@ -368,7 +392,10 @@ func GetOperatorLogo(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, r
 			ctype = "image/svg+xml"
 		}
 		w.Header().Set("Content-Type", ctype)
-		w.Write(logo)
+		_, err = w.Write(logo)
+		if err != nil {
+			return
+		}
 	}
 }
 
@@ -405,7 +432,10 @@ func CanI(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, req *http.Re
 			JSONError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		w.Write(responseBody)
+		_, err = w.Write(responseBody)
+		if err != nil {
+			return
+		}
 	}
 }
 

--- a/cmd/kubeops/internal/response/response.go
+++ b/cmd/kubeops/internal/response/response.go
@@ -32,7 +32,10 @@ func (e ErrorResponse) Write(w http.ResponseWriter) {
 		return
 	}
 	w.WriteHeader(e.Code)
-	w.Write(responseBody)
+	_, err = w.Write(responseBody)
+	if err != nil {
+		return
+	}
 }
 
 /*
@@ -62,5 +65,8 @@ func (d DataResponse) Write(w http.ResponseWriter) {
 		return
 	}
 	w.WriteHeader(d.Code)
-	w.Write(responseBody)
+	_, err = w.Write(responseBody)
+	if err != nil {
+		return
+	}
 }

--- a/cmd/kubeops/server/server.go
+++ b/cmd/kubeops/server/server.go
@@ -117,8 +117,9 @@ func Serve(serveOpts ServeOptions) error {
 	addr := ":" + port
 
 	srv := &http.Server{
-		Addr:    addr,
-		Handler: n,
+		ReadHeaderTimeout: 60 * time.Second, // mitigate slowloris attacks, set to nginx's default
+		Addr:              addr,
+		Handler:           n,
 	}
 
 	go func() {


### PR DESCRIPTION
### Description of the change

After reporting #4810 , I've added the linter just in the `kubeops` code . 
The building is gonna fail now, but if we start fixing the issues, we will be, eventually, able to merge this PR.

### Benefits

Prevent new `gosec` issues.

### Possible drawbacks

N/A

### Applicable issues

- related #4810 

### Additional information

N/A