### PR TITLE
Add gh linter - fix issues in kubeappsapis

### DIFF
--- a/cmd/kubeapps-apis/cmd/root_test.go
+++ b/cmd/kubeapps-apis/cmd/root_test.go
@@ -26,6 +26,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 				"--plugin-dir", "foo01",
 				"--clusters-config-path", "foo02",
 				"--pinniped-proxy-url", "foo03",
+				"--pinniped-proxy-ca-cert", "foo06",
 				"--global-repos-namespace", "kubeapps-global",
 				"--unsafe-local-dev-kubeconfig", "true",
 				"--plugin-config-path", "foo05",

--- a/cmd/kubeapps-apis/cmd/root_test.go
+++ b/cmd/kubeapps-apis/cmd/root_test.go
@@ -58,7 +58,10 @@ func TestParseFlagsCorrect(t *testing.T) {
 			cmd.SetErr(b)
 			setFlags(cmd)
 			cmd.SetArgs(tt.args)
-			cmd.Execute()
+			err := cmd.Execute()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
 			if got, want := serveOpts, tt.conf; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}

--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages_fan_in.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages_fan_in.go
@@ -94,6 +94,7 @@ func fanInAvailablePackageSummaries(ctx context.Context, pkgPlugins []pkgPluginW
 			for i, ch := range fanInput {
 				if nextItems[i] == nil {
 					// If the channel is closed, the value will remain nil.
+					//nolint:ineffassign
 					ok := true
 					nextItems[i], ok = <-ch
 					if !ok {
@@ -288,6 +289,7 @@ func fanInInstalledPackageSummaries(ctx context.Context, pkgPlugins []pkgPluginW
 			for i, ch := range fanInput {
 				if nextItems[i] == nil {
 					// If the channel is closed, the value will remain nil.
+					//nolint:ineffassign
 					ok := true
 					nextItems[i], ok = <-ch
 					if !ok {

--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins_test.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins_test.go
@@ -423,10 +423,9 @@ func TestCreateConfigGetterWithParams(t *testing.T) {
 			}
 
 			if tc.expectedErrMsg == nil {
-				if restConfig == nil {
+				if restConfig == nil && restConfig.Host != "" {
 					t.Errorf("got: nil, want: rest.Config")
-				}
-				if got, want := restConfig.Host, tc.expectedAPIHost; got != want {
+				} else if got, want := restConfig.Host, tc.expectedAPIHost; got != want {
 					t.Errorf("got: %q, want: %q", got, want)
 				}
 			}

--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins_test.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins_test.go
@@ -423,9 +423,10 @@ func TestCreateConfigGetterWithParams(t *testing.T) {
 			}
 
 			if tc.expectedErrMsg == nil {
-				if restConfig == nil && restConfig.Host != "" {
+				if restConfig == nil || restConfig.Host != "" {
 					t.Errorf("got: nil, want: rest.Config")
-				} else if got, want := restConfig.Host, tc.expectedAPIHost; got != want {
+				}
+				if got, want := restConfig.Host, tc.expectedAPIHost; got != want {
 					t.Errorf("got: %q, want: %q", got, want)
 				}
 			}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart_test.go
@@ -127,7 +127,10 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 				// stand up an http server just for the duration of this test
 				var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(200)
-					w.Write(tarGzBytes)
+					_, err = w.Write(tarGzBytes)
+					if err != nil {
+						t.Fatalf("%+v", err)
+					}
 				})
 				if tc.basicAuth {
 					handler = basicAuth(handler, "foo", "bar", "myrealm")
@@ -193,7 +196,10 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 				t.Fatalf("%+v", err)
 			}
 
-			s.redisMockExpectGetFromRepoCache(mock, nil, *repo)
+			err = s.redisMockExpectGetFromRepoCache(mock, nil, *repo)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
 			chartVersion := tc.request.PkgVersion
 			if chartVersion == "" {
 				chartVersion = charts[0].chartRevision
@@ -257,10 +263,16 @@ func TestTransientHttpFailuresAreRetriedForChartCache(t *testing.T) {
 				if !nofail && failuresAllowed > 0 {
 					failuresAllowed--
 					w.WriteHeader(503)
-					w.Write([]byte(fmt.Sprintf("The server is not ready to handle the request: [%d try left before OK]", failuresAllowed)))
+					_, err = w.Write([]byte(fmt.Sprintf("The server is not ready to handle the request: [%d try left before OK]", failuresAllowed)))
+					if err != nil {
+						t.Fatalf("%+v", err)
+					}
 				} else {
 					w.WriteHeader(200)
-					w.Write(tarGzBytes)
+					_, err := w.Write(tarGzBytes)
+					if err != nil {
+						t.Fatalf("%+v", err)
+					}
 				}
 			})
 			ts := httptest.NewServer(handler)
@@ -292,7 +304,10 @@ func TestTransientHttpFailuresAreRetriedForChartCache(t *testing.T) {
 		chartVersion := charts[0].chartRevision
 		requestChartUrl := charts[0].chartUrl
 
-		s.redisMockExpectGetFromRepoCache(mock, nil, *repo)
+		err = s.redisMockExpectGetFromRepoCache(mock, nil, *repo)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
 		chartCacheKey, err := s.chartCache.KeyFor(
 			repoNamespace,
 			packageIdentifier,
@@ -434,7 +449,10 @@ func TestNonExistingRepoOrInvalidPkgVersionGetAvailablePackageDetail(t *testing.
 				// stand up an http server just for the duration of this test
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(200)
-					w.Write(tarGzBytes)
+					_, err = w.Write(tarGzBytes)
+					if err != nil {
+						t.Fatalf("%+v", err)
+					}
 				}))
 				defer ts.Close()
 				replaceUrls[fmt.Sprintf("{{%s}}", s.tgzFile)] = ts.URL
@@ -464,7 +482,10 @@ func TestNonExistingRepoOrInvalidPkgVersionGetAvailablePackageDetail(t *testing.
 
 			repoExists := requestRepoName == tc.repoName && requestRepoNamespace == tc.repoNamespace
 			if repoExists {
-				s.redisMockExpectGetFromRepoCache(mock, nil, *repo)
+				err = s.redisMockExpectGetFromRepoCache(mock, nil, *repo)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
 				requestChartName := strings.Split(tc.request.AvailablePackageRef.Identifier, "/")[1]
 				chartExists := requestChartName == "redis"
 				if chartExists {
@@ -615,7 +636,10 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 				// stand up an http server just for the duration of this test
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(200)
-					w.Write(tarGzBytes)
+					_, err = w.Write(tarGzBytes)
+					if err != nil {
+						t.Fatalf("%+v", err)
+					}
 				}))
 				defer ts.Close()
 				replaceUrls[fmt.Sprintf("{{%s}}", s.tgzFile)] = ts.URL
@@ -696,7 +720,10 @@ func TestChartCacheResyncNotIdle(t *testing.T) {
 		// stand up an http server just for the duration of this test
 		var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(200)
-			w.Write(tarGzBytes)
+			_, err = w.Write(tarGzBytes)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
 		})
 		ts := httptest.NewServer(handler)
 		defer ts.Close()
@@ -869,7 +896,10 @@ func TestChartWithRelativeURL(t *testing.T) {
 			fmt.Fprintln(w, string(indexYAMLBytes))
 		} else if r.RequestURI == "/charts/airflow-1.0.0.tgz" {
 			w.WriteHeader(200)
-			w.Write(tarGzBytes)
+			_, err = w.Write(tarGzBytes)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
 		} else {
 			w.WriteHeader(404)
 		}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/integration_utils_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/integration_utils_test.go
@@ -954,8 +954,14 @@ func kubeGetCtrlClient() (ctrlclient.WithWatch, error) {
 			return nil, err
 		} else {
 			scheme := runtime.NewScheme()
-			sourcev1.AddToScheme(scheme)
-			helmv2.AddToScheme(scheme)
+			err = sourcev1.AddToScheme(scheme)
+			if err != nil {
+				return nil, err
+			}
+			err = helmv2.AddToScheme(scheme)
+			if err != nil {
+				return nil, err
+			}
 
 			return ctrlclient.NewWithWatch(config, ctrlclient.Options{Scheme: scheme})
 		}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
@@ -16,6 +16,7 @@ import (
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
+//nolint:deadcode
 func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) (interface{}, error) {
 	log.Info("+fluxv2 RegisterWithGRPCServer")
 
@@ -35,6 +36,7 @@ func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) 
 
 // RegisterHTTPHandlerFromEndpoint enables a plugin to register an http
 // handler to translate to the gRPC request.
+//nolint:deadcode
 func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
 	log.Info("+fluxv2 RegisterHTTPHandlerFromEndpoint")
 	err := v1alpha1.RegisterFluxV2PackagesServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/oci_repo.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/oci_repo.go
@@ -250,7 +250,14 @@ func (r *OCIRegistry) downloadChart(chart *repo.ChartVersion) (*bytes.Buffer, er
 
 	t := transport.NewOrIdle(r.tlsConfig)
 	clientOpts := append(r.helmOptions, getter.WithTransport(t))
-	defer transport.Release(t)
+
+	defer func() {
+		err = transport.Release(t)
+	}()
+
+	if err != nil {
+		return nil, err
+	}
 
 	// trim the oci scheme prefix if needed
 	getThis := strings.TrimPrefix(u.String(), fmt.Sprintf("%s://", registry.OCIScheme))
@@ -259,6 +266,7 @@ func (r *OCIRegistry) downloadChart(chart *repo.ChartVersion) (*bytes.Buffer, er
 
 // logout attempts to logout from the OCI registry.
 // It returns an error on failure.
+//nolint:unused
 func (r *OCIRegistry) logout() error {
 	log.Info("+logout")
 	err := r.registryClient.Logout(r.url.Host)

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_integration_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_integration_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 const (
-	fluxHelmReleases    = "helmreleases"
-	fluxHelmReleaseList = "HelmReleaseList"
+	fluxHelmReleases = "helmreleases"
 )
 
 // This is an integration test: it tests the full integration of flux plugin with flux back-end

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_test.go
@@ -1143,7 +1143,10 @@ func newChartsAndReleases(t *testing.T, existingK8sObjs []testSpecGetInstalledPa
 		// stand up an http server just for the duration of this test
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(200)
-			w.Write(tarGzBytes)
+			_, err = w.Write(tarGzBytes)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
 		}))
 		httpServers = append(httpServers, ts)
 

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo.go
@@ -39,9 +39,8 @@ import (
 const (
 	// see docs at https://fluxcd.io/docs/components/source/ and
 	// https://fluxcd.io/docs/components/helm/api/
-	fluxHelmRepositories   = "helmrepositories"
-	fluxHelmRepositoryList = "HelmRepositoryList"
-	redactedString         = "REDACTED"
+	fluxHelmRepositories = "helmrepositories"
+	redactedString       = "REDACTED"
 )
 
 var (

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo_integration_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo_integration_test.go
@@ -1300,8 +1300,11 @@ func setUserManagedSecretsAndCleanup(t *testing.T, fluxPluginReposClient v1alpha
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		fluxPluginReposClient.SetUserManagedSecrets(
+		_, err = fluxPluginReposClient.SetUserManagedSecrets(
 			ctx, &v1alpha1.SetUserManagedSecretsRequest{Value: oldValue.Value})
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
 	})
 }
 

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo_test.go
@@ -718,7 +718,10 @@ func TestGetAvailablePackageSummaryAfterFluxHelmRepoDelete(t *testing.T) {
 			// stand up an http server just for the duration of this test
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(200)
-				w.Write(tarGzBytes)
+				_, err = w.Write(tarGzBytes)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
 			}))
 			defer ts.Close()
 			replaceUrls[fmt.Sprintf("{{%s}}", s.tgzFile)] = ts.URL

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/test_util_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/test_util_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
+	log "k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -174,7 +175,10 @@ func basicAuth(handler http.HandlerFunc, username, password, realm string) http.
 		if !ok || subtle.ConstantTimeCompare([]byte(user), []byte(username)) != 1 || subtle.ConstantTimeCompare([]byte(pass), []byte(password)) != 1 {
 			w.Header().Set("WWW-Authenticate", `Basic realm="`+realm+`"`)
 			w.WriteHeader(401)
-			w.Write([]byte("Unauthorised.\n"))
+			_, err := w.Write([]byte("Unauthorised.\n"))
+			if err != nil {
+				log.Fatalf("%+v", err)
+			}
 			return
 		}
 		handler(w, r)
@@ -304,8 +308,14 @@ func repoRef(id, namespace string) *corev1.PackageRepositoryReference {
 func newCtrlClient(repos []sourcev1.HelmRepository, charts []sourcev1.HelmChart, releases []helmv2.HelmRelease) withWatchWrapper {
 	// register the flux GitOps Toolkit schema definitions
 	scheme := runtime.NewScheme()
-	sourcev1.AddToScheme(scheme)
-	helmv2.AddToScheme(scheme)
+	err := sourcev1.AddToScheme(scheme)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = helmv2.AddToScheme(scheme)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	rm := apimeta.NewDefaultRESTMapper([]schema.GroupVersion{sourcev1.GroupVersion, helmv2.GroupVersion})
 	rm.Add(schema.GroupVersionKind{

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/globals_vars_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/globals_vars_test.go
@@ -264,17 +264,6 @@ var (
 		NamespaceScoped: false,
 	}
 
-	addRepoReqTlsSkipVerify = &corev1.AddPackageRepositoryRequest{
-		Name:            "bar",
-		Context:         &corev1.Context{Namespace: "foo"},
-		Type:            "helm",
-		Url:             "http://example.com",
-		NamespaceScoped: true,
-		TlsConfig: &corev1.PackageRepositoryTlsConfig{
-			InsecureSkipVerify: true,
-		},
-	}
-
 	addRepoReqSimple = func(repoType string) *corev1.AddPackageRepositoryRequest {
 		return &corev1.AddPackageRepositoryRequest{
 			Name:            "bar",

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
@@ -32,6 +32,7 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
+//nolint:deadcode
 func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) (interface{}, error) {
 	svr := NewServer(opts.ConfigGetter, opts.ClustersConfig.KubeappsClusterName, opts.ClustersConfig.GlobalReposNamespace, opts.PluginConfigPath)
 	v1alpha1.RegisterHelmPackagesServiceServer(opts.Registrar, svr)
@@ -41,6 +42,7 @@ func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) 
 
 // RegisterHTTPHandlerFromEndpoint enables a plugin to register an http
 // handler to translate to the gRPC request.
+//nolint:deadcode
 func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
 	return v1alpha1.RegisterHelmPackagesServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)
 }

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -308,7 +308,7 @@ func (s *Server) GetAvailablePackageDetail(ctx context.Context, request *corev1.
 	if version == "" {
 		version = chart.ChartVersions[0].Version
 	}
-	fileID := fileIDForChart(unescapedChartID, chart.ChartVersions[0].Version)
+	fileID := fileIDForChart(unescapedChartID, version)
 	chartFiles, err := s.manager.GetChartFiles(namespace, fileID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Unable to retrieve chart files: %v", err)
@@ -995,7 +995,7 @@ func (s *Server) GetInstalledPackageResourceRefs(ctx context.Context, request *c
 }
 
 func (s *Server) AddPackageRepository(ctx context.Context, request *corev1.AddPackageRepositoryRequest) (*corev1.AddPackageRepositoryResponse, error) {
-	log.Infof("+helm AddPackageRepository '%s' pointing to '%s'", request.Name, request.Url)
+	log.Infof("+helm AddPackageRepository '%s' pointing to '%s'", request.GetName(), request.GetUrl())
 	if request == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "no request provided")
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/test_util_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/test_util_test.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	log "k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -190,9 +191,12 @@ func getCertsForTesting(t *testing.T) (ca, pub, priv []byte) {
 func newCtrlClient(repos []*appRepov1.AppRepository) client.WithWatch {
 	// Register required schema definitions
 	scheme := runtime.NewScheme()
-	appRepov1.AddToScheme(scheme)
+	err := appRepov1.AddToScheme(scheme)
+	if err != nil {
+		log.Fatalf("%s", err)
+	}
 
-	rm := apimeta.NewDefaultRESTMapper([]schema.GroupVersion{{AppRepositoryGroup, AppRepositoryVersion}})
+	rm := apimeta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: AppRepositoryGroup, Version: AppRepositoryVersion}})
 	rm.Add(schema.GroupVersionKind{
 		Group:   AppRepositoryGroup,
 		Version: AppRepositoryVersion,

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/postgresql_utils.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/postgresql_utils.go
@@ -73,7 +73,7 @@ func (m *PostgresAssetManager) GetChartWithFallback(namespace, chartID string, w
 	err := m.QueryOne(&chart, fmt.Sprintf("SELECT info FROM %s WHERE repo_namespace = $1 AND chart_id = $2", dbutils.ChartTable), namespace, chartID)
 	if err != nil {
 		splittedID := strings.Split(chartID, "/")
-		if withFallback == true && len(splittedID) == 2 {
+		if withFallback && len(splittedID) == 2 {
 			// fallback query when a chart_id is not being retrieved
 			// it may occur when upgrading a mirrored chart (eg, jfrog/bitnami/wordpress)
 			// and helms only gives 'jfrog/wordpress' but we want to retrieve 'jfrog/bitnami/wordpress'
@@ -120,7 +120,7 @@ func (m *PostgresAssetManager) GetChartVersionWithFallback(namespace, chartID, v
 	err := m.QueryOne(&chart, fmt.Sprintf("SELECT info FROM %s WHERE repo_namespace = $1 AND chart_id = $2", dbutils.ChartTable), namespace, chartID)
 	if err != nil {
 		splittedID := strings.Split(chartID, "/")
-		if withFallback == true && len(splittedID) == 2 {
+		if withFallback && len(splittedID) == 2 {
 			// fallback query when a chart_id is not being retrieved
 			// it may occur when upgrading a mirrored chart (eg, jfrog/bitnami/wordpress)
 			// and helms only gives 'jfrog/wordpress' but we want to retrieve 'jfrog/bitnami/wordpress'
@@ -157,7 +157,7 @@ func (m *PostgresAssetManager) GetChartFilesWithFallback(namespace, filesID stri
 	err := m.QueryOne(&chartFiles, fmt.Sprintf("SELECT info FROM %s WHERE repo_namespace = $1 AND chart_files_id = $2", dbutils.ChartFilesTable), namespace, filesID)
 	if err != nil {
 		splittedID := strings.Split(filesID, "/")
-		if withFallback == true && len(splittedID) == 2 {
+		if withFallback && len(splittedID) == 2 {
 			// fallback query when a chart_files_id is not being retrieved
 			// it may occur when upgrading a mirrored chart (eg, jfrog/bitnami/wordpress)
 			// and helms only gives 'jfrog/wordpress' but we want to retrieve 'jfrog/bitnami/wordpress'

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
@@ -27,6 +27,7 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
+//nolint:deadcode
 func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) (interface{}, error) {
 	svr := NewServer(opts.ConfigGetter, opts.ClustersConfig.KubeappsClusterName, opts.PluginConfigPath)
 	v1alpha1.RegisterKappControllerPackagesServiceServer(opts.Registrar, svr)
@@ -35,6 +36,7 @@ func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) 
 
 // RegisterHTTPHandlerFromEndpoint enables a plugin to register an http
 // handler to translate to the gRPC request.
+//nolint:deadcode
 func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
 	return v1alpha1.RegisterKappControllerPackagesServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)
 }

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
@@ -303,6 +303,7 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 	installedPkgSummaries := []*corev1.InstalledPackageSummary{}
 
 	if len(pkgInstalls) > 0 {
+		//nolint:ineffassign
 		startAt := -1
 		if pageSize > 0 {
 			startAt = itemOffset
@@ -523,6 +524,7 @@ func (s *Server) GetInstalledPackageDetail(ctx context.Context, request *corev1.
 		}
 	}
 	// trim the new doc separator in the last element
+	//nolint:staticcheck
 	valuesApplied = strings.Trim(valuesApplied, "---")
 
 	installedPackageDetail, err := s.buildInstalledPackageDetail(pkgInstall, pkgMetadata, pkgVersionsMap, app, valuesApplied, cluster)

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_repositories.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_repositories.go
@@ -65,7 +65,7 @@ func (s *Server) AddPackageRepository(ctx context.Context, request *corev1.AddPa
 	// update secret with owner reference if needed
 	if pkgSecret != nil {
 		setOwnerReference(pkgSecret, pkgRepository)
-		pkgSecret, err = s.updateSecret(ctx, cluster, pkgSecret)
+		_, err = s.updateSecret(ctx, cluster, pkgSecret)
 		if err != nil {
 			return nil, statuserror.FromK8sError("update", "Secret", request.Name, err)
 		}
@@ -261,7 +261,7 @@ func (s *Server) UpdatePackageRepository(ctx context.Context, request *corev1.Up
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to build the PackageRepository: %v", err)
 	}
-	pkgRepository, err = s.updatePkgRepository(ctx, cluster, namespace, pkgRepository)
+	_, err = s.updatePkgRepository(ctx, cluster, namespace, pkgRepository)
 	if err != nil {
 		return nil, statuserror.FromK8sError("update", "PackageRepository", name, err)
 	}

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_resources.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_resources.go
@@ -6,7 +6,6 @@ package main
 import (
 	"context"
 	"fmt"
-	k8scorev1 "k8s.io/api/core/v1"
 	"strings"
 
 	ctlapp "github.com/k14s/kapp/pkg/kapp/app"
@@ -17,6 +16,7 @@ import (
 	corev1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	k8scorev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,7 +35,6 @@ const (
 	pkgInstallsResource     = "packageinstalls"
 	appResource             = "App"
 	appsResource            = "apps"
-	appLabelKey             = "kapp.k14s.io/app"
 )
 
 // Dynamic ResourceInterface getters to encapsulate the logic of getting the proper group version API resources
@@ -113,6 +112,7 @@ func (s *Server) getAppResource(ctx context.Context, cluster, namespace string) 
 //  Single resource getters
 
 // getPkg returns the package for the given cluster, namespace and identifier
+//nolint:unused
 func (s *Server) getPkg(ctx context.Context, cluster, namespace, identifier string) (*datapackagingv1alpha1.Package, error) {
 	var pkg datapackagingv1alpha1.Package
 	resource, err := s.getPkgResource(ctx, cluster, namespace)
@@ -340,6 +340,7 @@ func (s *Server) getPkgRepositories(ctx context.Context, cluster, namespace stri
 }
 
 // getApps returns the list of apps for the given cluster and namespace
+//nolint:unused
 func (s *Server) getApps(ctx context.Context, cluster, namespace, identifier string) ([]*kappctrlv1alpha1.App, error) {
 	resource, err := s.getAppResource(ctx, cluster, namespace)
 	if err != nil {

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
@@ -300,7 +300,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -318,7 +318,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -417,7 +417,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -435,7 +435,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -453,7 +453,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -530,7 +530,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -594,7 +594,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -655,7 +655,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -673,7 +673,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -691,7 +691,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -792,7 +792,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -810,7 +810,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -828,7 +828,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -929,7 +929,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -947,7 +947,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -1035,7 +1035,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -1053,7 +1053,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -1078,6 +1078,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		},
 	}
 
+	//nolint:govet
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var unstructuredObjects []k8sruntime.Object
@@ -1174,7 +1175,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -1192,7 +1193,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -1210,7 +1211,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -1334,7 +1335,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -1428,7 +1429,7 @@ Some support information
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -1519,7 +1520,7 @@ Some support information
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -1620,7 +1621,7 @@ Some support information
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -1720,7 +1721,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&packagingv1alpha1.PackageInstall{
@@ -1748,7 +1749,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -1809,7 +1810,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -1854,7 +1855,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&packagingv1alpha1.PackageInstall{
@@ -1882,7 +1883,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -1982,7 +1983,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&packagingv1alpha1.PackageInstall{
@@ -2010,7 +2011,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -2086,7 +2087,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&packagingv1alpha1.PackageInstall{
@@ -2114,7 +2115,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -2200,7 +2201,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -2218,7 +2219,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&packagingv1alpha1.PackageInstall{
@@ -2246,7 +2247,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -2290,7 +2291,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -2410,7 +2411,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&packagingv1alpha1.PackageInstall{
@@ -2438,7 +2439,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 				},
@@ -2516,7 +2517,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -2534,7 +2535,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -2552,7 +2553,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&packagingv1alpha1.PackageInstall{
@@ -2580,7 +2581,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -2715,7 +2716,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -2860,7 +2861,7 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -2922,7 +2923,7 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -2951,7 +2952,7 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -3096,7 +3097,7 @@ fetchStderr
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&datapackagingv1alpha1.Package{
@@ -3158,7 +3159,7 @@ fetchStderr
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -3187,7 +3188,7 @@ fetchStderr
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -3356,7 +3357,7 @@ fetchStderr
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -3385,7 +3386,7 @@ fetchStderr
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -3590,7 +3591,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&kappctrlv1alpha1.App{
@@ -3603,7 +3604,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -3749,7 +3750,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 			},
@@ -3831,7 +3832,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&kappctrlv1alpha1.App{
@@ -3844,7 +3845,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -3987,7 +3988,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&kappctrlv1alpha1.App{
@@ -4000,7 +4001,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -4066,7 +4067,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 					Paused:     true,
 					Canceled:   false,
-					SyncPeriod: &metav1.Duration{(time.Second * 99)},
+					SyncPeriod: &metav1.Duration{Duration: (time.Second * 99)},
 					NoopDelete: false,
 				},
 				Status: packagingv1alpha1.PackageInstallStatus{
@@ -4145,7 +4146,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&kappctrlv1alpha1.App{
@@ -4158,7 +4159,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -4304,7 +4305,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&kappctrlv1alpha1.App{
@@ -4317,7 +4318,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -4416,7 +4417,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&kappctrlv1alpha1.App{
@@ -4429,7 +4430,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -4575,7 +4576,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&kappctrlv1alpha1.App{
@@ -4588,7 +4589,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -4730,7 +4731,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&kappctrlv1alpha1.App{
@@ -4743,7 +4744,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -4888,7 +4889,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&kappctrlv1alpha1.App{
@@ -4901,7 +4902,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -5046,7 +5047,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&kappctrlv1alpha1.App{
@@ -5059,7 +5060,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -5204,7 +5205,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&kappctrlv1alpha1.App{
@@ -5217,7 +5218,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -5362,7 +5363,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&kappctrlv1alpha1.App{
@@ -5375,7 +5376,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 						Name:      "my-installation",
 					},
 					Spec: kappctrlv1alpha1.AppSpec{
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					},
 					Status: kappctrlv1alpha1.AppStatus{
 						Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -5583,7 +5584,7 @@ func TestUpdateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&packagingv1alpha1.PackageInstall{
@@ -5611,7 +5612,7 @@ func TestUpdateInstalledPackage(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -5676,7 +5677,7 @@ func TestUpdateInstalledPackage(t *testing.T) {
 					},
 					Paused:     false,
 					Canceled:   false,
-					SyncPeriod: &metav1.Duration{(time.Second * 30)},
+					SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 					NoopDelete: false,
 				},
 				Status: packagingv1alpha1.PackageInstallStatus{
@@ -5758,7 +5759,7 @@ func TestUpdateInstalledPackage(t *testing.T) {
 						Licenses:                        []string{"my-license"},
 						ReleaseNotes:                    "release notes",
 						CapactiyRequirementsDescription: "capacity description",
-						ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				&packagingv1alpha1.PackageInstall{
@@ -5786,7 +5787,7 @@ func TestUpdateInstalledPackage(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -5918,7 +5919,7 @@ func TestDeleteInstalledPackage(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -5988,7 +5989,7 @@ func TestDeleteInstalledPackage(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -6110,7 +6111,7 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -6210,7 +6211,7 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -6310,7 +6311,7 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 						},
 						Paused:     false,
 						Canceled:   false,
-						SyncPeriod: &metav1.Duration{(time.Second * 30)},
+						SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 						NoopDelete: false,
 					},
 					Status: packagingv1alpha1.PackageInstallStatus{
@@ -9031,7 +9032,7 @@ func TestGetPackageRepositorySummariesFiltering(t *testing.T) {
 			},
 			existingObjects: repositories,
 			expectedResponse: []metav1.ObjectMeta{
-				metav1.ObjectMeta{Name: "nsrepo", Namespace: "privatens"},
+				{Name: "nsrepo", Namespace: "privatens"},
 			},
 		},
 		{
@@ -9041,7 +9042,7 @@ func TestGetPackageRepositorySummariesFiltering(t *testing.T) {
 			},
 			existingObjects: repositories,
 			expectedResponse: []metav1.ObjectMeta{
-				metav1.ObjectMeta{Name: "globalrepo", Namespace: globalPackagingNamespace},
+				{Name: "globalrepo", Namespace: globalPackagingNamespace},
 			},
 		},
 		{
@@ -9051,8 +9052,8 @@ func TestGetPackageRepositorySummariesFiltering(t *testing.T) {
 			},
 			existingObjects: repositories,
 			expectedResponse: []metav1.ObjectMeta{
-				metav1.ObjectMeta{Name: "globalrepo", Namespace: globalPackagingNamespace},
-				metav1.ObjectMeta{Name: "nsrepo", Namespace: "privatens"},
+				{Name: "globalrepo", Namespace: globalPackagingNamespace},
+				{Name: "nsrepo", Namespace: "privatens"},
 			},
 		},
 	}

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
@@ -288,7 +288,7 @@ func TestBuildPostInstallationNotes(t *testing.T) {
 				Name:      "my-installation",
 			},
 			Spec: kappctrlv1alpha1.AppSpec{
-				SyncPeriod: &metav1.Duration{(time.Second * 30)},
+				SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 			},
 			Status: kappctrlv1alpha1.AppStatus{
 				Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -341,7 +341,7 @@ fetchStderr
 				Name:      "my-installation",
 			},
 			Spec: kappctrlv1alpha1.AppSpec{
-				SyncPeriod: &metav1.Duration{(time.Second * 30)},
+				SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 			},
 			Status: kappctrlv1alpha1.AppStatus{
 				Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -377,7 +377,7 @@ fetchStdout
 				Name:      "my-installation",
 			},
 			Spec: kappctrlv1alpha1.AppSpec{
-				SyncPeriod: &metav1.Duration{(time.Second * 30)},
+				SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 			},
 			Status: kappctrlv1alpha1.AppStatus{
 				Deploy: &kappctrlv1alpha1.AppStatusDeploy{
@@ -415,7 +415,7 @@ fetchStderr
 				Name:      "my-installation",
 			},
 			Spec: kappctrlv1alpha1.AppSpec{
-				SyncPeriod: &metav1.Duration{(time.Second * 30)},
+				SyncPeriod: &metav1.Duration{Duration: (time.Second * 30)},
 			},
 			Status: kappctrlv1alpha1.AppStatus{
 				Fetch: &kappctrlv1alpha1.AppStatusFetch{
@@ -488,7 +488,7 @@ func TestBuildReadme(t *testing.T) {
 					Licenses:                        []string{"my-license"},
 					ReleaseNotes:                    "release notes",
 					CapactiyRequirementsDescription: "capacity description",
-					ReleasedAt:                      metav1.Time{time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+					ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
 				},
 			},
 			version: &semver.Version{},

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
@@ -821,6 +821,7 @@ func TestFilterMetadatas(t *testing.T) {
 		},
 	}
 
+	//nolint:govet
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			if got, want := FilterMetadatas(tc.metadatas, &tc.filterOptions), tc.expectedMetadatas; !cmp.Equal(want, got) {

--- a/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go
@@ -861,13 +861,13 @@ func TestDefaultValues(t *testing.T) {
 		{"empty", "null", nil, "null"},
 		{"scalar", "4", &structuralschema.Structural{
 			Generic: structuralschema.Generic{
-				Default: structuralschema.JSON{"foo"},
+				Default: structuralschema.JSON{Object: "foo"},
 			},
 		}, "4"},
 		{"scalar array", "[1,2]", &structuralschema.Structural{
 			Items: &structuralschema.Structural{
 				Generic: structuralschema.Generic{
-					Default: structuralschema.JSON{"foo"},
+					Default: structuralschema.JSON{Object: "foo"},
 				},
 			},
 		}, "[1,2]"},
@@ -876,17 +876,17 @@ func TestDefaultValues(t *testing.T) {
 				Properties: map[string]structuralschema.Structural{
 					"a": {
 						Generic: structuralschema.Generic{
-							Default: structuralschema.JSON{"A"},
+							Default: structuralschema.JSON{Object: "A"},
 						},
 					},
 					"b": {
 						Generic: structuralschema.Generic{
-							Default: structuralschema.JSON{"B"},
+							Default: structuralschema.JSON{Object: "B"},
 						},
 					},
 					"c": {
 						Generic: structuralschema.Generic{
-							Default: structuralschema.JSON{"C"},
+							Default: structuralschema.JSON{Object: "C"},
 						},
 					},
 				},
@@ -942,12 +942,12 @@ func TestDefaultValues(t *testing.T) {
 						Properties: map[string]structuralschema.Structural{
 							"a": {
 								Generic: structuralschema.Generic{
-									Default: structuralschema.JSON{"A"},
+									Default: structuralschema.JSON{Object: "A"},
 								},
 							},
 							"b": {
 								Generic: structuralschema.Generic{
-									Default: structuralschema.JSON{"B"},
+									Default: structuralschema.JSON{Object: "B"},
 								},
 							},
 						},
@@ -957,12 +957,12 @@ func TestDefaultValues(t *testing.T) {
 					Properties: map[string]structuralschema.Structural{
 						"a": {
 							Generic: structuralschema.Generic{
-								Default: structuralschema.JSON{"N"},
+								Default: structuralschema.JSON{Object: "N"},
 							},
 						},
 						"b": {
 							Generic: structuralschema.Generic{
-								Default: structuralschema.JSON{"O"},
+								Default: structuralschema.JSON{Object: "O"},
 							},
 						},
 					},
@@ -974,12 +974,12 @@ func TestDefaultValues(t *testing.T) {
 								Properties: map[string]structuralschema.Structural{
 									"a": {
 										Generic: structuralschema.Generic{
-											Default: structuralschema.JSON{"alpha"},
+											Default: structuralschema.JSON{Object: "alpha"},
 										},
 									},
 									"b": {
 										Generic: structuralschema.Generic{
-											Default: structuralschema.JSON{"beta"},
+											Default: structuralschema.JSON{Object: "beta"},
 										},
 									},
 								},
@@ -989,7 +989,7 @@ func TestDefaultValues(t *testing.T) {
 				},
 				"foo": {
 					Generic: structuralschema.Generic{
-						Default: structuralschema.JSON{"bar"},
+						Default: structuralschema.JSON{Object: "bar"},
 					},
 				},
 			},
@@ -999,7 +999,7 @@ func TestDefaultValues(t *testing.T) {
 				Properties: map[string]structuralschema.Structural{
 					"a": {
 						Generic: structuralschema.Generic{
-							Default: structuralschema.JSON{"A"},
+							Default: structuralschema.JSON{Object: "A"},
 						},
 					},
 				},
@@ -1013,7 +1013,7 @@ func TestDefaultValues(t *testing.T) {
 				Properties: map[string]structuralschema.Structural{
 					"a": {
 						Generic: structuralschema.Generic{
-							Default: structuralschema.JSON{"A"},
+							Default: structuralschema.JSON{Object: "A"},
 						},
 					},
 				},
@@ -1025,7 +1025,7 @@ func TestDefaultValues(t *testing.T) {
 			},
 			Items: &structuralschema.Structural{
 				Generic: structuralschema.Generic{
-					Default: structuralschema.JSON{"A"},
+					Default: structuralschema.JSON{Object: "A"},
 				},
 			},
 		}, `["A"]`},
@@ -1035,7 +1035,7 @@ func TestDefaultValues(t *testing.T) {
 				"a": {
 					Generic: structuralschema.Generic{
 						Nullable: true,
-						Default:  structuralschema.JSON{"A"},
+						Default:  structuralschema.JSON{Object: "A"},
 					},
 				},
 			},
@@ -1045,7 +1045,7 @@ func TestDefaultValues(t *testing.T) {
 				"a": {
 					Generic: structuralschema.Generic{
 						Nullable: false,
-						Default:  structuralschema.JSON{"A"},
+						Default:  structuralschema.JSON{Object: "A"},
 					},
 				},
 			},
@@ -1056,7 +1056,7 @@ func TestDefaultValues(t *testing.T) {
 					Structural: &structuralschema.Structural{
 						Generic: structuralschema.Generic{
 							Nullable: true,
-							Default:  structuralschema.JSON{"A"},
+							Default:  structuralschema.JSON{Object: "A"},
 						},
 					},
 				},
@@ -1068,7 +1068,7 @@ func TestDefaultValues(t *testing.T) {
 					Structural: &structuralschema.Structural{
 						Generic: structuralschema.Generic{
 							Nullable: false,
-							Default:  structuralschema.JSON{"A"},
+							Default:  structuralschema.JSON{Object: "A"},
 						},
 					},
 				},

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
@@ -16,12 +16,7 @@ import (
 
 // Set the pluginDetail once during a module init function so the single struct
 // can be used throughout the plugin.
-var (
-	pluginDetail pluginsgrpcv1alpha1.Plugin
-	// This version var is updated during the build (see the -ldflags option
-	// in the cmd/kubeapps-apis/Dockerfile)
-	version = "devel"
-)
+var pluginDetail pluginsgrpcv1alpha1.Plugin
 
 func init() {
 	pluginDetail = pluginsgrpcv1alpha1.Plugin{
@@ -32,6 +27,7 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
+//nolint:deadcode
 func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) (interface{}, error) {
 	svr, err := NewServer(opts.ConfigGetter, opts.ClientQPS, opts.ClientBurst)
 	if err != nil {
@@ -43,11 +39,13 @@ func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) 
 
 // RegisterHTTPHandlerFromEndpoint enables a plugin to register an http
 // handler to translate to the gRPC request.
+//nolint:deadcode
 func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
 	return v1alpha1.RegisterResourcesServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)
 }
 
 // GetPluginDetail returns a core.plugins.Plugin describing itself.
+//nolint:deadcode
 func GetPluginDetail() *pluginsgrpcv1alpha1.Plugin {
 	return &pluginDetail
 }

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -12,6 +12,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -115,7 +116,7 @@ func NewServer(configGetter core.KubernetesConfigGetter, clientQPS float32, clie
 		},
 		corePackagesClientGetter: func() (pkgsGRPCv1alpha1.PackagesServiceClient, error) {
 			port := os.Getenv("PORT")
-			conn, err := grpc.Dial("localhost:"+port, grpc.WithInsecure())
+			conn, err := grpc.Dial("localhost:"+port, grpc.WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "unable to dial to localhost grpc service: %s", err.Error())
 			}

--- a/cmd/kubeapps-apis/server/server.go
+++ b/cmd/kubeapps-apis/server/server.go
@@ -22,6 +22,7 @@ import (
 	packagesGRPCv1alpha1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	pluginsGRPCv1alpha1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -85,7 +86,7 @@ func Serve(serveOpts core.ServeOptions) error {
 		Ctx:         ctx,
 		Mux:         gw,
 		Addr:        listenAddr,
-		DialOptions: []grpc.DialOption{grpc.WithInsecure()},
+		DialOptions: []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
 	}
 
 	// Create the core.plugins.v1alpha1 server which handles registration of


### PR DESCRIPTION
### Description of the change

This PR is aimed at fixing those issues in the `kubeapps-apis` component. Some of them has been fixed and other, just marked as `nolint`.

### Benefits

Once we fix every issue, we will be able to merge the PR and therefore detect any linter issue before merging a PR.

### Possible drawbacks

N/A

### Applicable issues

- related #3087

### Additional information

N/A
