### PR TITLE
Make repos' bearer auth prefix-safe

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/globals_vars_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/globals_vars_test.go
@@ -341,7 +341,12 @@ var (
 		},
 	}
 
-	addRepoReqBearerToken = func(token string) *corev1.AddPackageRepositoryRequest {
+	addRepoReqBearerToken = func(token string, withPrefix bool) *corev1.AddPackageRepositoryRequest {
+		prefixedToken := token
+		if withPrefix {
+			prefixedToken = "Bearer " + token
+		}
+
 		return &corev1.AddPackageRepositoryRequest{
 			Name:            "bar",
 			Context:         &corev1.Context{Namespace: "foo", Cluster: KubeappsCluster},
@@ -351,7 +356,7 @@ var (
 			Auth: &corev1.PackageRepositoryAuth{
 				Type: corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BEARER,
 				PackageRepoAuthOneOf: &corev1.PackageRepositoryAuth_Header{
-					Header: token,
+					Header: prefixedToken,
 				},
 			},
 		}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_auth.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_auth.go
@@ -86,7 +86,7 @@ func newSecretFromTlsConfigAndAuth(repoName types.NamespacedName,
 				if token == RedactedString {
 					isSameSecret = true
 				} else {
-					secret.Data[SecretAuthHeaderKey] = []byte("Bearer " + token)
+					secret.Data[SecretAuthHeaderKey] = []byte("Bearer " + strings.Trim(token, "Bearer "))
 				}
 			} else {
 				return nil, false, status.Errorf(codes.InvalidArgument, "Bearer token is missing")

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_auth.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_auth.go
@@ -86,7 +86,7 @@ func newSecretFromTlsConfigAndAuth(repoName types.NamespacedName,
 				if token == RedactedString {
 					isSameSecret = true
 				} else {
-					secret.Data[SecretAuthHeaderKey] = []byte("Bearer " + strings.Trim(token, "Bearer "))
+					secret.Data[SecretAuthHeaderKey] = []byte("Bearer " + strings.TrimPrefix(token, "Bearer "))
 				}
 			} else {
 				return nil, false, status.Errorf(codes.InvalidArgument, "Bearer token is missing")

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
@@ -293,8 +293,16 @@ func TestAddPackageRepository(t *testing.T) {
 		},
 		// BEARER TOKEN
 		{
-			name:                  "package repository with bearer token",
-			request:               addRepoReqBearerToken("the-token"),
+			name:                  "package repository with bearer token w/o prefix",
+			request:               addRepoReqBearerToken("the-token", false),
+			expectedResponse:      addRepoExpectedResp,
+			expectedRepo:          addRepoAuthHeaderWithSecretRef("apprepo-bar"),
+			statusCode:            codes.OK,
+			expectedCreatedSecret: setSecretOwnerRef("bar", newAuthTokenSecret("apprepo-bar", "foo", "Bearer the-token")),
+		},
+		{
+			name:                  "package repository with bearer token w/ prefix",
+			request:               addRepoReqBearerToken("the-token", true),
 			expectedResponse:      addRepoExpectedResp,
 			expectedRepo:          addRepoAuthHeaderWithSecretRef("apprepo-bar"),
 			statusCode:            codes.OK,
@@ -302,7 +310,7 @@ func TestAddPackageRepository(t *testing.T) {
 		},
 		{
 			name:       "package repository with no bearer token",
-			request:    addRepoReqBearerToken(""),
+			request:    addRepoReqBearerToken("", false),
 			statusCode: codes.InvalidArgument,
 		},
 		{
@@ -321,7 +329,7 @@ func TestAddPackageRepository(t *testing.T) {
 		},
 		{
 			name:               "package repository bearer token (user managed secrets)",
-			request:            addRepoReqBearerToken("the-token"),
+			request:            addRepoReqBearerToken("the-token", false),
 			userManagedSecrets: true,
 			statusCode:         codes.InvalidArgument,
 		},

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
@@ -524,8 +524,7 @@ func (s *Server) GetInstalledPackageDetail(ctx context.Context, request *corev1.
 		}
 	}
 	// trim the new doc separator in the last element
-	//nolint:staticcheck
-	valuesApplied = strings.Trim(valuesApplied, "---")
+	valuesApplied = strings.TrimSuffix(valuesApplied, "---")
 
 	installedPackageDetail, err := s.buildInstalledPackageDetail(pkgInstall, pkgMetadata, pkgVersionsMap, app, valuesApplied, cluster)
 	if err != nil {

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_adapters.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_adapters.go
@@ -1059,9 +1059,11 @@ func (s *Server) buildPkgRepositorySecretCreate(namespace, name string, auth *co
 
 	case corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BEARER:
 		pkgSecret.Type = k8scorev1.SecretTypeOpaque
-
-		token := auth.GetHeader()
-		pkgSecret.StringData[BearerAuthToken] = token
+		if token := auth.GetHeader(); token != "" {
+			pkgSecret.StringData[BearerAuthToken] = "Bearer " + strings.Trim(token, "Bearer ")
+		} else {
+			return nil, status.Errorf(codes.InvalidArgument, "Bearer token is missing")
+		}
 	}
 
 	return pkgSecret, nil
@@ -1152,12 +1154,12 @@ func (s *Server) buildPkgRepositorySecretUpdate(pkgSecret *k8scorev1.Secret, aut
 			if token == Redacted {
 				return false, nil
 			} else {
-				pkgSecret.StringData[BearerAuthToken] = token
+				pkgSecret.StringData[BearerAuthToken] = "Bearer " + strings.Trim(token, "Bearer ")
 			}
 		} else {
 			pkgSecret.Type = k8scorev1.SecretTypeOpaque
 			pkgSecret.Data = nil
-			pkgSecret.StringData[BearerAuthToken] = token
+			pkgSecret.StringData[BearerAuthToken] = "Bearer " + strings.Trim(token, "Bearer ")
 		}
 	}
 

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_adapters.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_adapters.go
@@ -1060,7 +1060,7 @@ func (s *Server) buildPkgRepositorySecretCreate(namespace, name string, auth *co
 	case corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BEARER:
 		pkgSecret.Type = k8scorev1.SecretTypeOpaque
 		if token := auth.GetHeader(); token != "" {
-			pkgSecret.StringData[BearerAuthToken] = "Bearer " + strings.Trim(token, "Bearer ")
+			pkgSecret.StringData[BearerAuthToken] = "Bearer " + strings.TrimPrefix(token, "Bearer ")
 		} else {
 			return nil, status.Errorf(codes.InvalidArgument, "Bearer token is missing")
 		}
@@ -1154,12 +1154,12 @@ func (s *Server) buildPkgRepositorySecretUpdate(pkgSecret *k8scorev1.Secret, aut
 			if token == Redacted {
 				return false, nil
 			} else {
-				pkgSecret.StringData[BearerAuthToken] = "Bearer " + strings.Trim(token, "Bearer ")
+				pkgSecret.StringData[BearerAuthToken] = "Bearer " + strings.TrimPrefix(token, "Bearer ")
 			}
 		} else {
 			pkgSecret.Type = k8scorev1.SecretTypeOpaque
 			pkgSecret.Data = nil
-			pkgSecret.StringData[BearerAuthToken] = "Bearer " + strings.Trim(token, "Bearer ")
+			pkgSecret.StringData[BearerAuthToken] = "Bearer " + strings.TrimPrefix(token, "Bearer ")
 		}
 	}
 

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
@@ -7054,6 +7054,66 @@ func TestAddPackageRepository(t *testing.T) {
 			},
 		},
 		{
+			name: "create with auth (plugin managed, bearer auth w/ Bearer prefix)",
+			requestCustomizer: func(request *corev1.AddPackageRepositoryRequest) *corev1.AddPackageRepositoryRequest {
+				request.Auth = &corev1.PackageRepositoryAuth{
+					Type: corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BEARER,
+					PackageRepoAuthOneOf: &corev1.PackageRepositoryAuth_Header{
+						Header: "Bearer foo",
+					},
+				}
+				return request
+			},
+			repositoryCustomizer: func(repository *packagingv1alpha1.PackageRepository) *packagingv1alpha1.PackageRepository {
+				repository.Spec.Fetch.ImgpkgBundle.SecretRef = &kappctrlv1alpha1.AppFetchLocalRef{} // the name will be empty as the fake client does not handle generating names
+				return repository
+			},
+			expectedStatusCode: codes.OK,
+			expectedRef:        defaultRef,
+			customChecks: func(t *testing.T, s *Server) {
+				secret, err := s.getSecret(context.Background(), defaultGlobalContext.Cluster, globalPackagingNamespace, "")
+				if err != nil {
+					t.Fatalf("error fetching newly created secret:%+v", err)
+				}
+				if !isPluginManaged(defaultRepository(), secret) {
+					t.Errorf("annotations and ownership was not properly set: %+v", secret)
+				}
+				if secret.Type != k8scorev1.SecretTypeOpaque || secret.StringData[BearerAuthToken] != "Bearer foo" {
+					t.Errorf("secret data was not properly constructed: %+v", secret)
+				}
+			},
+		},
+		{
+			name: "create with auth (plugin managed, bearer auth w/o Bearer prefix)",
+			requestCustomizer: func(request *corev1.AddPackageRepositoryRequest) *corev1.AddPackageRepositoryRequest {
+				request.Auth = &corev1.PackageRepositoryAuth{
+					Type: corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BEARER,
+					PackageRepoAuthOneOf: &corev1.PackageRepositoryAuth_Header{
+						Header: "foo",
+					},
+				}
+				return request
+			},
+			repositoryCustomizer: func(repository *packagingv1alpha1.PackageRepository) *packagingv1alpha1.PackageRepository {
+				repository.Spec.Fetch.ImgpkgBundle.SecretRef = &kappctrlv1alpha1.AppFetchLocalRef{} // the name will be empty as the fake client does not handle generating names
+				return repository
+			},
+			expectedStatusCode: codes.OK,
+			expectedRef:        defaultRef,
+			customChecks: func(t *testing.T, s *Server) {
+				secret, err := s.getSecret(context.Background(), defaultGlobalContext.Cluster, globalPackagingNamespace, "")
+				if err != nil {
+					t.Fatalf("error fetching newly created secret:%+v", err)
+				}
+				if !isPluginManaged(defaultRepository(), secret) {
+					t.Errorf("annotations and ownership was not properly set: %+v", secret)
+				}
+				if secret.Type != k8scorev1.SecretTypeOpaque || secret.StringData[BearerAuthToken] != "Bearer foo" {
+					t.Errorf("secret data was not properly constructed: %+v", secret)
+				}
+			},
+		},
+		{
 			name: "create with auth (plugin managed, docker auth)",
 			requestCustomizer: func(request *corev1.AddPackageRepositoryRequest) *corev1.AddPackageRepositoryRequest {
 				request.Auth = &corev1.PackageRepositoryAuth{
@@ -7785,6 +7845,66 @@ func TestUpdatePackageRepository(t *testing.T) {
 					t.Errorf("annotations and ownership was not properly set: %+v", secret)
 				}
 				if secret.Type != k8scorev1.SecretTypeBasicAuth || secret.StringData[k8scorev1.BasicAuthUsernameKey] != "foo" || secret.StringData[k8scorev1.BasicAuthPasswordKey] != "bar" {
+					t.Errorf("secret data was not properly constructed: %+v", secret)
+				}
+			},
+		},
+		{
+			name: "updated with auth (plugin managed, bearer auth w/ Bearer prefix)",
+			requestCustomizer: func(request *corev1.UpdatePackageRepositoryRequest) *corev1.UpdatePackageRepositoryRequest {
+				request.Auth = &corev1.PackageRepositoryAuth{
+					Type: corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BEARER,
+					PackageRepoAuthOneOf: &corev1.PackageRepositoryAuth_Header{
+						Header: "Bearer foo",
+					},
+				}
+				return request
+			},
+			repositoryCustomizer: func(repository *packagingv1alpha1.PackageRepository) *packagingv1alpha1.PackageRepository {
+				repository.Spec.Fetch.ImgpkgBundle.SecretRef = &kappctrlv1alpha1.AppFetchLocalRef{} // the name will be empty as the fake client does not handle generating names
+				return repository
+			},
+			expectedStatusCode: codes.OK,
+			expectedRef:        defaultRef,
+			customChecks: func(t *testing.T, s *Server) {
+				secret, err := s.getSecret(context.Background(), defaultGlobalContext.Cluster, globalPackagingNamespace, "")
+				if err != nil {
+					t.Fatalf("error fetching newly created secret:%+v", err)
+				}
+				if !isPluginManaged(defaultRepository(), secret) {
+					t.Errorf("annotations and ownership was not properly set: %+v", secret)
+				}
+				if secret.Type != k8scorev1.SecretTypeOpaque || secret.StringData[BearerAuthToken] != "Bearer foo" {
+					t.Errorf("secret data was not properly constructed: %+v", secret)
+				}
+			},
+		},
+		{
+			name: "updated with auth (plugin managed, bearer auth w/o Bearer prefix)",
+			requestCustomizer: func(request *corev1.UpdatePackageRepositoryRequest) *corev1.UpdatePackageRepositoryRequest {
+				request.Auth = &corev1.PackageRepositoryAuth{
+					Type: corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BEARER,
+					PackageRepoAuthOneOf: &corev1.PackageRepositoryAuth_Header{
+						Header: "foo",
+					},
+				}
+				return request
+			},
+			repositoryCustomizer: func(repository *packagingv1alpha1.PackageRepository) *packagingv1alpha1.PackageRepository {
+				repository.Spec.Fetch.ImgpkgBundle.SecretRef = &kappctrlv1alpha1.AppFetchLocalRef{} // the name will be empty as the fake client does not handle generating names
+				return repository
+			},
+			expectedStatusCode: codes.OK,
+			expectedRef:        defaultRef,
+			customChecks: func(t *testing.T, s *Server) {
+				secret, err := s.getSecret(context.Background(), defaultGlobalContext.Cluster, globalPackagingNamespace, "")
+				if err != nil {
+					t.Fatalf("error fetching newly created secret:%+v", err)
+				}
+				if !isPluginManaged(defaultRepository(), secret) {
+					t.Errorf("annotations and ownership was not properly set: %+v", secret)
+				}
+				if secret.Type != k8scorev1.SecretTypeOpaque || secret.StringData[BearerAuthToken] != "Bearer foo" {
 					t.Errorf("secret data was not properly constructed: %+v", secret)
 				}
 			},

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -215,6 +215,7 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 				AppRepositoryResourceName:      appRepoName,
 				AppRepositoryResourceNamespace: appRepoNamespace,
 			},
+			//nolint:staticcheck
 			numCertsExpected:  len(systemCertPool.Subjects()),
 			cluster:           "",
 			kubeappsNamespace: appRepoNamespace,
@@ -226,6 +227,7 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 				AppRepositoryResourceName:      appRepoName,
 				AppRepositoryResourceNamespace: appRepoNamespace,
 			},
+			//nolint:staticcheck
 			numCertsExpected:  len(systemCertPool.Subjects()),
 			cluster:           "target-cluster",
 			kubeappsNamespace: appRepoNamespace,
@@ -237,6 +239,7 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 				AppRepositoryResourceName:      appRepoName,
 				AppRepositoryResourceNamespace: appRepoNamespace,
 			},
+			//nolint:staticcheck
 			numCertsExpected:  len(systemCertPool.Subjects()),
 			cluster:           "",
 			kubeappsNamespace: "",
@@ -258,6 +261,7 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 					},
 				},
 			},
+			//nolint:staticcheck
 			numCertsExpected:  len(systemCertPool.Subjects()) + 1,
 			cluster:           "",
 			kubeappsNamespace: "",
@@ -300,6 +304,7 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 					},
 				},
 			},
