### PR TITLE
Add status helm repos API

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
@@ -191,6 +191,11 @@ func (s *Server) mapToPackageRepositoryDetail(source *apprepov1alpha1.AppReposit
 		Url:             source.Spec.URL,
 		Auth:            auth,
 		TlsConfig:       tlsConfig,
+		// TODO(agamez): check if we can get the status from the repo somehow
+		// https://github.com/vmware-tanzu/kubeapps/issues/153
+		Status: &corev1.PackageRepositoryStatus{
+			Ready: true,
+		},
 	}
 
 	// Custom details
@@ -377,6 +382,7 @@ func (s *Server) repoSummaries(ctx context.Context, cluster string, namespace st
 			Type:            repo.Spec.Type,
 			Url:             repo.Spec.URL,
 			// TODO(agamez): check if we can get the status from the repo somehow
+			// https://github.com/vmware-tanzu/kubeapps/issues/153
 			Status: &corev1.PackageRepositoryStatus{
 				Ready: true,
 			},

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
@@ -376,6 +376,10 @@ func (s *Server) repoSummaries(ctx context.Context, cluster string, namespace st
 			NamespaceScoped: s.globalPackagingNamespace != repo.Namespace,
 			Type:            repo.Spec.Type,
 			Url:             repo.Spec.URL,
+			// TODO(agamez): check if we can get the status from the repo somehow
+			Status: &corev1.PackageRepositoryStatus{
+				Ready: true,
+			},
 		}
 		summaries = append(summaries, summary)
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
@@ -126,6 +126,7 @@ var repo1Summary = &corev1.PackageRepositorySummary{
 	NamespaceScoped: true,
 	Type:            "helm",
 	Url:             "https://test-repo",
+	Status:          &corev1.PackageRepositoryStatus{Ready: true},
 }
 
 var repo2Summary = &corev1.PackageRepositorySummary{
@@ -135,6 +136,7 @@ var repo2Summary = &corev1.PackageRepositorySummary{
 	NamespaceScoped: true,
 	Type:            "oci",
 	Url:             "https://test-repo2",
+	Status:          &corev1.PackageRepositoryStatus{Ready: true},
 }
 
 var appReposAPIVersion = fmt.Sprintf("%s/%s", appRepov1alpha1.SchemeGroupVersion.Group, appRepov1alpha1.SchemeGroupVersion.Version)

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
@@ -615,6 +615,7 @@ func TestGetPackageRepositoryDetail(t *testing.T) {
 				Url:             url,
 				Auth:            auth,
 				TlsConfig:       tlsConfig,
+				Status:          &corev1.PackageRepositoryStatus{Ready: true},
 			},
 		}
 		if customDetails != nil {


### PR DESCRIPTION
### Description of the change

I've noticed the Helm plugin is not setting the `status.ready` field. As it defaults to `false`, the UI shows misleading information to the users. This PR sets it to `true`, but ideally, we would want actually to query the status of the repo sync.

### Benefits

No more misleading "not ready" info to the users.

### Possible drawbacks

A failed sync job will still be marked as "ready" when it is not. However, this is the initial behavior and there is another (old) issue tracking it: #153. 

### Applicable issues

- related https://github.com/vmware-tanzu/kubeapps/issues/4764

### Additional information

This is just a workaround, but we should be able to query, somehow, the status of an AppRepository job's execution.

