### PR TITLE
Avoid overriding categories on each chunk

### DIFF
--- a/dashboard/src/reducers/availablepackages.test.ts
+++ b/dashboard/src/reducers/availablepackages.test.ts
@@ -273,6 +273,50 @@ describe("packageReducer", () => {
     expect(state2.items.length).toBe(2);
   });
 
+  it("two receiveAvailablePackageSummaries should add categories (no dups)", () => {
+    const state1 = packageReducer(
+      {
+        ...initialState,
+        isFetching: true,
+      },
+      {
+        type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
+        payload: {
+          response: {
+            availablePackageSummaries: [availablePackageSummary1],
+            nextPageToken,
+            categories: ["foo", "bar"],
+          },
+        } as IReceivePackagesActionPayload,
+      },
+    );
+    const state2 = packageReducer(
+      {
+        ...state1,
+        isFetching: true,
+      },
+      {
+        type: getType(actions.availablepackages.receiveAvailablePackageSummaries) as any,
+        payload: {
+          response: {
+            availablePackageSummaries: [availablePackageSummary1],
+            nextPageToken: "",
+            categories: ["foo"],
+          },
+        } as IReceivePackagesActionPayload,
+      },
+    );
+    expect(state2).toEqual({
+      ...initialState,
+      isFetching: false,
+      hasFinishedFetching: true,
+      categories: ["foo", "bar"],
+      items: [availablePackageSummary1],
+      nextPageToken: "",
+    });
+    expect(state2.categories.length).toBe(2);
+  });
+
   it("requestAvailablePackageSummaries and receiveAvailablePackageSummaries with multiple pages", () => {
     const stateReq1 = packageReducer(initialState, {
       type: getType(actions.availablepackages.requestAvailablePackageSummaries) as any,

--- a/dashboard/src/reducers/availablepackages.ts
+++ b/dashboard/src/reducers/availablepackages.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { JSONSchemaType } from "ajv";
-import { uniqBy } from "lodash";
+import { uniq, uniqBy } from "lodash";
 import { IPackageState } from "shared/types";
 import { getType } from "typesafe-actions";
 import actions from "../actions";
@@ -84,7 +84,7 @@ const packageReducer = (
         isFetching: false,
         hasFinishedFetching: isLastPage,
         nextPageToken: action.payload.response.nextPageToken,
-        categories: action.payload.response.categories,
+        categories: uniq([...state.categories, ...action.payload.response.categories]),
         items: uniqBy(
           [...state.items, ...action.payload.response.availablePackageSummaries],
           "availablePackageRef.identifier",


### PR DESCRIPTION
### Description of the change

Since the API (after pagination) is returning the categories for the current chunk of pkg repos, replacing the whole `categories: xxxxx` leads to end up with an incomplete set of categories, as reported in the issue.
This PR aggregates the categories like we are doing for the packages.

### Benefits

Categories won't get overridden on each chunk.

### Possible drawbacks

N/A

### Applicable issues

- fixes #5066

### Additional information

~Draft as I have to write a test to prevent regressions.~