+			//nolint:staticcheck
 			numCertsExpected:  len(systemCertPool.Subjects()),
 			cluster:           "",
 			kubeappsNamespace: "",
@@ -342,6 +347,7 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 					},
 				},
 			},
+			//nolint:staticcheck
 			numCertsExpected:  len(systemCertPool.Subjects()),
 			cluster:           "",
 			kubeappsNamespace: "",

--- a/pkg/http-client/httpclient_test.go
+++ b/pkg/http-client/httpclient_test.go
@@ -161,24 +161,28 @@ func TestGetCertPool(t *testing.T) {
 		expectedSubjectCount int
 	}{
 		{
-			name:                 "invocation with nil cert",
-			cert:                 nil,
+			name: "invocation with nil cert",
+			cert: nil,
+			//nolint:staticcheck
 			expectedSubjectCount: len(systemCertPool.Subjects()),
 		},
 		{
-			name:                 "invocation with empty cert",
-			cert:                 []byte{},
+			name: "invocation with empty cert",
+			cert: []byte{},
+			//nolint:staticcheck
 			expectedSubjectCount: len(systemCertPool.Subjects()),
 		},
 		{
-			name:                 "invocation with valid cert",
-			cert:                 []byte(pemCert),
+			name: "invocation with valid cert",
+			cert: []byte(pemCert),
+			//nolint:staticcheck
 			expectedSubjectCount: len(systemCertPool.Subjects()) + 1,
 		},
 		{
-			name:                 "invocation with invalid cert",
-			cert:                 []byte("not valid cert"),
-			expectError:          true,
+			name:        "invocation with invalid cert",
+			cert:        []byte("not valid cert"),
+			expectError: true,
+			//nolint:staticcheck
 			expectedSubjectCount: len(systemCertPool.Subjects()) + 1,
 		},
 	}
