### PR TITLE
Rename to `customDetail`

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/globals_vars_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/globals_vars_test.go
@@ -188,7 +188,7 @@ var (
 		}
 	}
 
-	addRepoCustomDetailsHelm = v1alpha1.AppRepository{
+	addRepoCustomDetailHelm = v1alpha1.AppRepository{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       AppRepositoryKind,
 			APIVersion: AppRepositoryApi,
@@ -210,7 +210,7 @@ var (
 		},
 	}
 
-	addRepoCustomDetailsOci = v1alpha1.AppRepository{
+	addRepoCustomDetailOci = v1alpha1.AppRepository{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       AppRepositoryKind,
 			APIVersion: AppRepositoryApi,

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
@@ -31,15 +31,15 @@ const (
 )
 
 type HelmRepository struct {
-	cluster       string
-	name          types.NamespacedName
-	url           string
-	repoType      string
-	description   string
-	interval      string
-	tlsConfig     *corev1.PackageRepositoryTlsConfig
-	auth          *corev1.PackageRepositoryAuth
-	customDetails *v1alpha1.HelmPackageRepositoryCustomDetail
+	cluster      string
+	name         types.NamespacedName
+	url          string
+	repoType     string
+	description  string
+	interval     string
+	tlsConfig    *corev1.PackageRepositoryTlsConfig
+	auth         *corev1.PackageRepositoryAuth
+	customDetail *v1alpha1.HelmPackageRepositoryCustomDetail
 }
 
 var ValidRepoTypes = []string{HelmRepoType, OCIRepoType}
@@ -80,7 +80,7 @@ func (s *Server) newRepo(ctx context.Context, repo *HelmRepository) (*corev1.Pac
 	}
 
 	// Repository validation
-	if repo.customDetails != nil && repo.customDetails.PerformValidation {
+	if repo.customDetail != nil && repo.customDetail.PerformValidation {
 		if err = s.ValidateRepository(helmRepoCrd, secret); err != nil {
 			return nil, err
 		}
@@ -140,18 +140,18 @@ func newHelmRepoCrd(repo *HelmRepository, secret *k8scorev1.Secret) (*apprepov1a
 			appRepoCrd.Spec.Auth = *repoAuth
 		}
 	}
-	if repo.customDetails != nil {
-		if repo.customDetails.DockerRegistrySecrets != nil {
-			appRepoCrd.Spec.DockerRegistrySecrets = repo.customDetails.DockerRegistrySecrets
+	if repo.customDetail != nil {
+		if repo.customDetail.DockerRegistrySecrets != nil {
+			appRepoCrd.Spec.DockerRegistrySecrets = repo.customDetail.DockerRegistrySecrets
 		}
-		if repo.customDetails.FilterRule != nil {
+		if repo.customDetail.FilterRule != nil {
 			appRepoCrd.Spec.FilterRule = apprepov1alpha1.FilterRuleSpec{
-				JQ:        repo.customDetails.FilterRule.Jq,
-				Variables: repo.customDetails.FilterRule.Variables,
+				JQ:        repo.customDetail.FilterRule.Jq,
+				Variables: repo.customDetail.FilterRule.Variables,
 			}
 		}
-		if repo.customDetails.OciRepositories != nil {
-			appRepoCrd.Spec.OCIRepositories = repo.customDetails.OciRepositories
+		if repo.customDetail.OciRepositories != nil {
+			appRepoCrd.Spec.OCIRepositories = repo.customDetail.OciRepositories
 		}
 	}
 	return appRepoCrd, nil
@@ -200,16 +200,16 @@ func (s *Server) mapToPackageRepositoryDetail(source *apprepov1alpha1.AppReposit
 
 	// Custom details
 	if source.Spec.DockerRegistrySecrets != nil || source.Spec.FilterRule.JQ != "" || source.Spec.OCIRepositories != nil {
-		var customDetails = &v1alpha1.HelmPackageRepositoryCustomDetail{}
-		customDetails.DockerRegistrySecrets = source.Spec.DockerRegistrySecrets
+		var customDetail = &v1alpha1.HelmPackageRepositoryCustomDetail{}
+		customDetail.DockerRegistrySecrets = source.Spec.DockerRegistrySecrets
 		if source.Spec.FilterRule.JQ != "" {
-			customDetails.FilterRule = &v1alpha1.RepositoryFilterRule{
+			customDetail.FilterRule = &v1alpha1.RepositoryFilterRule{
 				Jq:        source.Spec.FilterRule.JQ,
 				Variables: source.Spec.FilterRule.Variables,
 			}
 		}
-		customDetails.OciRepositories = source.Spec.OCIRepositories
-		target.CustomDetail, err = anypb.New(customDetails)
+		customDetail.OciRepositories = source.Spec.OCIRepositories
+		target.CustomDetail, err = anypb.New(customDetail)
 		if err != nil {
 			return nil, err
 		}
@@ -316,17 +316,17 @@ func (s *Server) updateRepo(ctx context.Context, repo *HelmRepository) (*corev1.
 	appRepo.Spec.PassCredentials = repo.auth != nil && repo.auth.PassCredentials
 
 	// Custom details
-	if repo.customDetails != nil {
-		appRepo.Spec.DockerRegistrySecrets = repo.customDetails.DockerRegistrySecrets
-		if repo.customDetails.FilterRule != nil {
+	if repo.customDetail != nil {
+		appRepo.Spec.DockerRegistrySecrets = repo.customDetail.DockerRegistrySecrets
+		if repo.customDetail.FilterRule != nil {
 			appRepo.Spec.FilterRule = apprepov1alpha1.FilterRuleSpec{
-				JQ:        repo.customDetails.FilterRule.Jq,
-				Variables: repo.customDetails.FilterRule.Variables,
+				JQ:        repo.customDetail.FilterRule.Jq,
+				Variables: repo.customDetail.FilterRule.Variables,
 			}
 		} else {
 			appRepo.Spec.FilterRule = apprepov1alpha1.FilterRuleSpec{}
 		}
-		appRepo.Spec.OCIRepositories = repo.customDetails.OciRepositories
+		appRepo.Spec.OCIRepositories = repo.customDetail.OciRepositories
 	} else {
 		appRepo.Spec.DockerRegistrySecrets = nil
 		appRepo.Spec.OCIRepositories = nil

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
@@ -401,7 +401,7 @@ func TestAddPackageRepository(t *testing.T) {
 			name:             "package repository with custom values",
 			request:          addRepoReqCustomValues,
 			expectedResponse: addRepoExpectedResp,
-			expectedRepo:     &addRepoCustomDetailsHelm,
+			expectedRepo:     &addRepoCustomDetailHelm,
 			statusCode:       codes.OK,
 		},
 		{
@@ -414,7 +414,7 @@ func TestAddPackageRepository(t *testing.T) {
 			name:             "package repository with validation success (Helm)",
 			request:          addRepoReqCustomValuesHelmValid,
 			expectedResponse: addRepoExpectedResp,
-			expectedRepo:     &addRepoCustomDetailsHelm,
+			expectedRepo:     &addRepoCustomDetailHelm,
 			repoClientGetter: newRepoHttpClient(map[string]*http.Response{"https://example.com/index.yaml": {StatusCode: 200}}),
 			statusCode:       codes.OK,
 		},
@@ -422,7 +422,7 @@ func TestAddPackageRepository(t *testing.T) {
 			name:             "package repository with validation success (OCI)",
 			request:          addRepoReqCustomValuesOCIValid,
 			expectedResponse: addRepoExpectedResp,
-			expectedRepo:     &addRepoCustomDetailsOci,
+			expectedRepo:     &addRepoCustomDetailOci,
 			repoClientGetter: newRepoHttpClient(map[string]*http.Response{
 				"https://example.com/v2/repo1/tags/list?n=1":  httpResponse(200, "{ \"name\":\"repo1\", \"tags\":[\"tag1\"] }"),
 				"https://example.com/v2/repo1/manifests/tag1": httpResponse(200, "{ \"config\":{ \"mediaType\":\"application/vnd.cncf.helm.config\" } }"),
@@ -635,7 +635,7 @@ func TestGetPackageRepositoryDetail(t *testing.T) {
 	}
 	buildResponse := func(namespace, name, repoType, url, description string,
 		auth *corev1.PackageRepositoryAuth, tlsConfig *corev1.PackageRepositoryTlsConfig,
-		customDetails *v1alpha1.HelmPackageRepositoryCustomDetail) *corev1.GetPackageRepositoryDetailResponse {
+		customDetail *v1alpha1.HelmPackageRepositoryCustomDetail) *corev1.GetPackageRepositoryDetailResponse {
 		response := &corev1.GetPackageRepositoryDetailResponse{
 			Detail: &corev1.PackageRepositoryDetail{
 				PackageRepoRef: &corev1.PackageRepositoryReference{
@@ -653,8 +653,8 @@ func TestGetPackageRepositoryDetail(t *testing.T) {
 				Status:          &corev1.PackageRepositoryStatus{Ready: true},
 			},
 		}
-		if customDetails != nil {
-			response.Detail.CustomDetail = toProtoBufAny(customDetails)
+		if customDetail != nil {
+			response.Detail.CustomDetail = toProtoBufAny(customDetail)
 		}
 		return response
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -1022,25 +1022,25 @@ func (s *Server) AddPackageRepository(ctx context.Context, request *corev1.AddPa
 	}
 
 	// Get Helm-specific values
-	var customDetails *helmv1.HelmPackageRepositoryCustomDetail
+	var customDetail *helmv1.HelmPackageRepositoryCustomDetail
 	if request.CustomDetail != nil {
-		customDetails = &helmv1.HelmPackageRepositoryCustomDetail{}
-		if err := request.CustomDetail.UnmarshalTo(customDetails); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "customDetails could not be parsed: [%v]", request.CustomDetail)
+		customDetail = &helmv1.HelmPackageRepositoryCustomDetail{}
+		if err := request.CustomDetail.UnmarshalTo(customDetail); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "customDetail could not be parsed: [%v]", request.CustomDetail)
 		}
-		log.Infof("+helm customDetails [%v]", customDetails)
+		log.Infof("+helm customDetail [%v]", customDetail)
 	}
 
 	helmRepo := &HelmRepository{
-		cluster:       cluster,
-		name:          name,
-		url:           request.GetUrl(),
-		repoType:      request.GetType(),
-		description:   request.GetDescription(),
-		interval:      request.GetInterval(),
-		tlsConfig:     request.GetTlsConfig(),
-		auth:          request.GetAuth(),
-		customDetails: customDetails,
+		cluster:      cluster,
+		name:         name,
+		url:          request.GetUrl(),
+		repoType:     request.GetType(),
+		description:  request.GetDescription(),
+		interval:     request.GetInterval(),
+		tlsConfig:    request.GetTlsConfig(),
+		auth:         request.GetAuth(),
+		customDetail: customDetail,
 	}
 	if repoRef, err := s.newRepo(ctx, helmRepo); err != nil {
 		return nil, err
@@ -1119,13 +1119,13 @@ func (s *Server) UpdatePackageRepository(ctx context.Context, request *corev1.Up
 	log.Infof("+helm UpdatePackageRepository '%s' in context [%v]", repoRef.Identifier, repoRef.Context)
 
 	// Get Helm-specific values
-	var customDetails *helmv1.HelmPackageRepositoryCustomDetail
+	var customDetail *helmv1.HelmPackageRepositoryCustomDetail
 	if request.CustomDetail != nil {
-		customDetails = &helmv1.HelmPackageRepositoryCustomDetail{}
-		if err := request.CustomDetail.UnmarshalTo(customDetails); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "customDetails could not be parsed: [%v]", request.CustomDetail)
+		customDetail = &helmv1.HelmPackageRepositoryCustomDetail{}
+		if err := request.CustomDetail.UnmarshalTo(customDetail); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "customDetail could not be parsed: [%v]", request.CustomDetail)
 		}
-		log.V(4).Infof("+helm upgrade repo %s customDetails [%v]", repoRef.Identifier, customDetails)
+		log.V(4).Infof("+helm upgrade repo %s customDetail [%v]", repoRef.Identifier, customDetail)
 	}
 
 	helmRepo := &HelmRepository{
@@ -1134,12 +1134,12 @@ func (s *Server) UpdatePackageRepository(ctx context.Context, request *corev1.Up
 			Name:      repoRef.Identifier,
 			Namespace: repoRef.GetContext().GetNamespace(),
 		},
-		url:           request.GetUrl(),
-		description:   request.GetDescription(),
-		interval:      request.GetInterval(),
-		tlsConfig:     request.GetTlsConfig(),
-		auth:          request.GetAuth(),
-		customDetails: customDetails,
+		url:          request.GetUrl(),
+		description:  request.GetDescription(),
+		interval:     request.GetInterval(),
+		tlsConfig:    request.GetTlsConfig(),
+		auth:         request.GetAuth(),
+		customDetail: customDetail,
 	}
 	if responseRef, err := s.updateRepo(ctx, helmRepo); err != nil {
 		return nil, err

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -121,7 +121,7 @@ const pkgRepoFormData = {
     username: "",
   },
   customCA: "",
-  customDetails: {
+  customDetail: {
     dockerRegistrySecrets: [],
     ociRepositories: [],
     performValidation: false,
@@ -420,8 +420,8 @@ describe("addRepo", () => {
         repoActions.addRepo("my-namespace", {
           ...pkgRepoFormData,
           type: RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI,
-          customDetails: {
-            ...pkgRepoFormData.customDetails,
+          customDetail: {
+            ...pkgRepoFormData.customDetail,
             ociRepositories: ["apache", "jenkins"],
           },
         }),
@@ -432,8 +432,8 @@ describe("addRepo", () => {
         {
           ...pkgRepoFormData,
           type: RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI,
-          customDetails: {
-            ...pkgRepoFormData.customDetails,
+          customDetail: {
+            ...pkgRepoFormData.customDetail,
             ociRepositories: ["apache", "jenkins"],
           },
         },
@@ -551,7 +551,7 @@ describe("addRepo", () => {
     await store.dispatch(
       repoActions.addRepo("my-namespace", {
         ...pkgRepoFormData,
-        customDetails: { ...pkgRepoFormData.customDetails, dockerRegistrySecrets: ["repo-1"] },
+        customDetail: { ...pkgRepoFormData.customDetail, dockerRegistrySecrets: ["repo-1"] },
       }),
     );
 
@@ -560,7 +560,7 @@ describe("addRepo", () => {
       "my-namespace",
       {
         ...pkgRepoFormData,
-        customDetails: { ...pkgRepoFormData.customDetails, dockerRegistrySecrets: ["repo-1"] },
+        customDetail: { ...pkgRepoFormData.customDetail, dockerRegistrySecrets: ["repo-1"] },
       },
       true,
     );
@@ -693,7 +693,7 @@ describe("updateRepo", () => {
       repoActions.updateRepo("my-namespace", {
         ...pkgRepoFormData,
         type: RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI,
-        customDetails: { ...pkgRepoFormData.customDetails, ociRepositories: ["apache", "jenkins"] },
+        customDetail: { ...pkgRepoFormData.customDetail, ociRepositories: ["apache", "jenkins"] },
       }),
     );
     expect(PackageRepositoriesService.updatePackageRepository).toHaveBeenCalledWith(
@@ -702,7 +702,7 @@ describe("updateRepo", () => {
       {
         ...pkgRepoFormData,
         type: RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI,
-        customDetails: { ...pkgRepoFormData.customDetails, ociRepositories: ["apache", "jenkins"] },
+        customDetail: { ...pkgRepoFormData.customDetail, ociRepositories: ["apache", "jenkins"] },
       },
     );
   });

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
@@ -47,7 +47,7 @@ const pkgRepoFormData = {
     username: "",
   },
   customCA: "",
-  customDetails: {
+  customDetail: {
     dockerRegistrySecrets: [],
     ociRepositories: [],
     performValidation: true,
@@ -247,7 +247,7 @@ it("should call the install method with OCI information", async () => {
     type: "oci",
     url: "https://oci.repo",
     plugin: { name: PluginNames.PACKAGES_HELM, version: "v1alpha1" },
-    customDetails: {
+    customDetail: {
       ociRepositories: ["apache", "jenkins"],
       dockerRegistrySecrets: [],
       filterRule: undefined,
@@ -283,7 +283,7 @@ it("should call the install skipping TLS verification", async () => {
     type: "helm",
     url: "https://helm.repo",
     plugin: { name: PluginNames.PACKAGES_HELM, version: "v1alpha1" },
-    customDetails: {
+    customDetail: {
       ociRepositories: [],
       dockerRegistrySecrets: [],
       filterRule: undefined,
@@ -320,7 +320,7 @@ it("should call the install passing credentials", async () => {
     type: "helm",
     url: "https://helm.repo",
     plugin: { name: PluginNames.PACKAGES_HELM, version: "v1alpha1" },
-    customDetails: {
+    customDetail: {
       ociRepositories: [],
       dockerRegistrySecrets: [],
       filterRule: undefined,
@@ -357,7 +357,7 @@ describe("when using a filter", () => {
       type: "helm",
       url: "https://helm.repo",
       plugin: { name: PluginNames.PACKAGES_HELM, version: "v1alpha1" },
-      customDetails: {
+      customDetail: {
         ociRepositories: [],
         dockerRegistrySecrets: [],
         filterRule: {
@@ -398,7 +398,7 @@ describe("when using a filter", () => {
       type: "helm",
       url: "https://helm.repo",
       plugin: { name: PluginNames.PACKAGES_HELM, version: "v1alpha1" },
-      customDetails: {
+      customDetail: {
         ociRepositories: [],
         dockerRegistrySecrets: [],
         filterRule: {
@@ -443,7 +443,7 @@ describe("when using a filter", () => {
       type: "oci",
       url: "https://oci.repo",
       plugin: { name: PluginNames.PACKAGES_HELM, version: "v1alpha1" },
-      customDetails: {
+      customDetail: {
         ociRepositories: ["apache", "jenkins"],
         dockerRegistrySecrets: [],
         filterRule: undefined,
@@ -477,7 +477,7 @@ it("should call the install method with a description", async () => {
     name: "helm-repo",
     type: "helm",
     url: "https://helm.repo",
-    customDetails: {
+    customDetail: {
       ociRepositories: [],
       dockerRegistrySecrets: [],
       filterRule: undefined,

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
@@ -268,7 +268,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
         username: isUserManagedSecret ? "" : basicUser,
       } as UsernamePassword,
       customCA: isUserManagedCASecret ? "" : customCA,
-      customDetails: {
+      customDetail: {
         ociRepositories: ociRepoList,
         performValidation,
         filterRule: filter,

--- a/dashboard/src/shared/PackageRepositoriesService.test.ts
+++ b/dashboard/src/shared/PackageRepositoriesService.test.ts
@@ -29,7 +29,7 @@ const pkgRepoFormData = {
     username: "",
   },
   customCA: "",
-  customDetails: {
+  customDetail: {
     dockerRegistrySecrets: [],
     ociRepositories: [],
     performValidation: false,

--- a/dashboard/src/shared/PackageRepositoriesService.ts
+++ b/dashboard/src/shared/PackageRepositoriesService.ts
@@ -55,7 +55,7 @@ export class PackageRepositoriesService {
       namespace,
       request,
       namespaceScoped,
-      this.buildEncodedCustomDetails(request),
+      this.buildEncodedCustomDetail(request),
     );
 
     return await this.coreRepositoriesClient().AddPackageRepository(addPackageRepositoryRequest);
@@ -72,7 +72,7 @@ export class PackageRepositoriesService {
       namespace,
       request,
       undefined,
-      this.buildEncodedCustomDetails(request),
+      this.buildEncodedCustomDetail(request),
     );
 
     return await this.coreRepositoriesClient().UpdatePackageRepository(
@@ -94,7 +94,7 @@ export class PackageRepositoriesService {
     namespace: string,
     request: IPkgRepoFormData,
     namespaceScoped?: boolean,
-    customDetails?: any,
+    pluginCustomDetail?: any,
   ) {
     const addPackageRepositoryRequest = {
       context: { cluster, namespace },
@@ -105,7 +105,7 @@ export class PackageRepositoriesService {
       url: request.url,
       interval: request.interval,
       plugin: request.plugin,
-      customDetails: customDetails,
+      customDetail: pluginCustomDetail,
     } as AddPackageRepositoryRequest;
 
     // add optional fields if present in the request
@@ -210,7 +210,7 @@ export class PackageRepositoriesService {
     return addPackageRepositoryRequest;
   }
 
-  private static buildEncodedCustomDetails(request: IPkgRepoFormData) {
+  private static buildEncodedCustomDetail(request: IPkgRepoFormData) {
     // if using the Helm plugin, add its custom fields.
     // An "Any" object has  "typeUrl" with the FQN of the type and a "value",
     // which is the result of the encoding (+finish(), to get the Uint8Array)
@@ -220,7 +220,7 @@ export class PackageRepositoriesService {
         return {
           typeUrl: `${helmProtobufPackage}.HelmPackageRepositoryCustomDetail`,
           value: HelmPackageRepositoryCustomDetail.encode(
-            request.customDetails as HelmPackageRepositoryCustomDetail,
+            request.customDetail as HelmPackageRepositoryCustomDetail,
           ).finish(),
         } as Any;
       default:

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -443,5 +443,5 @@ export interface IPkgRepoFormData {
   skipTLS: boolean;
   type: string;
   url: string;
-  customDetails: Partial<HelmPackageRepositoryCustomDetail>; // add more types if necesary, currently just helm's custom details
+  customDetail: Partial<HelmPackageRepositoryCustomDetail>; // add more types if necesary, currently just helm's custom details
 }


### PR DESCRIPTION
### Description of the change

This PR simply performs a consistent rename from `customDetails` (note the final `s`) to `customDetail` (as defined in the proto file).

### Benefits

Today, the custom details weren't being processed simply due to this extra `s`.

### Possible drawbacks

N/A

### Applicable issues

- related #4764 

### Additional information

N/A
