### PR TITLE
Add ignore clause to netlify builds

### DIFF
--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -1,6 +1,7 @@
 [build]
 publish = "public"
 command = "hugo --gc --minify"
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ."
 
 [context.production.environment]
 HUGO_VERSION = "0.98.0"


### PR DESCRIPTION
### Description of the change

Netlify builds often fail because there is no new content added to the website. It compares the cached version with the PR's (to main) content and given there are no changes, no deploy action is performed. Adding an ignore clause to netlify.toml file to prevent this situation, so builds only proceed when changes in the base directory (/site).

### Benefits

- Save some building cycles for netlify.
- Avoid the "failed" badge for netlify on top of our readme.

### Possible drawbacks

N/A

### Applicable issues

- fixes #4878 

### Additional information

