### PR TITLE
Mark old kubeops calls to be migrated to the resources API

### DIFF
--- a/dashboard/src/shared/Config.ts
+++ b/dashboard/src/shared/Config.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import axios from "axios";
+import * as url from "shared/url";
 
 export enum SupportedThemes {
   dark = "dark",
@@ -39,8 +40,7 @@ export interface IFeatureFlags {
 
 export default class Config {
   public static async getConfig() {
-    const url = Config.APIEndpoint;
-    const { data } = await axios.get<IConfig>(url);
+    const { data } = await axios.get<IConfig>(url.api.config);
     return data;
   }
 
@@ -82,7 +82,4 @@ export default class Config {
     this.setTheme(theme);
     localStorage.setItem("user-theme", theme);
   }
-
-  private static APIEndpoint = "config.json";
-  public static OperatorsApi = "operators.coreos.com";
 }

--- a/dashboard/src/shared/I18n.ts
+++ b/dashboard/src/shared/I18n.ts
@@ -3,6 +3,7 @@
 
 import messages_en from "../locales/en.json";
 import { axiosWithAuth } from "./AxiosInstance";
+import * as url from "shared/url";
 
 export interface II18nConfig {
   locale: ISupportedLangs | "custom";
@@ -34,8 +35,9 @@ export default class I18n {
 
   public static async getCustomConfig(lang: ISupportedLangs) {
     try {
-      const customMessages = (await axiosWithAuth.get<Record<string, string>>("custom_locale.json"))
-        .data;
+      const customMessages = (
+        await axiosWithAuth.get<Record<string, string>>(url.api.custom_locale)
+      ).data;
       if (Object.keys(customMessages).length === 0) {
         throw new Error("Empty custom locale");
       }

--- a/dashboard/src/shared/Kube.ts
+++ b/dashboard/src/shared/Kube.ts
@@ -52,6 +52,7 @@ export class Kube {
     return u;
   }
 
+  // TODO(agamez): Migrate API call, see #4785
   public static async getResource(
     cluster: string,
     apiVersion: string,
@@ -80,11 +81,13 @@ export class Kube {
     });
   }
 
+  // TODO(agamez): Migrate API call, see #4785
   public static async getAPIGroups(cluster: string) {
     const { data: apiGroups } = await axiosWithAuth.get<any>(`${url.api.k8s.base(cluster)}/apis`);
     return apiGroups.groups;
   }
 
+  // TODO(agamez): Migrate API call, see #4785
   public static async getResourceKinds(cluster: string, groups: any[]) {
     const result: IKubeState["kinds"] = {};
     const addResource = (r: any, version: string) => {
@@ -115,6 +118,7 @@ export class Kube {
     return result;
   }
 
+  // TODO(agamez): Migrate API call, see #4785
   public static async canI(
     cluster: string,
     group: string,

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -11,6 +11,7 @@ import { KubeappsGrpcClient } from "./KubeappsGrpcClient";
 export default class Namespace {
   private static resourcesClient = () => new KubeappsGrpcClient().getResourcesServiceClientImpl();
 
+  // TODO(agamez): Migrate API call, see #4785
   public static async list(cluster: string) {
     // This call is hitting an actual backend endpoint (see cmd\kubeops\internal\http-handler)
     // while the other two calls (create, get) have been updated to use the

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -130,6 +130,10 @@ export const api = {
   // access the k8s api server directly).
   k8s: {
     base: (cluster: string) => `api/clusters/${cluster}`,
+    apis: (cluster: string) => `${api.k8s.base(cluster)}/apis`,
+    v1: (cluster: string) => `${api.k8s.base(cluster)}/api/v1`,
+    groupVersion: (cluster: string, groupVersion: string) =>
+      `${api.k8s.base(cluster)}/apis/${groupVersion}`,
     namespaces: (cluster: string) => `${api.k8s.base(cluster)}/api/v1/namespaces`,
     namespace: (cluster: string, namespace: string) =>
       namespace ? `${api.k8s.namespaces(cluster)}/${namespace}` : `${api.k8s.base(cluster)}/api/v1`,
@@ -181,4 +185,6 @@ export const api = {
   },
 
   kubeappsapis: "apis",
+  config: "config.json",
+  custom_locale: "custom_locale.json",
 };


### PR DESCRIPTION
### Description of the change

This PR performs a quick review on the UI calls to kubeops. As this component will be deprecated soon, we should start migrating those calls to the kubeapps-apis component.
The PR just adds a comment on those calls to be migrated, as well as centralizes some sparse URLs into the `url.ts` file.

### Benefits

Knowing what to migrate will be easier.

### Possible drawbacks

N/A

### Applicable issues

- related https://github.com/vmware-tanzu/kubeapps/issues/4785

### Additional information

N/A
