### PR TITLE
Add gh linter - fix issues in kubeops, asset-syncer and apprepo-ctrl

### DIFF
--- a/cmd/apprepository-controller/Dockerfile
+++ b/cmd/apprepository-controller/Dockerfile
@@ -11,7 +11,14 @@ COPY cmd cmd
 ARG VERSION
 
 ARG GOSEC_VERSION="2.12.0"
+ARG GOLANGCILINT_VERSION="1.46.2"
+
 RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v$GOSEC_VERSION
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v$GOLANGCILINT_VERSION
+
+# Run golangci-lint to detect issues
+RUN golangci-lint run --timeout=10m ./cmd/apprepository-controller/...
+RUN golangci-lint run --timeout=10m ./pkg/...
 
 # Run gosec to detect any security-related error at build time
 RUN gosec ./cmd/apprepository-controller/...

--- a/cmd/apprepository-controller/cmd/root_test.go
+++ b/cmd/apprepository-controller/cmd/root_test.go
@@ -133,7 +133,10 @@ func TestParseFlagsCorrect(t *testing.T) {
 			cmd.SetErr(b)
 			setFlags(cmd)
 			cmd.SetArgs(tt.args)
-			cmd.Execute()
+			err := cmd.Execute()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
 			if got, want := serveOpts, tt.conf; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}

--- a/cmd/asset-syncer/Dockerfile
+++ b/cmd/asset-syncer/Dockerfile
@@ -11,7 +11,14 @@ COPY cmd cmd
 ARG VERSION
 
 ARG GOSEC_VERSION="2.12.0"
+ARG GOLANGCILINT_VERSION="1.46.2"
+
 RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v$GOSEC_VERSION
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v$GOLANGCILINT_VERSION
+
+# Run golangci-lint to detect issues
+RUN golangci-lint run --timeout=10m ./cmd/asset-syncer/...
+RUN golangci-lint run --timeout=10m ./pkg/...
 
 # Run gosec to detect any security-related error at build time
 RUN gosec ./cmd/asset-syncer/...

--- a/cmd/asset-syncer/cmd/root_test.go
+++ b/cmd/asset-syncer/cmd/root_test.go
@@ -117,7 +117,10 @@ func TestParseFlagsCorrect(t *testing.T) {
 			cmd.SetOut(b)
 			cmd.SetErr(b)
 			cmd.SetArgs(tt.args)
-			cmd.Execute()
+			err := cmd.Execute()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
 			if got, want := serveOpts, tt.conf; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}

--- a/cmd/asset-syncer/server/postgresql_db_test.go
+++ b/cmd/asset-syncer/server/postgresql_db_test.go
@@ -405,7 +405,10 @@ func TestRepoAlreadyProcessed(t *testing.T) {
 	}
 
 	// not processed when repo exists but has not been processed
-	pam.EnsureRepoExists(repoNamespace, repoName)
+	_, err := pam.EnsureRepoExists(repoNamespace, repoName)
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
 	got = pam.LastChecksum(repo)
 	if got != "" {
 		t.Errorf("got: %s, want: %s", got, "")
@@ -413,7 +416,10 @@ func TestRepoAlreadyProcessed(t *testing.T) {
 
 	pam.UpdateLastCheck(repoNamespace, repoName, checksum, time.Now())
 	// processed when checksums match
-	pam.EnsureRepoExists(repoNamespace, repoName)
+	_, err := pam.EnsureRepoExists(repoNamespace, repoName)
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
 	got = pam.LastChecksum(repo)
 	if got != checksum {
 		t.Errorf("got: %s, want: %s", got, checksum)

--- a/cmd/asset-syncer/server/sync.go
+++ b/cmd/asset-syncer/server/sync.go
@@ -47,6 +47,9 @@ func Sync(serveOpts Config, version string, args []string) error {
 			return fmt.Errorf("Error: %v", err)
 		}
 		authorizationHeader, err = kube.GetAuthHeaderFromDockerConfig(dockerConfig)
+		if err != nil {
+			return fmt.Errorf("Error: %v", err)
+		}
 	}
 
 	filters, err := parseFilters(serveOpts.FilterRules)

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -6,7 +6,6 @@ package server
 import (
 	"bytes"
 	"compress/gzip"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"image"
@@ -46,7 +45,10 @@ func (h *badHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	w := httptest.NewRecorder()
 	w.WriteHeader(500)
 	if len(h.errMsg) > 0 {
-		w.Write([]byte(h.errMsg))
+		_, err := w.Write([]byte(h.errMsg))
+		if err != nil {
+			return nil, err
+		}
 	}
 	return w.Result(), nil
 }
@@ -119,12 +121,11 @@ type goodIconClient struct{}
 func iconBytes() []byte {
 	var b bytes.Buffer
 	img := imaging.New(1, 1, color.White)
-	imaging.Encode(&b, img, imaging.PNG)
+	err := imaging.Encode(&b, img, imaging.PNG)
+	if err != nil {
+		return nil
+	}
 	return b.Bytes()
-}
-
-func iconB64() string {
-	return base64.StdEncoding.EncodeToString(iconBytes())
 }
 
 func (h *goodIconClient) Do(req *http.Request) (*http.Response, error) {

--- a/cmd/kubeops/Dockerfile
+++ b/cmd/kubeops/Dockerfile
@@ -11,7 +11,14 @@ COPY cmd cmd
 ARG VERSION
 
 ARG GOSEC_VERSION="2.12.0"
+ARG GOLANGCILINT_VERSION="1.46.2"
+
 RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v$GOSEC_VERSION
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v$GOLANGCILINT_VERSION
+
+# Run golangci-lint to detect issues
+RUN golangci-lint run --timeout=10m ./cmd/kubeops/...
+RUN golangci-lint run --timeout=10m ./pkg/...
 
 # Run gosec to detect any security-related error at build time
 RUN gosec ./cmd/kubeops/...

--- a/cmd/kubeops/cmd/root_test.go
+++ b/cmd/kubeops/cmd/root_test.go
@@ -60,7 +60,10 @@ func TestParseFlagsCorrect(t *testing.T) {
 			cmd.SetErr(b)
 			setFlags(cmd)
 			cmd.SetArgs(tt.args)
-			cmd.Execute()
+			err := cmd.Execute()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
 			if got, want := serveOpts, tt.conf; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}

--- a/cmd/kubeops/internal/response/response_test.go
+++ b/cmd/kubeops/internal/response/response_test.go
@@ -49,7 +49,8 @@ func TestErrorResponse_Write(t *testing.T) {
 			tt.e.Write(w)
 			assert.Equal(t, tt.e.Code, w.Code)
 			var body ErrorResponse
-			json.NewDecoder(w.Body).Decode(&body)
+			err := json.NewDecoder(w.Body).Decode(&body)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.e, body)
 		})
 	}


### PR DESCRIPTION
### Description of the change

This PR is aimed at fixing those issues in the `kubeops`, `asset-syncer`and `apprepo-ctrl` components. Some of them has been fixed and other, just marked as `nolint`.

### Benefits

Once we fix every issue, we will be able to merge the PR and therefore detect any linter issue before merging a PR.

### Possible drawbacks

N/A

### Applicable issues

- related #3087

### Additional information

N/A
