### PR TITLE
Rename the repos API's custom detail name field - 2

### DIFF
--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
@@ -11,7 +11,7 @@ import {
   PackageRepositoryReference,
 } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
-import { RepositoryCustomDetails } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
+import { HelmPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
 import { act } from "react-dom/test-utils";
 import * as ReactRedux from "react-redux";
 import { IPackageRepositoryState } from "reducers/repos";
@@ -513,7 +513,7 @@ describe("when the repository info is already populated", () => {
           jq: ".name == $var0 or .name == $var1",
           variables: { $var0: "nginx", $var1: "wordpress" },
         },
-      } as Partial<RepositoryCustomDetails>,
+      } as Partial<HelmPackageRepositoryCustomDetail>,
     } as PackageRepositoryDetail;
 
     let wrapper: any;
@@ -539,7 +539,7 @@ describe("when the repository info is already populated", () => {
       type: "helm",
       customDetail: {
         filterRule: { jq: ".name | test($var) | not", variables: { $var: "nginx" } },
-      } as Partial<RepositoryCustomDetails>,
+      } as Partial<HelmPackageRepositoryCustomDetail>,
     } as PackageRepositoryDetail;
 
     let wrapper: any;

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
@@ -23,7 +23,7 @@ import {
   UsernamePassword,
 } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
-import { RepositoryCustomDetails } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
+import { HelmPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
 import { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Action } from "redux";
@@ -199,21 +199,22 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
 
       // setting custom details for the Helm plugin
       if (repo.packageRepoRef?.plugin?.name === PluginNames.PACKAGES_HELM) {
-        const repositoryCustomDetails = repo.customDetail as Partial<RepositoryCustomDetails>;
-        setOCIRepositories(repositoryCustomDetails?.ociRepositories?.join(", ") || "");
-        setPerformValidation(repositoryCustomDetails?.performValidation || false);
-        if (repositoryCustomDetails?.filterRule?.jq) {
-          const { names, regex, exclude } = toParams(repositoryCustomDetails.filterRule!);
+        const HelmPackageRepositoryCustomDetail =
+          repo.customDetail as Partial<HelmPackageRepositoryCustomDetail>;
+        setOCIRepositories(HelmPackageRepositoryCustomDetail?.ociRepositories?.join(", ") || "");
+        setPerformValidation(HelmPackageRepositoryCustomDetail?.performValidation || false);
+        if (HelmPackageRepositoryCustomDetail?.filterRule?.jq) {
+          const { names, regex, exclude } = toParams(HelmPackageRepositoryCustomDetail.filterRule!);
           setFilterRegex(regex);
           setFilterExclude(exclude);
           setFilterNames(names);
         }
         setHelmPsAuthMethod(
-          repositoryCustomDetails?.dockerRegistrySecrets?.length
+          HelmPackageRepositoryCustomDetail?.dockerRegistrySecrets?.length
             ? PackageRepositoryAuth_PackageRepositoryAuthType.PACKAGE_REPOSITORY_AUTH_TYPE_DOCKER_CONFIG_JSON
             : PackageRepositoryAuth_PackageRepositoryAuthType.PACKAGE_REPOSITORY_AUTH_TYPE_UNSPECIFIED,
         );
-        setSecretPSName(repositoryCustomDetails?.dockerRegistrySecrets?.[0] || "");
+        setSecretPSName(HelmPackageRepositoryCustomDetail?.dockerRegistrySecrets?.[0] || "");
       }
     }
   }, [repo, namespace, currentCluster, dispatch]);
@@ -272,7 +273,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
         performValidation,
         filterRule: filter,
         dockerRegistrySecrets: isUserManagedPSSecret && secretPSName ? [secretPSName] : [],
-      } as RepositoryCustomDetails,
+      } as HelmPackageRepositoryCustomDetail,
       description,
       dockerRegCreds: {
         username: isUserManagedSecret ? "" : secretUser,
@@ -1336,7 +1337,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                           }
                           onChange={handleImgPSChange}
                           disabled={
-                            !!(repo?.customDetail as Partial<RepositoryCustomDetails>)
+                            !!(repo?.customDetail as Partial<HelmPackageRepositoryCustomDetail>)
                               ?.dockerRegistrySecrets?.length
                           }
                           required={
@@ -1366,7 +1367,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                           }
                           onChange={handleImgPSChange}
                           disabled={
-                            !!(repo?.customDetail as Partial<RepositoryCustomDetails>)
+                            !!(repo?.customDetail as Partial<HelmPackageRepositoryCustomDetail>)
                               ?.dockerRegistrySecrets?.length
                           }
                           required={
@@ -1401,7 +1402,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                               checked={isUserManagedPSSecret}
                               disabled={true}
                               // disabled={
-                              //   !!(repo?.customDetail as Partial<RepositoryCustomDetails>)
+                              //   !!(repo?.customDetail as Partial<HelmPackageRepositoryCustomDetail>)
                               //     ?.dockerRegistrySecrets?.length
                               // }
                             />
@@ -1457,8 +1458,9 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                                   PackageRepositoryAuth_PackageRepositoryAuthType.PACKAGE_REPOSITORY_AUTH_TYPE_DOCKER_CONFIG_JSON
                                 }
                                 disabled={
-                                  !!(repo?.customDetail as Partial<RepositoryCustomDetails>)
-                                    ?.dockerRegistrySecrets?.length
+                                  !!(
+                                    repo?.customDetail as Partial<HelmPackageRepositoryCustomDetail>
+                                  )?.dockerRegistrySecrets?.length
                                 }
                               />
                             </CdsInput>
