### PR TITLE
Clean up unused vars from the pkgRepo state

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -156,7 +156,7 @@ const pkgRepoFormData = {
 } as IPkgRepoFormData;
 
 const actionTestCases: ITestCase[] = [
-  { name: "addRepo", action: repoActions.addRepo },
+  { name: "addOrUpdateRepo", action: repoActions.addOrUpdateRepo },
   {
     name: "addedRepo",
     action: repoActions.addedRepo,
@@ -177,8 +177,6 @@ const actionTestCases: ITestCase[] = [
     args: [packageRepositoryDetail],
     payload: packageRepositoryDetail,
   },
-  { name: "redirect", action: repoActions.redirect, args: "/foo", payload: "/foo" },
-  { name: "redirected", action: repoActions.redirected },
   {
     name: "errorRepos",
     action: repoActions.errorRepos,
@@ -506,14 +504,14 @@ describe("installRepo", () => {
     });
   });
 
-  it("dispatches addRepo and errorRepos if error fetching", async () => {
+  it("dispatches addOrUpdateRepo and errorRepos if error fetching", async () => {
     PackageRepositoriesService.addPackageRepository = jest.fn().mockImplementationOnce(() => {
       throw new Error("Boom!");
     });
 
     const expectedActions = [
       {
-        type: getType(repoActions.addRepo),
+        type: getType(repoActions.addOrUpdateRepo),
       },
       {
         type: getType(repoActions.errorRepos),
@@ -534,10 +532,10 @@ describe("installRepo", () => {
     expect(res).toEqual(false);
   });
 
-  it("dispatches addRepo and addedRepo if no error", async () => {
+  it("dispatches addOrUpdateRepo and addedRepo if no error", async () => {
     const expectedActions = [
       {
-        type: getType(repoActions.addRepo),
+        type: getType(repoActions.addOrUpdateRepo),
       },
       {
         type: getType(repoActions.addedRepo),
@@ -604,7 +602,7 @@ describe("updateRepo", () => {
     } as GetPackageRepositoryDetailResponse);
     const expectedActions = [
       {
-        type: getType(repoActions.requestRepoUpdate),
+        type: getType(repoActions.addOrUpdateRepo),
       },
       {
         type: getType(repoActions.repoUpdated),
@@ -647,7 +645,7 @@ describe("updateRepo", () => {
     } as GetPackageRepositoryDetailResponse);
     const expectedActions = [
       {
-        type: getType(repoActions.requestRepoUpdate),
+        type: getType(repoActions.addOrUpdateRepo),
       },
       {
         type: getType(repoActions.repoUpdated),
@@ -675,7 +673,7 @@ describe("updateRepo", () => {
     });
     const expectedActions = [
       {
-        type: getType(repoActions.requestRepoUpdate),
+        type: getType(repoActions.addOrUpdateRepo),
       },
       {
         type: getType(repoActions.errorRepos),
@@ -775,10 +773,13 @@ describe("findPackageInRepo", () => {
         type: getType(repoActions.requestRepoDetail),
       },
       {
-        type: getType(actions.availablepackages.createErrorPackage),
-        payload: new NotFoundError(
-          "Package my-repo/my-package not found in the repository other-namespace.",
-        ),
+        type: getType(repoActions.errorRepos),
+        payload: {
+          err: new NotFoundError(
+            "Package my-repo/my-package not found in the repository other-namespace.",
+          ),
+          op: "fetch",
+        },
       },
     ];
 

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -393,17 +393,17 @@ describe("fetchRepoSummaries", () => {
   });
 });
 
-describe("installRepo", () => {
-  const installRepoCMD = repoActions.installRepo("my-namespace", pkgRepoFormData);
+describe("addRepo", () => {
+  const addRepoCMD = repoActions.addRepo("my-namespace", pkgRepoFormData);
 
   context("when authHeader provided", () => {
-    const installRepoCMDAuth = repoActions.installRepo("my-namespace", {
+    const addRepoCMDAuth = repoActions.addRepo("my-namespace", {
       ...pkgRepoFormData,
       authHeader: "Bearer: abc",
     });
 
     it("calls PackageRepositoriesService create including a auth struct (authHeader)", async () => {
-      await store.dispatch(installRepoCMDAuth);
+      await store.dispatch(addRepoCMDAuth);
       expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
         "default",
         "my-namespace",
@@ -417,7 +417,7 @@ describe("installRepo", () => {
 
     it("calls PackageRepositoriesService create including ociRepositories", async () => {
       await store.dispatch(
-        repoActions.installRepo("my-namespace", {
+        repoActions.addRepo("my-namespace", {
           ...pkgRepoFormData,
           type: RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI,
           customDetails: {
@@ -443,7 +443,7 @@ describe("installRepo", () => {
 
     it("calls PackageRepositoriesService create skipping TLS verification", async () => {
       await store.dispatch(
-        repoActions.installRepo("my-namespace", { ...pkgRepoFormData, skipTLS: true }),
+        repoActions.addRepo("my-namespace", { ...pkgRepoFormData, skipTLS: true }),
       );
       expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
         "default",
@@ -457,19 +457,19 @@ describe("installRepo", () => {
     });
 
     it("returns true", async () => {
-      const res = await store.dispatch(installRepoCMDAuth);
+      const res = await store.dispatch(addRepoCMDAuth);
       expect(res).toBe(true);
     });
   });
 
   context("when a customCA is provided", () => {
-    const installRepoCMDAuth = repoActions.installRepo("my-namespace", {
+    const addRepoCMDAuth = repoActions.addRepo("my-namespace", {
       ...pkgRepoFormData,
       customCA: "This is a cert!",
     });
 
     it("calls PackageRepositoriesService create including a auth struct (custom CA)", async () => {
-      await store.dispatch(installRepoCMDAuth);
+      await store.dispatch(addRepoCMDAuth);
       expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
         "default",
         "my-namespace",
@@ -481,15 +481,15 @@ describe("installRepo", () => {
       );
     });
 
-    it("returns true (installRepoCMDAuth)", async () => {
-      const res = await store.dispatch(installRepoCMDAuth);
+    it("returns true (addRepoCMDAuth)", async () => {
+      const res = await store.dispatch(addRepoCMDAuth);
       expect(res).toBe(true);
     });
   });
 
   context("when authHeader and customCA are empty", () => {
     it("calls PackageRepositoriesService create without a auth struct", async () => {
-      await store.dispatch(installRepoCMD);
+      await store.dispatch(addRepoCMD);
       expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
         "default",
         "my-namespace",
@@ -498,8 +498,8 @@ describe("installRepo", () => {
       );
     });
 
-    it("returns true (installRepoCMD)", async () => {
-      const res = await store.dispatch(installRepoCMD);
+    it("returns true (addRepoCMD)", async () => {
+      const res = await store.dispatch(addRepoCMD);
       expect(res).toBe(true);
     });
   });
@@ -519,7 +519,7 @@ describe("installRepo", () => {
       },
     ];
 
-    await store.dispatch(installRepoCMD);
+    await store.dispatch(addRepoCMD);
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -528,7 +528,7 @@ describe("installRepo", () => {
       throw new Error("Boom!");
     });
 
-    const res = await store.dispatch(installRepoCMD);
+    const res = await store.dispatch(addRepoCMD);
     expect(res).toEqual(false);
   });
 
@@ -543,13 +543,13 @@ describe("installRepo", () => {
       },
     ];
 
-    await store.dispatch(installRepoCMD);
+    await store.dispatch(addRepoCMD);
     expect(store.getActions()).toEqual(expectedActions);
   });
 
   it("includes registry secrets if given", async () => {
     await store.dispatch(
-      repoActions.installRepo("my-namespace", {
+      repoActions.addRepo("my-namespace", {
         ...pkgRepoFormData,
         customDetails: { ...pkgRepoFormData.customDetails, dockerRegistrySecrets: ["repo-1"] },
       }),
@@ -568,7 +568,7 @@ describe("installRepo", () => {
 
   it("calls PackageRepositoriesService create with description", async () => {
     await store.dispatch(
-      repoActions.installRepo("my-namespace", {
+      repoActions.addRepo("my-namespace", {
         ...pkgRepoFormData,
         description: "This is a weird description 123!@#$%^&&*()_+-=<>?/.,;:'\"",
       }),

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -23,7 +23,7 @@ const { createAction } = deprecated;
 export const addOrUpdateRepo = createAction("ADD_OR_UPDATE_REPO");
 
 export const addedRepo = createAction("ADDED_REPO", resolve => {
-  return (added: PackageRepositorySummary) => resolve(added);
+  return (repoSummary: PackageRepositorySummary) => resolve(repoSummary);
 });
 
 export const errorRepos = createAction("ERROR_REPOS", resolve => {
@@ -31,15 +31,15 @@ export const errorRepos = createAction("ERROR_REPOS", resolve => {
 });
 
 export const receiveRepoDetail = createAction("RECEIVE_REPO", resolve => {
-  return (repo: PackageRepositoryDetail) => resolve(repo);
+  return (repoDetail: PackageRepositoryDetail) => resolve(repoDetail);
 });
 
 export const receiveRepoSummaries = createAction("RECEIVE_REPOS", resolve => {
-  return (repos: PackageRepositorySummary[]) => resolve(repos);
+  return (repoSummaries: PackageRepositorySummary[]) => resolve(repoSummaries);
 });
 
 export const repoUpdated = createAction("REPO_UPDATED", resolve => {
-  return (updated: PackageRepositorySummary) => resolve(updated);
+  return (repoSummary: PackageRepositorySummary) => resolve(repoSummary);
 });
 
 export const requestRepoDetail = createAction("REQUEST_REPO");

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -100,7 +100,7 @@ export const fetchRepoSummaries = (
   };
 };
 
-export const fetchRepo = (
+export const fetchRepoDetail = (
   packageRepoRef: PackageRepositoryReference,
 ): ThunkAction<Promise<boolean>, IStoreState, null, PkgReposAction> => {
   return async dispatch => {
@@ -129,7 +129,7 @@ export const fetchRepo = (
   };
 };
 
-export const installRepo = (
+export const addRepo = (
   namespace: string,
   request: IPkgRepoFormData,
 ): ThunkAction<Promise<boolean>, IStoreState, null, PkgReposAction> => {

--- a/dashboard/src/components/AppUpgrade/AppUpgrade.test.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.test.tsx
@@ -145,7 +145,7 @@ it("renders the repo selection form if not introduced", () => {
 it("renders the repo selection form if not introduced when the app is loaded", () => {
   const state = {
     repos: {
-      repos: [repo1Summary],
+      reposSummaries: [repo1Summary],
     } as IPackageRepositoryState,
     apps: {
       selected: { name: "foo" },
@@ -198,7 +198,7 @@ describe("when an error exists", () => {
   it("renders a warning message if there are no repositories", () => {
     const state = {
       repos: {
-        repos: [] as PackageRepositorySummary[],
+        reposSummaries: [] as PackageRepositorySummary[],
       } as IPackageRepositoryState,
       apps: {
         selected: { name: "foo" },
@@ -263,8 +263,8 @@ it("renders the upgrade form when the repo is available, clears state and fetche
       selectedDetails: availablePackageDetail,
     } as IInstalledPackageState,
     repos: {
-      repo: repo1Detail,
-      repos: [repo1Summary],
+      repoDetail: repo1Detail,
+      reposSummaries: [repo1Summary],
       isFetching: false,
     } as IPackageRepositoryState,
     packages: { selected: selectedPackage } as IPackageState,
@@ -299,8 +299,8 @@ it("renders the upgrade form with the version property", () => {
       selectedDetails: availablePackageDetail,
     } as IInstalledPackageState,
     repos: {
-      repo: repo1Detail,
-      repos: [repo1Summary],
+      repoDetail: repo1Detail,
+      reposSummaries: [repo1Summary],
       isFetching: false,
     } as Partial<IPackageRepositoryState>,
     packages: { selected: selectedPackage } as IPackageState,
@@ -327,8 +327,8 @@ it("skips the repo selection form if the app contains upgrade info", () => {
       selectedDetails: availablePackageDetail,
     } as IInstalledPackageState,
     repos: {
-      repo: repo1Detail,
-      repos: [repo1Summary],
+      repoDetail: repo1Detail,
+      reposSummaries: [repo1Summary],
       isFetching: false,
     } as IPackageRepositoryState,
     packages: { selected: selectedPackage } as IPackageState,

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -36,13 +36,9 @@ const defaultPackageState = {
   size: 20,
 } as IPackageState;
 const defaultProps = {
-  packages: defaultPackageState,
-  repo: "",
-  filter: {},
   cluster: initialState.config.kubeappsCluster,
   namespace: "kubeapps",
   kubeappsNamespace: "kubeapps",
-  csvs: [],
 };
 const availablePkgSummary1: AvailablePackageSummary = {
   name: "foo",
@@ -95,7 +91,7 @@ const csv = {
 const defaultState = {
   packages: defaultPackageState,
   operators: { csvs: [] } as Partial<IOperatorsState>,
-  repos: { repos: [] } as Partial<IPackageRepositoryState>,
+  repos: { reposSummaries: [] } as Partial<IPackageRepositoryState>,
   config: {
     kubeappsCluster: defaultProps.cluster,
     kubeappsNamespace: defaultProps.kubeappsNamespace,
@@ -661,7 +657,9 @@ describe("filters by package repository", () => {
     const wrapper = mountWrapper(
       getStore({
         ...populatedState,
-        repos: { repos: [{ name: "foo" } as PackageRepositorySummary] },
+        repos: {
+          reposSummaries: [{ name: "foo" } as PackageRepositorySummary],
+        } as IPackageRepositoryState,
       }),
       <MemoryRouter initialEntries={[routePathParam]}>
         <Route path={routePath}>
@@ -689,7 +687,9 @@ describe("filters by package repository", () => {
     const wrapper = mountWrapper(
       getStore({
         ...populatedState,
-        repos: { repos: [{ name: "foo" } as PackageRepositorySummary] },
+        repos: {
+          reposSummaries: [{ name: "foo" } as PackageRepositorySummary],
+        } as IPackageRepositoryState,
       }),
       <MemoryRouter initialEntries={[`/c/${defaultProps.cluster}/ns/my-ns/catalog`]}>
         <Route path={routePath}>

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -87,7 +87,7 @@ export default function Catalog() {
       isFetching,
     },
     operators,
-    repos: { repos },
+    repos: { reposSummaries: repos },
     config: { appVersion, kubeappsCluster, globalReposNamespace, featureFlags },
   } = useSelector((state: IStoreState) => state);
   const { cluster, namespace } = ReactRouter.useParams() as IRouteParams;

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoButton.test.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoButton.test.tsx
@@ -73,11 +73,11 @@ it("should render a secondary button", () => {
   expect(wrapper.find(CdsIcon)).not.toExist();
 });
 
-it("calls installRepo when submitting", () => {
-  const installRepo = jest.fn();
+it("calls addRepo when submitting", () => {
+  const addRepo = jest.fn();
   actions.repos = {
     ...actions.repos,
-    installRepo,
+    addRepo,
   };
 
   const wrapper = mountWrapper(defaultStore, <PkgRepoAddButton {...defaultProps} />);
@@ -86,7 +86,7 @@ it("calls installRepo when submitting", () => {
   });
   wrapper.update();
   (wrapper.find(PkgRepoForm).prop("onSubmit") as any)();
-  expect(installRepo).toHaveBeenCalled();
+  expect(addRepo).toHaveBeenCalled();
 });
 
 it("calls updateRepo when submitting and there is a repo available", () => {

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoButton.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoButton.tsx
@@ -44,7 +44,7 @@ export function PkgRepoAddButton({
     if (packageRepoRef) {
       return dispatch(actions.repos.updateRepo(namespace, request));
     } else {
-      return dispatch(actions.repos.installRepo(namespace, request));
+      return dispatch(actions.repos.addRepo(namespace, request));
     }
   };
 

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
@@ -9,6 +9,7 @@ import {
   PackageRepositoryAuth_PackageRepositoryAuthType,
   PackageRepositoryDetail,
   PackageRepositoryReference,
+  PackageRepositorySummary,
 } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
 import { HelmPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
@@ -28,7 +29,12 @@ const defaultProps = {
 };
 
 const defaultState = {
-  repos: { repo: {} } as Partial<IPackageRepositoryState>,
+  repos: {
+    isFetching: false,
+    repos: [] as PackageRepositorySummary[],
+    repo: {} as PackageRepositoryDetail,
+    errors: {},
+  } as IPackageRepositoryState,
 } as IStoreState;
 
 const pkgRepoFormData = {
@@ -90,20 +96,26 @@ afterEach(() => {
   spyOnUseDispatch.mockRestore();
 });
 
-it("disables the submit button while fetching", async () => {
+it("disables the submit button while loading", async () => {
   let wrapper: any;
   await act(async () => {
     wrapper = mountWrapper(
-      getStore({ repos: { validating: true } }),
+      getStore({
+        ...defaultState,
+        repos: { ...defaultState.repos, isFetching: true } as IPackageRepositoryState,
+      }),
       <PkgRepoForm {...defaultProps} />,
     );
   });
-  expect(
-    wrapper
-      .find(CdsButton)
-      .filterWhere((b: any) => b.html().includes("Validating"))
-      .prop("disabled"),
-  ).toBe(true);
+  await waitFor(() => {
+    wrapper.update();
+    expect(
+      wrapper
+        .find(CdsButton)
+        .filterWhere((b: any) => b.html().includes("Loading"))
+        .prop("disabled"),
+    ).toBe(true);
+  });
 });
 
 it("submit button can not be fired more than once", async () => {
@@ -130,29 +142,67 @@ it("submit button can not be fired more than once", async () => {
   expect(onSubmit.mock.calls.length).toBe(1);
 });
 
-it("should show a validation error", async () => {
+it("shows an error creating a repo", async () => {
   let wrapper: any;
   await act(async () => {
     wrapper = mountWrapper(
-      getStore({ repos: { errors: { validate: new Error("Boom!") } } }),
-      <PkgRepoForm {...defaultProps} />,
-    );
-  });
-  expect(wrapper.find(Alert).text()).toContain("Boom!");
-});
-
-it("shows an error updating a repo", async () => {
-  let wrapper: any;
-  await act(async () => {
-    wrapper = mountWrapper(
-      getStore({ repos: { errors: { update: new Error("boom!") } } }),
+      getStore({
+        repos: {
+          errors: { create: new Error("boom!") },
+        } as IPackageRepositoryState,
+      }),
       <PkgRepoForm {...defaultProps} />,
     );
   });
   expect(wrapper.find(Alert)).toIncludeText("boom!");
 });
 
-it("should call the install method when the validation success", async () => {
+it("shows an error deleting a repo", async () => {
+  let wrapper: any;
+  await act(async () => {
+    wrapper = mountWrapper(
+      getStore({
+        repos: {
+          errors: { delete: new Error("boom!") },
+        } as IPackageRepositoryState,
+      }),
+      <PkgRepoForm {...defaultProps} />,
+    );
+  });
+  expect(wrapper.find(Alert)).toIncludeText("boom!");
+});
+
+it("shows an error fetching a repo", async () => {
+  let wrapper: any;
+  await act(async () => {
+    wrapper = mountWrapper(
+      getStore({
+        repos: {
+          errors: { fetch: new Error("boom!") },
+        } as IPackageRepositoryState,
+      }),
+      <PkgRepoForm {...defaultProps} />,
+    );
+  });
+  expect(wrapper.find(Alert)).toIncludeText("boom!");
+});
+
+it("shows an error updating a repo", async () => {
+  let wrapper: any;
+  await act(async () => {
+    wrapper = mountWrapper(
+      getStore({
+        repos: {
+          errors: { update: new Error("boom!") },
+        } as IPackageRepositoryState,
+      }),
+      <PkgRepoForm {...defaultProps} />,
+    );
+  });
+  expect(wrapper.find(Alert)).toIncludeText("boom!");
+});
+
+it("should call the install method", async () => {
   const install = jest.fn().mockReturnValue(true);
   actions.repos = {
     ...actions.repos,
@@ -474,7 +524,10 @@ describe("when the repository info is already populated", () => {
     let wrapper: any;
     await act(async () => {
       wrapper = mountWrapper(
-        getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+        getStore({
+          ...defaultState,
+          repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+        }),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
     });
@@ -494,7 +547,10 @@ describe("when the repository info is already populated", () => {
     let wrapper: any;
     await act(async () => {
       wrapper = mountWrapper(
-        getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+        getStore({
+          ...defaultState,
+          repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+        }),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
     });
@@ -519,7 +575,10 @@ describe("when the repository info is already populated", () => {
     let wrapper: any;
     await act(async () => {
       wrapper = mountWrapper(
-        getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+        getStore({
+          ...defaultState,
+          repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+        }),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
     });
@@ -545,7 +604,10 @@ describe("when the repository info is already populated", () => {
     let wrapper: any;
     await act(async () => {
       wrapper = mountWrapper(
-        getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+        getStore({
+          ...defaultState,
+          repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+        }),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
     });
@@ -565,7 +627,10 @@ describe("when the repository info is already populated", () => {
     let wrapper: any;
     await act(async () => {
       wrapper = mountWrapper(
-        getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+        getStore({
+          ...defaultState,
+          repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+        }),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
     });
@@ -585,7 +650,10 @@ describe("when the repository info is already populated", () => {
     let wrapper: any;
     await act(async () => {
       wrapper = mountWrapper(
-        getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+        getStore({
+          ...defaultState,
+          repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+        }),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
     });
@@ -600,7 +668,10 @@ describe("when the repository info is already populated", () => {
     let wrapper: any;
     await act(async () => {
       wrapper = mountWrapper(
-        getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+        getStore({
+          ...defaultState,
+          repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+        }),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
     });
@@ -616,7 +687,10 @@ describe("when the repository info is already populated", () => {
       let wrapper: any;
       await act(async () => {
         wrapper = mountWrapper(
-          getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+          getStore({
+            ...defaultState,
+            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });
@@ -635,7 +709,10 @@ describe("when the repository info is already populated", () => {
       let wrapper: any;
       await act(async () => {
         wrapper = mountWrapper(
-          getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+          getStore({
+            ...defaultState,
+            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });
@@ -657,7 +734,10 @@ describe("when the repository info is already populated", () => {
       let wrapper: any;
       await act(async () => {
         wrapper = mountWrapper(
-          getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+          getStore({
+            ...defaultState,
+            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });
@@ -680,7 +760,10 @@ describe("when the repository info is already populated", () => {
       let wrapper: any;
       await act(async () => {
         wrapper = mountWrapper(
-          getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+          getStore({
+            ...defaultState,
+            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });
@@ -707,7 +790,10 @@ describe("when the repository info is already populated", () => {
       let wrapper: any;
       await act(async () => {
         wrapper = mountWrapper(
-          getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+          getStore({
+            ...defaultState,
+            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });
@@ -734,7 +820,10 @@ describe("when the repository info is already populated", () => {
       let wrapper: any;
       await act(async () => {
         wrapper = mountWrapper(
-          getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+          getStore({
+            ...defaultState,
+            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });
@@ -759,7 +848,10 @@ describe("when the repository info is already populated", () => {
       let wrapper: any;
       await act(async () => {
         wrapper = mountWrapper(
-          getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+          getStore({
+            ...defaultState,
+            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });
@@ -785,7 +877,10 @@ describe("when the repository info is already populated", () => {
       let wrapper: any;
       await act(async () => {
         wrapper = mountWrapper(
-          getStore({ ...defaultState, repos: { ...defaultState.repos, repo: testRepo } }),
+          getStore({
+            ...defaultState,
+            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
@@ -31,8 +31,8 @@ const defaultProps = {
 const defaultState = {
   repos: {
     isFetching: false,
-    repos: [] as PackageRepositorySummary[],
-    repo: {} as PackageRepositoryDetail,
+    reposSummaries: [] as PackageRepositorySummary[],
+    repoDetail: {} as PackageRepositoryDetail,
     errors: {},
   } as IPackageRepositoryState,
 } as IStoreState;
@@ -526,7 +526,7 @@ describe("when the repository info is already populated", () => {
       wrapper = mountWrapper(
         getStore({
           ...defaultState,
-          repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
         }),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
@@ -549,7 +549,7 @@ describe("when the repository info is already populated", () => {
       wrapper = mountWrapper(
         getStore({
           ...defaultState,
-          repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
         }),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
@@ -577,7 +577,7 @@ describe("when the repository info is already populated", () => {
       wrapper = mountWrapper(
         getStore({
           ...defaultState,
-          repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
         }),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
@@ -606,7 +606,7 @@ describe("when the repository info is already populated", () => {
       wrapper = mountWrapper(
         getStore({
           ...defaultState,
-          repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
         }),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
@@ -629,7 +629,7 @@ describe("when the repository info is already populated", () => {
       wrapper = mountWrapper(
         getStore({
           ...defaultState,
-          repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
         }),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
@@ -652,7 +652,7 @@ describe("when the repository info is already populated", () => {
       wrapper = mountWrapper(
         getStore({
           ...defaultState,
-          repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
         }),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
@@ -670,7 +670,7 @@ describe("when the repository info is already populated", () => {
       wrapper = mountWrapper(
         getStore({
           ...defaultState,
-          repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+          repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
         }),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
@@ -689,7 +689,7 @@ describe("when the repository info is already populated", () => {
         wrapper = mountWrapper(
           getStore({
             ...defaultState,
-            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+            repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
           }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
@@ -711,7 +711,7 @@ describe("when the repository info is already populated", () => {
         wrapper = mountWrapper(
           getStore({
             ...defaultState,
-            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+            repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
           }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
@@ -736,7 +736,7 @@ describe("when the repository info is already populated", () => {
         wrapper = mountWrapper(
           getStore({
             ...defaultState,
-            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+            repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
           }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
@@ -762,7 +762,7 @@ describe("when the repository info is already populated", () => {
         wrapper = mountWrapper(
           getStore({
             ...defaultState,
-            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+            repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
           }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
@@ -792,7 +792,7 @@ describe("when the repository info is already populated", () => {
         wrapper = mountWrapper(
           getStore({
             ...defaultState,
-            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+            repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
           }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
@@ -822,7 +822,7 @@ describe("when the repository info is already populated", () => {
         wrapper = mountWrapper(
           getStore({
             ...defaultState,
-            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+            repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
           }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
@@ -850,7 +850,7 @@ describe("when the repository info is already populated", () => {
         wrapper = mountWrapper(
           getStore({
             ...defaultState,
-            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+            repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
           }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
@@ -879,7 +879,7 @@ describe("when the repository info is already populated", () => {
         wrapper = mountWrapper(
           getStore({
             ...defaultState,
-            repos: { ...defaultState.repos, repo: testRepo } as IPackageRepositoryState,
+            repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
           }),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
@@ -160,7 +160,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
 
   useEffect(() => {
     if (selectedPkgRepo) {
-      dispatch(actions.repos.fetchRepo(selectedPkgRepo));
+      dispatch(actions.repos.fetchRepoDetail(selectedPkgRepo));
     }
   }, [dispatch, selectedPkgRepo]);
 

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
@@ -71,7 +71,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
 
   const {
     repos: {
-      repo,
+      repoDetail: repo,
       isFetching,
       errors: { create: createError, update: updateError, delete: deleteError, fetch: fetchError },
     },

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
@@ -72,8 +72,8 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
   const {
     repos: {
       repo,
-      errors: { create: createError, update: updateError, validate: validationError },
-      validating,
+      isFetching,
+      errors: { create: createError, update: updateError, delete: deleteError, fetch: fetchError },
     },
     clusters: { currentCluster },
   } = useSelector((state: IStoreState) => state);
@@ -454,19 +454,6 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
   // };
   const handleIsUserManagedCASecretChange = (_e: React.ChangeEvent<HTMLInputElement>) => {
     setIsUserManagedCASecret(!isUserManagedCASecret);
-  };
-
-  const parseValidationError = (error: Error) => {
-    let message = error.message;
-    try {
-      const parsedMessage = JSON.parse(message);
-      if (parsedMessage.code && parsedMessage.message) {
-        message = `Code: ${parsedMessage.code}. Message: ${parsedMessage.message}`;
-      }
-    } catch (e: any) {
-      // Not a json message
-    }
-    return message;
   };
 
   const userManagedSecretText = "Use an existing secret";
@@ -1757,11 +1744,6 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
             installation in every namespace and cluster.
           </p>
         )}
-        {validationError && (
-          <Alert theme="danger">
-            Validation Failed. Got: {parseValidationError(validationError)}
-          </Alert>
-        )}
         {createError && (
           <Alert theme="danger">
             An error occurred while creating the repository: {createError.message}
@@ -1772,10 +1754,20 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
             An error occurred while updating the repository: {updateError.message}
           </Alert>
         )}
+        {deleteError && (
+          <Alert theme="danger">
+            An error occurred while deleting the repository: {deleteError.message}
+          </Alert>
+        )}
+        {fetchError && (
+          <Alert theme="danger">
+            An error occurred while fetching the repository: {fetchError.message}
+          </Alert>
+        )}
         <div className="margin-t-xl">
-          <CdsButton type="submit" disabled={validating}>
-            {validating
-              ? "Validating..."
+          <CdsButton type="submit" disabled={isFetching}>
+            {isFetching
+              ? "Loading..."
               : `${repo.name ? `Update '${repo.name}'` : "Install"} Repository`}
           </CdsButton>
         </div>

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoList.test.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoList.test.tsx
@@ -15,6 +15,7 @@ import { PkgRepoControl } from "./PkgRepoControl";
 import { PkgRepoDisabledControl } from "./PkgRepoDisabledControl";
 import PkgRepoList from "./PkgRepoList";
 import TableRow from "components/js/Table/components/TableRow";
+import { IPackageRepositoryState } from "reducers/repos";
 
 const {
   clusters: { currentCluster, clusters },
@@ -106,7 +107,7 @@ it("shows a warning if the cluster is not the default one", () => {
 
 it("shows an error fetching a repo", () => {
   const wrapper = mountWrapper(
-    getStore({ repos: { errors: { fetch: new Error("boom!") } } }),
+    getStore({ repos: { errors: { fetch: new Error("boom!") } } as IPackageRepositoryState }),
     <PkgRepoList />,
   );
   expect(wrapper.find(Alert)).toIncludeText("boom!");
@@ -114,7 +115,7 @@ it("shows an error fetching a repo", () => {
 
 it("shows an error deleting a repo", () => {
   const wrapper = mountWrapper(
-    getStore({ repos: { errors: { delete: new Error("boom!") } } }),
+    getStore({ repos: { errors: { delete: new Error("boom!") } } as IPackageRepositoryState }),
     <PkgRepoList />,
   );
   expect(wrapper.find(Alert)).toIncludeText("boom!");
@@ -164,8 +165,8 @@ describe("global and namespaced repositories", () => {
           },
         },
         repos: {
-          repos: [globalRepo],
-        },
+          reposSummaries: [globalRepo],
+        } as IPackageRepositoryState,
       }),
       <PkgRepoList />,
     );
@@ -192,8 +193,8 @@ describe("global and namespaced repositories", () => {
           },
         },
         repos: {
-          repos: [globalRepo],
-        },
+          reposSummaries: [globalRepo],
+        } as IPackageRepositoryState,
       }),
       <PkgRepoList />,
     );
@@ -225,8 +226,8 @@ describe("global and namespaced repositories", () => {
           },
         },
         repos: {
-          repos: [globalRepo, namespacedRepo],
-        },
+          reposSummaries: [globalRepo, namespacedRepo],
+        } as IPackageRepositoryState,
       }),
       <PkgRepoList />,
     );
@@ -238,8 +239,8 @@ describe("global and namespaced repositories", () => {
     const wrapper = mountWrapper(
       getStore({
         repos: {
-          repos: [namespacedRepo],
-        },
+          reposSummaries: [namespacedRepo],
+        } as IPackageRepositoryState,
       }),
       <PkgRepoList />,
     );
@@ -252,8 +253,8 @@ describe("global and namespaced repositories", () => {
     const wrapper = mountWrapper(
       getStore({
         repos: {
-          repos: [namespacedRepo],
-        },
+          reposSummaries: [namespacedRepo],
+        } as IPackageRepositoryState,
       }),
       <PkgRepoList />,
     );
@@ -268,8 +269,8 @@ describe("global and namespaced repositories", () => {
     const wrapper = mountWrapper(
       getStore({
         repos: {
-          repos: [namespacedRepo],
-        },
+          reposSummaries: [namespacedRepo],
+        } as IPackageRepositoryState,
       }),
       <PkgRepoList />,
     );

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoList.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoList.tsx
@@ -30,7 +30,7 @@ function PkgRepoList() {
   const dispatch = useDispatch();
   const location = useLocation();
   const {
-    repos: { errors, isFetching, repos },
+    repos: { errors, isFetching, reposSummaries: repos },
     clusters: { clusters, currentCluster },
     config: { kubeappsCluster, kubeappsNamespace, globalReposNamespace },
   } = useSelector((state: IStoreState) => state);

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoList.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoList.tsx
@@ -30,7 +30,7 @@ function PkgRepoList() {
   const dispatch = useDispatch();
   const location = useLocation();
   const {
-    repos: { errors, isFetchingElem, repos },
+    repos: { errors, isFetching, repos },
     clusters: { clusters, currentCluster },
     config: { kubeappsCluster, kubeappsNamespace, globalReposNamespace },
   } = useSelector((state: IStoreState) => state);
@@ -216,7 +216,7 @@ function PkgRepoList() {
                 <LoadingWrapper
                   className="margin-t-xxl"
                   loadingText="Fetching Package Repositories..."
-                  loaded={!isFetchingElem.repositories}
+                  loaded={!isFetching}
                 >
                   <h3>Global Repositories:</h3>
                   <p>Global Package Repositories are available for all Kubeapps users.</p>

--- a/dashboard/src/components/SelectRepoForm/SelectRepoForm.test.tsx
+++ b/dashboard/src/components/SelectRepoForm/SelectRepoForm.test.tsx
@@ -8,6 +8,7 @@ import { InstalledPackageDetail } from "gen/kubeappsapis/core/packages/v1alpha1/
 import { PackageRepositorySummary } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
 import * as ReactRedux from "react-redux";
+import { IPackageRepositoryState } from "reducers/repos";
 import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
 import SelectRepoForm from "./SelectRepoForm";
 
@@ -96,7 +97,7 @@ it("should select a repo", () => {
 
   const props = { ...defaultContext, app: installedPackageDetail };
   const wrapper = mountWrapper(
-    getStore({ repos: { repos: [repo] } }),
+    getStore({ repos: { reposSummaries: [repo] } as IPackageRepositoryState }),
     <SelectRepoForm {...props} />,
   );
   wrapper.find("select").simulate("change", { target: { value: "default/bitnami" } });

--- a/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
+++ b/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
@@ -24,8 +24,8 @@ function SelectRepoForm({ cluster, namespace, app }: ISelectRepoFormProps) {
   const {
     repos: {
       isFetching,
-      repos,
-      repo,
+      reposSummaries: repos,
+      repoDetail: repo,
       errors: { fetch: fetchError },
     },
     packages: {

--- a/dashboard/src/reducers/repos.test.ts
+++ b/dashboard/src/reducers/repos.test.ts
@@ -14,39 +14,23 @@ describe("reposReducer", () => {
 
   beforeEach(() => {
     initialState = {
-      addingRepo: false,
       errors: {},
-      form: {
-        name: "",
-        namespace: "",
-        show: false,
-        url: "",
-      },
       isFetching: false,
-      isFetchingElem: {
-        repositories: false,
-        secrets: false,
-      },
-      validating: false,
       repo: {} as PackageRepositoryDetail,
       repos: [] as PackageRepositorySummary[],
-      imagePullSecrets: [],
-    };
+    } as IPackageRepositoryState;
   });
 
   describe("repos", () => {
     const actionTypes = {
-      addRepo: getType(actions.repos.addRepo),
+      addOrUpdateRepo: getType(actions.repos.addOrUpdateRepo),
       addedRepo: getType(actions.repos.addedRepo),
-      requestRepoUpdate: getType(actions.repos.requestRepoUpdate),
-      repoUpdated: getType(actions.repos.repoUpdated),
-      requestRepos: getType(actions.repos.requestRepoSummaries),
-      receiveRepos: getType(actions.repos.receiveRepoSummaries),
-      requestRepo: getType(actions.repos.requestRepoDetail),
-      receiveRepo: getType(actions.repos.receiveRepoDetail),
-      redirect: getType(actions.repos.redirect),
-      redirected: getType(actions.repos.redirected),
       errorRepos: getType(actions.repos.errorRepos),
+      receiveRepo: getType(actions.repos.receiveRepoDetail),
+      receiveRepos: getType(actions.repos.receiveRepoSummaries),
+      repoUpdated: getType(actions.repos.repoUpdated),
+      requestRepo: getType(actions.repos.requestRepoDetail),
+      requestRepos: getType(actions.repos.requestRepoSummaries),
     };
 
     describe("reducer actions", () => {
@@ -59,7 +43,6 @@ describe("reposReducer", () => {
         ).toEqual({
           ...initialState,
           isFetching: true,
-          isFetchingElem: { repositories: true, secrets: false },
         });
       });
 
@@ -72,7 +55,6 @@ describe("reposReducer", () => {
         expect(state).toEqual({
           ...initialState,
           isFetching: true,
-          isFetchingElem: { repositories: true, secrets: false },
         });
         expect(
           reposReducer(state, {
@@ -91,7 +73,6 @@ describe("reposReducer", () => {
         expect(state).toEqual({
           ...initialState,
           isFetching: true,
-          isFetchingElem: { repositories: true, secrets: false },
         });
         expect(
           reposReducer(state, {
@@ -105,14 +86,14 @@ describe("reposReducer", () => {
     it("adds a repo", () => {
       const repoSummary = { name: "foo" } as PackageRepositorySummary;
       const state = reposReducer(undefined, {
-        type: actionTypes.addRepo,
+        type: actionTypes.addOrUpdateRepo,
       });
       expect(state).toEqual({
         ...initialState,
-        addingRepo: true,
+        isFetching: true,
       });
       expect(
-        reposReducer(state, {
+        reposReducer(initialState, {
           type: actionTypes.addedRepo,
           payload: repoSummary,
         }),
@@ -122,17 +103,8 @@ describe("reposReducer", () => {
     it("adds a repo sorting the result", () => {
       const repoSummary1 = { name: "zzz" } as PackageRepositorySummary;
       const repoSummary2 = { name: "aaa" } as PackageRepositorySummary;
-      const state = reposReducer(
-        { ...initialState, repos: [repoSummary1] },
-        {
-          type: actionTypes.addRepo,
-        },
-      );
-      expect(state).toEqual({
-        ...initialState,
-        repos: [repoSummary1],
-        addingRepo: true,
-      });
+      const state = { ...initialState, repos: [repoSummary1] };
+
       expect(
         reposReducer(state, {
           type: actionTypes.addedRepo,

--- a/dashboard/src/reducers/repos.test.ts
+++ b/dashboard/src/reducers/repos.test.ts
@@ -16,8 +16,8 @@ describe("reposReducer", () => {
     initialState = {
       errors: {},
       isFetching: false,
-      repo: {} as PackageRepositoryDetail,
-      repos: [] as PackageRepositorySummary[],
+      repoDetail: {} as PackageRepositoryDetail,
+      reposSummaries: [] as PackageRepositorySummary[],
     } as IPackageRepositoryState;
   });
 
@@ -61,7 +61,7 @@ describe("reposReducer", () => {
             type: actionTypes.receiveRepos,
             payload: [repoSummary],
           }),
-        ).toEqual({ ...initialState, repos: [repoSummary] });
+        ).toEqual({ ...initialState, reposSummaries: [repoSummary] } as IPackageRepositoryState);
       });
 
       it("unsets isFetching and receive repo", () => {
@@ -79,7 +79,7 @@ describe("reposReducer", () => {
             type: actionTypes.receiveRepo,
             payload: repoDetail,
           }),
-        ).toEqual({ ...initialState, repo: repoDetail });
+        ).toEqual({ ...initialState, repoDetail: repoDetail } as IPackageRepositoryState);
       });
     });
 
@@ -97,20 +97,23 @@ describe("reposReducer", () => {
           type: actionTypes.addedRepo,
           payload: repoSummary,
         }),
-      ).toEqual({ ...initialState, repos: [repoSummary] });
+      ).toEqual({ ...initialState, reposSummaries: [repoSummary] } as IPackageRepositoryState);
     });
 
     it("adds a repo sorting the result", () => {
       const repoSummary1 = { name: "zzz" } as PackageRepositorySummary;
       const repoSummary2 = { name: "aaa" } as PackageRepositorySummary;
-      const state = { ...initialState, repos: [repoSummary1] };
+      const state = { ...initialState, reposSummaries: [repoSummary1] } as IPackageRepositoryState;
 
       expect(
         reposReducer(state, {
           type: actionTypes.addedRepo,
           payload: repoSummary2,
         }),
-      ).toEqual({ ...initialState, repos: [repoSummary2, repoSummary1] });
+      ).toEqual({
+        ...initialState,
+        reposSummaries: [repoSummary2, repoSummary1],
+      } as IPackageRepositoryState);
     });
 
     it("updates a repo", () => {
@@ -121,13 +124,16 @@ describe("reposReducer", () => {
       } as PackageRepositorySummary;
       expect(
         reposReducer(
-          { ...initialState, repos: [repoSummary] },
+          { ...initialState, reposSummaries: [repoSummary] },
           {
             type: actionTypes.repoUpdated,
             payload: { ...repoSummary, url: "bar" },
           },
         ),
-      ).toEqual({ ...initialState, repos: [{ ...repoSummary, url: "bar" }] });
+      ).toEqual({
+        ...initialState,
+        reposSummaries: [{ ...repoSummary, url: "bar" }],
+      } as IPackageRepositoryState);
     });
   });
 });

--- a/dashboard/src/reducers/repos.ts
+++ b/dashboard/src/reducers/repos.ts
@@ -24,15 +24,15 @@ export interface IPackageRepositoryState {
     update?: Error;
   };
   isFetching: boolean;
-  repo: PackageRepositoryDetail;
-  repos: PackageRepositorySummary[];
+  repoDetail: PackageRepositoryDetail;
+  reposSummaries: PackageRepositorySummary[];
 }
 
 export const initialState: IPackageRepositoryState = {
   errors: {},
   isFetching: false,
-  repo: {} as PackageRepositoryDetail,
-  repos: [] as PackageRepositorySummary[],
+  repoDetail: {} as PackageRepositoryDetail,
+  reposSummaries: [] as PackageRepositorySummary[],
 };
 
 const helmPackageRepositoryCustomDetail = {
@@ -54,7 +54,7 @@ const reposReducer = (
       return {
         ...state,
         isFetching: false,
-        repos: action.payload,
+        reposSummaries: action.payload,
         errors: {},
       };
     case getType(actions.repos.receiveRepoDetail):
@@ -96,19 +96,19 @@ const reposReducer = (
       return {
         ...state,
         isFetching: false,
-        repo: repoWithCustomDetail,
+        repoDetail: repoWithCustomDetail,
         errors: {},
       };
     case getType(actions.repos.requestRepoSummaries):
     case getType(actions.repos.addOrUpdateRepo):
       return { ...state, isFetching: true };
     case getType(actions.repos.requestRepoDetail):
-      return { ...state, repo: initialState.repo, errors: {} };
+      return { ...state, repoDetail: initialState.repoDetail, errors: {} };
     case getType(actions.repos.addedRepo):
       return {
         ...state,
         isFetching: false,
-        repos: [...state.repos, action.payload].sort((a, b) =>
+        reposSummaries: [...state.reposSummaries, action.payload].sort((a, b) =>
           a.name.toLowerCase() > b.name.toLowerCase()
             ? 1
             : b.name.toLowerCase() > a.name.toLowerCase()
@@ -118,13 +118,13 @@ const reposReducer = (
       };
     case getType(actions.repos.repoUpdated): {
       const updatedRepo = action.payload;
-      const repos = state.repos.map(r =>
+      const repos = state.reposSummaries.map(r =>
         r.name === updatedRepo.name &&
         r.packageRepoRef?.context?.namespace === updatedRepo.packageRepoRef?.context?.namespace
           ? updatedRepo
           : r,
       );
-      return { ...state, repos };
+      return { ...state, reposSummaries: repos };
     }
     case getType(actions.repos.errorRepos):
       return {

--- a/dashboard/src/reducers/repos.ts
+++ b/dashboard/src/reducers/repos.ts
@@ -7,70 +7,43 @@ import {
   PackageRepositorySummary,
 } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
 import { HelmPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
-import { ISecret } from "shared/types";
+import {
+  KappControllerPackageRepositoryCustomDetail,
+  PackageRepositoryFetch,
+} from "gen/kubeappsapis/plugins/kapp_controller/packages/v1alpha1/kapp_controller";
 import { PluginNames } from "shared/utils";
 import { getType } from "typesafe-actions";
 import actions from "../actions";
 import { PkgReposAction } from "../actions/repos";
 
 export interface IPackageRepositoryState {
-  addingRepo: boolean;
   errors: {
     create?: Error;
     delete?: Error;
     fetch?: Error;
     update?: Error;
-    validate?: Error;
   };
-  lastAdded?: PackageRepositoryDetail;
   isFetching: boolean;
-  isFetchingElem: {
-    repositories: boolean;
-    secrets: boolean;
-  };
-  validating: boolean;
   repo: PackageRepositoryDetail;
   repos: PackageRepositorySummary[];
-  form: {
-    name: string;
-    namespace: string;
-    url: string;
-    show: boolean;
-  };
-  imagePullSecrets: ISecret[];
-  redirectTo?: string;
 }
 
 export const initialState: IPackageRepositoryState = {
-  addingRepo: false,
   errors: {},
-  form: {
-    name: "",
-    namespace: "",
-    show: false,
-    url: "",
-  },
   isFetching: false,
-  isFetchingElem: {
-    repositories: false,
-    secrets: false,
-  },
-  validating: false,
   repo: {} as PackageRepositoryDetail,
   repos: [] as PackageRepositorySummary[],
-  imagePullSecrets: [],
 };
 
-function isFetching(state: IPackageRepositoryState, item: string, fetching: boolean) {
-  const composedIsFetching = {
-    ...state.isFetchingElem,
-    [item]: fetching,
-  };
-  return {
-    isFetching: Object.values(composedIsFetching).some(v => v),
-    isFetchingElem: composedIsFetching,
-  };
-}
+const helmPackageRepositoryCustomDetail = {
+  dockerRegistrySecrets: [],
+  ociRepositories: [],
+  performValidation: false,
+} as HelmPackageRepositoryCustomDetail;
+
+const kappPackageRepositoryCustomDetail = {
+  fetch: {} as PackageRepositoryFetch,
+} as KappControllerPackageRepositoryCustomDetail;
 
 const reposReducer = (
   state: IPackageRepositoryState = initialState,
@@ -80,49 +53,61 @@ const reposReducer = (
     case getType(actions.repos.receiveRepoSummaries):
       return {
         ...state,
-        ...isFetching(state, "repositories", false),
+        isFetching: false,
         repos: action.payload,
         errors: {},
       };
     case getType(actions.repos.receiveRepoDetail):
       // eslint-disable-next-line no-case-declarations
       let customDetail: any;
+      // eslint-disable-next-line no-case-declarations
+      let repoWithCustomDetail = { ...action.payload };
 
-      // TODO(agamez): decoding customDetail just for the helm plugin
-      if (action.payload.packageRepoRef?.plugin?.name === PluginNames.PACKAGES_HELM) {
-        customDetail = {
-          dockerRegistrySecrets: [],
-          ociRepositories: [],
-          performValidation: false,
-        } as HelmPackageRepositoryCustomDetail;
-
-        try {
-          if (action.payload?.customDetail?.value) {
-            // TODO(agamez): verify why the field is not automatically decoded.
-            customDetail = HelmPackageRepositoryCustomDetail.decode(
-              action.payload.customDetail.value as unknown as Uint8Array,
-            );
-          }
-          // eslint-disable-next-line no-empty
-        } catch (error) {}
+      if (action.payload?.customDetail?.value) {
+        switch (action.payload.packageRepoRef?.plugin?.name) {
+          // handle the decoding of the customDetail for the helm plugin
+          case PluginNames.PACKAGES_HELM:
+            customDetail = helmPackageRepositoryCustomDetail;
+            try {
+              customDetail = HelmPackageRepositoryCustomDetail.decode(
+                action.payload.customDetail.value,
+              );
+              repoWithCustomDetail = { ...action.payload, customDetail: customDetail };
+            } catch (error) {
+              repoWithCustomDetail = { ...action.payload };
+            }
+            break;
+          case PluginNames.PACKAGES_KAPP:
+            customDetail = kappPackageRepositoryCustomDetail;
+            try {
+              customDetail = KappControllerPackageRepositoryCustomDetail.decode(
+                action.payload.customDetail.value,
+              );
+              repoWithCustomDetail = { ...action.payload, customDetail: customDetail };
+            } catch (error) {
+              repoWithCustomDetail = { ...action.payload };
+            }
+            break;
+          default:
+            repoWithCustomDetail = { ...action.payload };
+            break;
+        }
       }
-
       return {
         ...state,
-        ...isFetching(state, "repositories", false),
-        repo: { ...action.payload, customDetail: customDetail },
+        isFetching: false,
+        repo: repoWithCustomDetail,
         errors: {},
       };
     case getType(actions.repos.requestRepoSummaries):
-      return { ...state, ...isFetching(state, "repositories", true) };
+    case getType(actions.repos.addOrUpdateRepo):
+      return { ...state, isFetching: true };
     case getType(actions.repos.requestRepoDetail):
       return { ...state, repo: initialState.repo, errors: {} };
-    case getType(actions.repos.addRepo):
-      return { ...state, addingRepo: true };
     case getType(actions.repos.addedRepo):
       return {
         ...state,
-        addingRepo: false,
+        isFetching: false,
         repos: [...state.repos, action.payload].sort((a, b) =>
           a.name.toLowerCase() > b.name.toLowerCase()
             ? 1
@@ -141,31 +126,18 @@ const reposReducer = (
       );
       return { ...state, repos };
     }
-    case getType(actions.repos.redirect):
-      return { ...state, redirectTo: action.payload };
-    case getType(actions.repos.redirected):
-      return { ...state, redirectTo: undefined };
     case getType(actions.repos.errorRepos):
       return {
         ...state,
         // don't reset the fetch error
         errors: { fetch: state.errors.fetch, [action.payload.op]: action.payload.err },
         isFetching: false,
-        isFetchingElem: {
-          repositories: false,
-          secrets: false,
-        },
-        validating: false,
       };
     case LOCATION_CHANGE:
       return {
         ...state,
         errors: {},
         isFetching: false,
-        isFetchingElem: {
-          repositories: false,
-          secrets: false,
-        },
       };
     default:
       return state;


### PR DESCRIPTION
### Description of the change

This PR removes several no longer used fields from the PkgRepo state as well as some unused actions from its reducer.

### Benefits

Less unused code!

### Possible drawbacks

N/A

### Applicable issues

- fixes #5061

### Additional information

From

```js
{
      addingRepo: false,
      errors: {},
      form: {
        name: "",
        namespace: "",
        show: false,
        url: "",
      },
      isFetching: false,
      isFetchingElem: {
        repositories: false,
        secrets: false,
      },
      validating: false,
      repo: {} as PackageRepositoryDetail,
      repos: [] as PackageRepositorySummary[],
      imagePullSecrets: [],
};
```

to

```js
 initialState = {
      errors: {},
      isFetching: false,
      repo: {} as PackageRepositoryDetail,
      repos: [] as PackageRepositorySummary[],
    };
```

Also, after this cleanup, the isFetching property is used to prevent the form from being sent multiple times:

![loading](https://user-images.githubusercontent.com/11535726/178307418-ec484fbd-5907-488c-90e8-3df291cabd5f.gif)