@@ -199,6 +203,8 @@ func TestGetCertPool(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error creating the cert pool: {%+v}", err)
 			}
+
+			//nolint:staticcheck
 			if got, want := len(caCertPool.Subjects()), tc.expectedSubjectCount; got != want {
 				t.Fatalf("cert pool subjects is not as expected, got {%d} instead of {%d}", got, want)
 			}

--- a/pkg/kube/kube_utils_test.go
+++ b/pkg/kube/kube_utils_test.go
@@ -67,7 +67,8 @@ func TestInitNetClient(t *testing.T) {
 		expectSkipTLS    bool
 	}{
 		{
-			name:             "default cert pool without auth",
+			name: "default cert pool without auth",
+			//nolint:staticcheck
 			numCertsExpected: len(systemCertPool.Subjects()),
 		},
 		{
@@ -82,7 +83,8 @@ func TestInitNetClient(t *testing.T) {
 					},
 				},
 			},
-			customCAData:     pemCert,
+			customCAData: pemCert,
+			//nolint:staticcheck
 			numCertsExpected: len(systemCertPool.Subjects()) + 1,
 		},
 		{
@@ -127,6 +129,7 @@ func TestInitNetClient(t *testing.T) {
 					},
 				},
 			},
+			//nolint:staticcheck
 			numCertsExpected: len(systemCertPool.Subjects()),
 			expectedHeaders:  http.Header{"Authorization": []string{authHeaderSecretData}},
 		},