@@ -1477,8 +1479,9 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                                   PackageRepositoryAuth_PackageRepositoryAuthType.PACKAGE_REPOSITORY_AUTH_TYPE_DOCKER_CONFIG_JSON
                                 }
                                 disabled={
-                                  !!(repo?.customDetail as Partial<RepositoryCustomDetails>)
-                                    ?.dockerRegistrySecrets?.length
+                                  !!(
+                                    repo?.customDetail as Partial<HelmPackageRepositoryCustomDetail>
+                                  )?.dockerRegistrySecrets?.length
                                 }
                               />
                             </CdsInput>
@@ -1498,8 +1501,9 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                                   PackageRepositoryAuth_PackageRepositoryAuthType.PACKAGE_REPOSITORY_AUTH_TYPE_DOCKER_CONFIG_JSON
                                 }
                                 disabled={
-                                  !!(repo?.customDetail as Partial<RepositoryCustomDetails>)
-                                    ?.dockerRegistrySecrets?.length
+                                  !!(
+                                    repo?.customDetail as Partial<HelmPackageRepositoryCustomDetail>
+                                  )?.dockerRegistrySecrets?.length
                                 }
                               />
                             </CdsInput>
@@ -1512,8 +1516,9 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                                 onChange={handleImgPSEmailChange}
                                 placeholder="user@example.com"
                                 disabled={
-                                  !!(repo?.customDetail as Partial<RepositoryCustomDetails>)
-                                    ?.dockerRegistrySecrets?.length
+                                  !!(
+                                    repo?.customDetail as Partial<HelmPackageRepositoryCustomDetail>
+                                  )?.dockerRegistrySecrets?.length
                                 }
                               />
                             </CdsInput>

--- a/dashboard/src/reducers/repos.ts
+++ b/dashboard/src/reducers/repos.ts
@@ -6,7 +6,7 @@ import {
   PackageRepositoryDetail,
   PackageRepositorySummary,
 } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
-import { RepositoryCustomDetails } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
+import { HelmPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
 import { ISecret } from "shared/types";
 import { PluginNames } from "shared/utils";
 import { getType } from "typesafe-actions";
@@ -94,12 +94,12 @@ const reposReducer = (
           dockerRegistrySecrets: [],
           ociRepositories: [],
           performValidation: false,
-        } as RepositoryCustomDetails;
+        } as HelmPackageRepositoryCustomDetail;
 
         try {
           if (action.payload?.customDetail?.value) {
             // TODO(agamez): verify why the field is not automatically decoded.
-            customDetail = RepositoryCustomDetails.decode(
+            customDetail = HelmPackageRepositoryCustomDetail.decode(
               action.payload.customDetail.value as unknown as Uint8Array,
             );
           }

--- a/dashboard/src/shared/PackageRepositoriesService.ts
+++ b/dashboard/src/shared/PackageRepositoriesService.ts
@@ -21,7 +21,7 @@ import {
 } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
 import {
   protobufPackage as helmProtobufPackage,
-  RepositoryCustomDetails,
+  HelmPackageRepositoryCustomDetail,
 } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
 import KubeappsGrpcClient from "./KubeappsGrpcClient";
 import { IPkgRepoFormData } from "./types";
@@ -218,9 +218,9 @@ export class PackageRepositoriesService {
     switch (request.plugin?.name) {
       case PluginNames.PACKAGES_HELM:
         return {
-          typeUrl: `${helmProtobufPackage}.RepositoryCustomDetails`,
-          value: RepositoryCustomDetails.encode(
-            request.customDetails as RepositoryCustomDetails,
+          typeUrl: `${helmProtobufPackage}.HelmPackageRepositoryCustomDetail`,
+          value: HelmPackageRepositoryCustomDetail.encode(
+            request.customDetails as HelmPackageRepositoryCustomDetail,
           ).finish(),
         } as Any;
       default:

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -21,7 +21,7 @@ import {
   UsernamePassword,
 } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
-import { RepositoryCustomDetails } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
+import { HelmPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
 import { IOperatorsState } from "reducers/operators";
 import { Subscription } from "rxjs";
 import { IAuthState } from "../reducers/auth";
@@ -443,5 +443,5 @@ export interface IPkgRepoFormData {
   skipTLS: boolean;
   type: string;
   url: string;
-  customDetails: Partial<RepositoryCustomDetails>; // add more types if necesary, currently just helm's custom details
+  customDetails: Partial<HelmPackageRepositoryCustomDetail>; // add more types if necesary, currently just helm's custom details
 }


### PR DESCRIPTION
### Description of the change

This PR performs the same renames done at https://github.com/vmware-tanzu/kubeapps/pull/5046, but in the new repos API's code.

### Benefits

Consistent naming

### Possible drawbacks

N/A

### Applicable issues

- fixes #5016

### Additional information

N/A
