### PR TITLE
Remove refs to tiller in the code

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -57,7 +57,7 @@ type Details struct {
 	// resource for the request.
 	// ChartName is the name of the chart within the repo.
 	ChartName string `json:"chartName"`
-	// ReleaseName is the Name of the release given to Tiller.
+	// ReleaseName is the Name of the release given to Helm.
 	ReleaseName string `json:"releaseName"`
 	// Version is the chart version.
 	Version string `json:"version"`

--- a/pkg/http-client/httpclient.go
+++ b/pkg/http-client/httpclient.go
@@ -104,9 +104,6 @@ func GetCertPool(certs []byte) (*x509.CertPool, error) {
 	// Require the SystemCertPool unless the env var is explicitly set.
 	caCertPool, err := x509.SystemCertPool()
 	if err != nil {
-		if _, ok := os.LookupEnv("TILLER_PROXY_ALLOW_EMPTY_CERT_POOL"); !ok {
-			return nil, err
-		}
 		caCertPool = x509.NewCertPool()
 	}
 

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -50,8 +50,7 @@ func FetchChartDetailFromTarballUrl(name string, chartTarballURL string, userAge
 //
 func FetchChartDetailFromTarball(reader io.Reader, name string) (map[string]string, error) {
 	// We read the whole chart into memory, this should be okay since the chart
-	// tarball needs to be small enough to fit into a GRPC call (Tiller
-	// requirement)
+	// tarball needs to be small enough to fit into a GRPC call
 	gzf, err := gzip.NewReader(reader)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Description of the change

Trivial PR just removing some references to Tiller in the code. It is just a reminiscence of the Helm 2 times and it is no longer used since many releases ago.

### Benefits

No more references to old parts of Kubeapps.

### Possible drawbacks

N/A

### Applicable issues

- related #4785 

### Additional information

N/A