### PR TITLE
Fix app fetch error

### DIFF
--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -27,7 +27,7 @@ import { MemoryRouter, Route } from "react-router-dom";
 import { IConfigState } from "reducers/config";
 import { InstalledPackage } from "shared/InstalledPackage";
 import PackagesService from "shared/PackagesService";
-import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
+import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 import { DeleteError, FetchError, IInstalledPackageState } from "shared/types";
 import { PluginNames } from "shared/utils";
 import { getType } from "typesafe-actions";
@@ -154,9 +154,21 @@ describe("AppView", () => {
   it("renders a loading wrapper", async () => {
     let wrapper: any;
     await act(async () => {
-      wrapper = mountWrapper(defaultStore, <AppView />);
+      wrapper = mountWrapper(
+        getStore({
+          apps: {
+            selected: undefined,
+            isFetching: true,
+          } as IInstalledPackageState,
+        }),
+        <MemoryRouter initialEntries={[routePathParam]}>
+          <Route path={routePath}>
+            <AppView />
+          </Route>
+        </MemoryRouter>,
+      );
     });
-    expect(wrapper.find(LoadingWrapper)).toExist();
+    expect(wrapper.find(LoadingWrapper).prop("loaded")).toBe(false);
   });
 
   it("renders a fetch error only", async () => {

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -24,10 +24,11 @@ import {
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter, Route } from "react-router-dom";
+import { IConfigState } from "reducers/config";
 import { InstalledPackage } from "shared/InstalledPackage";
 import PackagesService from "shared/PackagesService";
 import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
-import { DeleteError, FetchError } from "shared/types";
+import { DeleteError, FetchError, IInstalledPackageState } from "shared/types";
 import { PluginNames } from "shared/utils";
 import { getType } from "typesafe-actions";
 import AccessURLTable from "./AccessURLTable/AccessURLTable";
@@ -118,11 +119,14 @@ const resourceRefs = {
 
 const validState = {
   apps: {
+    isFetching: false,
+    items: [installedPackage],
     selected: {
       ...installedPackage,
       resourceRefs: [resourceRefs.configMap] as ResourceRef[],
+      revision: 1,
     },
-  },
+  } as IInstalledPackageState,
 };
 
 beforeEach(() => {
@@ -160,7 +164,7 @@ describe("AppView", () => {
 
     await act(async () => {
       wrapper = mountWrapper(
-        getStore({ apps: { error: new FetchError("boom!") } }),
+        getStore({ apps: { error: new FetchError("boom!") } as IInstalledPackageState }),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <AppView />
@@ -177,7 +181,7 @@ describe("AppView", () => {
     await act(async () => {
       wrapper = mountWrapper(
         getStore({
-          apps: { selected: { ...installedPackage } },
+          apps: { selected: { ...installedPackage } } as IInstalledPackageState,
           config: {
             customAppViews: [
               {
@@ -186,7 +190,7 @@ describe("AppView", () => {
                 repository: "apache",
               },
             ],
-          },
+          } as IConfigState,
         }),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
@@ -203,7 +207,7 @@ describe("AppView", () => {
     await act(async () => {
       wrapper = mountWrapper(
         getStore({
-          apps: { selected: { ...installedPackage } },
+          apps: { selected: { ...installedPackage } } as IInstalledPackageState,
           config: {
             customAppViews: [
               {
@@ -212,7 +216,7 @@ describe("AppView", () => {
                 repository: "demo-repo",
               },
             ],
-          },
+          } as IConfigState,
         }),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
@@ -232,8 +236,7 @@ describe("AppView", () => {
           apps: {
             selected: { ...installedPackage },
             selectedDetails: { ...availablePackageDetail },
-          },
-          config: {},
+          } as IInstalledPackageState,
         }),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
@@ -258,8 +261,7 @@ describe("AppView", () => {
                 plugin: { name: PluginNames.PACKAGES_HELM, version: "v1alpha1" } as Plugin,
               } as InstalledPackageReference,
             },
-          },
-          config: {},
+          } as IInstalledPackageState,
         }),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
@@ -279,8 +281,7 @@ describe("AppView", () => {
     await act(async () => {
       wrapper = mountWrapper(
         getStore({
-          apps: { selected: { ...installedPackage } },
-          config: {},
+          apps: { selected: { ...installedPackage } } as IInstalledPackageState,
         }),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
@@ -315,7 +316,7 @@ describe("AppView", () => {
       let wrapper: any;
       await act(async () => {
         wrapper = mountWrapper(
-          getStore({ apps: { selected: installedPackage } }),
+          getStore({ apps: { selected: installedPackage } as IInstalledPackageState }),
           <MemoryRouter initialEntries={[routePathParam]}>
             <Route path={routePath}>
               <AppView />
@@ -347,7 +348,7 @@ describe("AppView", () => {
       let wrapper: any;
       await act(async () => {
         wrapper = mountWrapper(
-          getStore({ apps: { selected: installedPackage } }),
+          getStore({ apps: { selected: installedPackage } as IInstalledPackageState }),
           <MemoryRouter initialEntries={[routePathParam]}>
             <Route path={routePath}>
               <AppView />
@@ -386,7 +387,10 @@ describe("AppView", () => {
       let wrapper: any;
       await act(async () => {
         wrapper = mountWrapper(
-          getStore({ ...validState, apps: { ...validState.apps, error: new Error("Boom!") } }),
+          getStore({
+            ...validState,
+            apps: { ...validState.apps, error: new Error("Boom!") } as IInstalledPackageState,
+          }),
           <MemoryRouter initialEntries={[routePathParam]}>
             <Route path={routePath}>
               <AppView />
@@ -405,7 +409,7 @@ describe("AppView", () => {
         wrapper = mountWrapper(
           getStore({
             ...validState,
-            apps: { ...validState.apps, error: new DeleteError("Boom!") },
+            apps: { ...validState.apps, error: new DeleteError("Boom!") } as IInstalledPackageState,
           }),
           <MemoryRouter initialEntries={[routePathParam]}>
             <Route path={routePath}>
@@ -430,7 +434,7 @@ describe("AppView", () => {
     let wrapper: any;
     await act(async () => {
       wrapper = mountWrapper(
-        getStore({ apps: { selected: installedPackage } }),
+        getStore({ apps: { selected: installedPackage } as IInstalledPackageState }),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <AppView />
@@ -460,7 +464,7 @@ describe("AppView actions", () => {
         resourceRefs: apiResourceRefs,
       } as GetInstalledPackageResourceRefsResponse),
     );
-    const store = getStore({ apps: { selected: installedPackage } });
+    const store = getStore({ apps: { selected: installedPackage } as IInstalledPackageState });
 
     await act(async () => {
       mountWrapper(
@@ -516,7 +520,7 @@ describe("AppView actions", () => {
       } as GetInstalledPackageResourceRefsResponse),
     );
 
-    const store = getStore({ apps: { selected: installedPackage } });
+    const store = getStore({ apps: { selected: installedPackage } as IInstalledPackageState });
     let wrapper: any;
     await act(async () => {
       wrapper = mountWrapper(

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -171,6 +171,29 @@ describe("AppView", () => {
     expect(wrapper.find(LoadingWrapper).prop("loaded")).toBe(false);
   });
 
+  it("does not render an loading wrapper if it isn't fetching", async () => {
+    let wrapper: any;
+    await act(async () => {
+      wrapper = mountWrapper(
+        getStore({
+          apps: {
+            selected: undefined,
+            isFetching: false,
+            error: new Error("foo not found"),
+          } as IInstalledPackageState,
+        }),
+        <MemoryRouter initialEntries={[routePathParam]}>
+          <Route path={routePath}>
+            <AppView />
+          </Route>
+        </MemoryRouter>,
+      );
+    });
+    expect(wrapper.find(LoadingWrapper).prop("loaded")).toBe(true);
+    expect(wrapper.find(Alert).html()).toContain("foo not found");
+    expect(wrapper.find(PageHeader)).not.toExist();
+  });
+
   it("renders a fetch error only", async () => {
     let wrapper: any;
 

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -9,6 +9,7 @@ import Alert from "components/js/Alert";
 import Column from "components/js/Column";
 import Row from "components/js/Row";
 import PageHeader from "components/PageHeader/PageHeader";
+import { push } from "connected-react-router";
 import {
   InstalledPackageReference,
   ResourceRef,
@@ -156,7 +157,7 @@ export default function AppView() {
     secrets: [],
   } as IAppViewResourceRefs);
   const {
-    apps: { error, selected: app, selectedDetails: appDetails },
+    apps: { error, isFetching, selected: app, selectedDetails: appDetails },
     config: { customAppViews },
   } = useSelector((state: IStoreState) => state);
 
@@ -256,6 +257,10 @@ export default function AppView() {
     dispatch(actions.installedpackages.getInstalledPackage(installedPkgRef));
   };
 
+  const goToAppsView = () => {
+    dispatch(push(url.app.apps.list(cluster, namespace)));
+  };
+
   if (fetchError) {
     if (fetchError.constructor === FetchError) {
       return (
@@ -286,9 +291,20 @@ export default function AppView() {
     return <CustomAppView resourceRefs={appViewResourceRefs} app={app!} appDetails={appDetails!} />;
   }
   return (
-    <LoadingWrapper loaded={!!app} loadingText="Retrieving application..." className="margin-t-xl">
+    <LoadingWrapper
+      loaded={!isFetching}
+      loadingText="Retrieving application..."
+      className="margin-t-xl"
+    >
       {!app || !app?.installedPackageRef ? (
-        <Alert theme="danger">There is a problem with this package</Alert>
+        <Alert theme="danger">
+          An error occurred while fetching the application: {error?.message}.{" "}
+          {!isFetching && (
+            <CdsButton size="sm" action="flat" onClick={goToAppsView} type="button">
+              Go Back{" "}
+            </CdsButton>
+          )}
+        </Alert>
       ) : (
         <section>
           <PageHeader

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -297,14 +297,16 @@ export default function AppView() {
       className="margin-t-xl"
     >
       {!app || !app?.installedPackageRef ? (
-        <Alert theme="danger">
-          An error occurred while fetching the application: {error?.message}.{" "}
-          {!isFetching && (
+        error ? (
+          <Alert theme="danger">
+            An error occurred while fetching the application: {error?.message}.{" "}
             <CdsButton size="sm" action="flat" onClick={goToAppsView} type="button">
               Go Back{" "}
             </CdsButton>
-          )}
-        </Alert>
+          </Alert>
+        ) : (
+          <></>
+        )
       ) : (
         <section>
           <PageHeader


### PR DESCRIPTION
### Description of the change

This PR hides the LoadingWrapper when it has finished the fetching and there is an error (it was leading to a bug reported at https://github.com/vmware-tanzu/kubeapps/issues/4960). Besides, I've updated the test suite to set the state types so that we can get earlier feedback at build (aka transpile) time.


### Benefits

No more endless spinner when loading an installed package that doesn't exist. Instead, an error message will be thrown, and the user will be able to go to the apps view.

### Possible drawbacks

N/A

### Applicable issues

- fixes https://github.com/vmware-tanzu/kubeapps/issues/4960

### Additional information

![fetch](https://user-images.githubusercontent.com/11535726/178749180-89f1977b-e855-49d8-8585-8b75ea073217.gif)