@@ -148,7 +151,8 @@ func TestInitNetClient(t *testing.T) {
 					},
 				},
 			},
-			expectProxied:    true,
+			expectProxied: true,
+			//nolint:staticcheck
 			numCertsExpected: len(systemCertPool.Subjects()),
 		},
 		{
@@ -156,7 +160,8 @@ func TestInitNetClient(t *testing.T) {
 			appRepoSpec: v1alpha1.AppRepositorySpec{
 				TLSInsecureSkipVerify: true,
 			},
-			expectSkipTLS:    true,
+			expectSkipTLS: true,
+			//nolint:staticcheck
 			numCertsExpected: len(systemCertPool.Subjects()),
 		},
 	}
@@ -228,6 +233,7 @@ func TestInitNetClient(t *testing.T) {
 			}
 			certPool := transport.TLSClientConfig.RootCAs
 
+			//nolint:staticcheck
 			if got, want := len(certPool.Subjects()), tc.numCertsExpected; got != want {
 				t.Errorf("got: %d, want: %d", got, want)
 			}


### PR DESCRIPTION
### Description of the change

This PR addresses the Bearer authentication in the two plugins supporting it (Helm and Carvel) and makes the implementation "prefix-safe". Regardless of what the API client send (either `Bearer foo` or `foo`) the prefix will be trimmed out and the secret's content will become `Bearer foo`.

### Benefits

The UI will be able to send the bearer token regardless of the plugin's implementation.

### Possible drawbacks

N/A

### Applicable issues

- fixes #5028

### Additional information

I haven't changed anything related to the terminology as, in supporting both (prefixed/non-prefixed) the "token" can actually be the token and not the whole header. Anyway, happy to rename if you still think so.

Edit: squeezing some golang-ci-lint-related code; the tool (used in the gh action) got updated and new checks were being triggered. Ignoring them as it is just code used for testing.  