### PR TITLE
Add credentials when pulling img in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -618,9 +618,9 @@ jobs:
       <<: *common_envars
     docker:
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
-      auth:
-        username: $DOCKER_USERNAME
-        password: $DOCKER_PASSWORD
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
     steps:
       - checkout
       - <<: *exports
@@ -645,9 +645,9 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=512"
     docker:
       - image: cimg/node:<< pipeline.parameters.NODE_VERSION >>
-      auth:
-        username: $DOCKER_USERNAME
-        password: $DOCKER_PASSWORD
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
     steps:
       - checkout
       - run:
@@ -665,9 +665,9 @@ jobs:
   test_pinniped_proxy:
     docker:
       - image: cimg/rust:<< pipeline.parameters.RUST_VERSION >>
-      auth:
-        username: $DOCKER_USERNAME
-        password: $DOCKER_PASSWORD
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
     steps:
       - checkout
       - run:
@@ -679,9 +679,9 @@ jobs:
       <<: *common_envars
     docker:
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
-      auth:
-        username: $DOCKER_USERNAME
-        password: $DOCKER_PASSWORD
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
     steps:
       - <<: *exports
       - checkout
@@ -693,9 +693,9 @@ jobs:
   build_go_images:
     docker:
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
-      auth:
-        username: $DOCKER_USERNAME
-        password: $DOCKER_PASSWORD
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
     working_directory: /home/circleci/go/src/github.com/vmware-tanzu/kubeapps
     environment:
       GOPATH: ${HOME}/.go_workspace
@@ -704,9 +704,9 @@ jobs:
   build_dashboard:
     docker:
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
-      auth:
-        username: $DOCKER_USERNAME
-        password: $DOCKER_PASSWORD
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
     environment:
       IMAGES: "dashboard"
     <<: *build_images
@@ -714,9 +714,9 @@ jobs:
     docker:
       # We're building the image in a docker container anyway so just re-use the golang image already in use.
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
-      auth:
-        username: $DOCKER_USERNAME
-        password: $DOCKER_PASSWORD
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
     environment:
       IMAGES: "pinniped-proxy"
     <<: *build_images
@@ -725,9 +725,9 @@ jobs:
       <<: *common_envars
     docker:
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
-      auth:
-        username: $DOCKER_USERNAME
-        password: $DOCKER_PASSWORD
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
     steps:
       - checkout
       - <<: *install_github
@@ -782,9 +782,9 @@ jobs:
       <<: *common_envars
     docker:
       - image: cimg/node:<< pipeline.parameters.NODE_VERSION >>
-      auth:
-        username: $DOCKER_USERNAME
-        password: $DOCKER_PASSWORD
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
     steps:
       - checkout
       - <<: *install_github
@@ -817,9 +817,9 @@ jobs:
       <<: *common_envars
     docker:
       - image: cimg/node:<< pipeline.parameters.NODE_VERSION >>
-      auth:
-        username: $DOCKER_USERNAME
-        password: $DOCKER_PASSWORD
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
     steps:
       - checkout
       - <<: *install_github
@@ -853,9 +853,9 @@ jobs:
   push_images:
     docker:
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
-      auth:
-        username: $DOCKER_USERNAME
-        password: $DOCKER_PASSWORD
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
     steps:
       - setup_remote_docker:
           version: << pipeline.parameters.DOCKER_VERSION >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,6 +516,9 @@ run_e2e_tests: &run_e2e_tests
 gke_test: &gke_test
   docker:
     - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
+      auth:
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
   steps:
     - checkout
     - run:
@@ -615,6 +618,9 @@ jobs:
       <<: *common_envars
     docker:
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
+      auth:
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
     steps:
       - checkout
       - <<: *exports
@@ -639,6 +645,9 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=512"
     docker:
       - image: cimg/node:<< pipeline.parameters.NODE_VERSION >>
+      auth:
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
     steps:
       - checkout
       - run:
@@ -656,6 +665,9 @@ jobs:
   test_pinniped_proxy:
     docker:
       - image: cimg/rust:<< pipeline.parameters.RUST_VERSION >>
+      auth:
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
     steps:
       - checkout
       - run:
@@ -667,6 +679,9 @@ jobs:
       <<: *common_envars
     docker:
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
+      auth:
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
     steps:
       - <<: *exports
       - checkout
@@ -678,6 +693,9 @@ jobs:
   build_go_images:
     docker:
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
+      auth:
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
     working_directory: /home/circleci/go/src/github.com/vmware-tanzu/kubeapps
     environment:
       GOPATH: ${HOME}/.go_workspace
@@ -686,6 +704,9 @@ jobs:
   build_dashboard:
     docker:
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
+      auth:
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
     environment:
       IMAGES: "dashboard"
     <<: *build_images
@@ -693,6 +714,9 @@ jobs:
     docker:
       # We're building the image in a docker container anyway so just re-use the golang image already in use.
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
+      auth:
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
     environment:
       IMAGES: "pinniped-proxy"
     <<: *build_images
@@ -701,6 +725,9 @@ jobs:
       <<: *common_envars
     docker:
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
+      auth:
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
     steps:
       - checkout
       - <<: *install_github
@@ -755,6 +782,9 @@ jobs:
       <<: *common_envars
     docker:
       - image: cimg/node:<< pipeline.parameters.NODE_VERSION >>
+      auth:
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
     steps:
       - checkout
       - <<: *install_github
@@ -787,6 +817,9 @@ jobs:
       <<: *common_envars
     docker:
       - image: cimg/node:<< pipeline.parameters.NODE_VERSION >>
+      auth:
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
     steps:
       - checkout
       - <<: *install_github
@@ -820,6 +853,9 @@ jobs:
   push_images:
     docker:
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
+      auth:
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
     steps:
       - setup_remote_docker:
           version: << pipeline.parameters.DOCKER_VERSION >>


### PR DESCRIPTION
### Description of the change

This trivial PR just adds the docker registry credentials when pulling the images used in the CircleCI runners.

### Benefits

Avoid rate limits, maybe?

### Possible drawbacks

N/A

### Applicable issues

- fixes #2985

### Additional information

After and before:

![image](https://user-images.githubusercontent.com/11535726/179021248-e48b84eb-c5e3-4d17-bd6e-a08e0401af63.png)

