### PR TITLE
Add pending e2e tests for the repos UI

### DIFF
--- a/integration/tests/main/03-create-private-package-repository.spec.js
+++ b/integration/tests/main/03-create-private-package-repository.spec.js
@@ -28,7 +28,10 @@ test("Create a new private package repository successfully", async ({ page }) =>
 
   await page.locator("text=Add Package Repository >> div").click();
   await page.fill("input#kubeapps-repo-name", repoName);
-  await page.fill("input#kubeapps-repo-url", "http://chartmuseum.chart-museum.svc.cluster.local:8080");
+  await page.fill(
+    "input#kubeapps-repo-url",
+    "http://chartmuseum.chart-museum.svc.cluster.local:8080",
+  );
   await page.locator("text=Helm Charts").first().click();
   await page.locator("text=Helm Repository").click();
 
@@ -48,82 +51,80 @@ test("Create a new private package repository successfully", async ({ page }) =>
   // Check if our package shows up in catalog
   await page.click(`a:has-text("${repoName}")`);
 
-  //TODO(agamez): this test is failing, check if it is an issue with the UI or
-  // even with the new Repos API.
-  // await page.click('a:has-text("foo apache chart for CI")');
+  await page.click('a:has-text("foo apache chart for CI")');
 
-  // // Deploy package
-  // await page.click('cds-button:has-text("Deploy")');
-  // await page.selectOption('select[name="package-versions"]', "8.6.2");
-  // const releaseNameLocator = page.locator("#releaseName");
-  // await releaseNameLocator.waitFor();
-  // await expect(releaseNameLocator).toHaveText("");
-  // const appName = utils.getRandomName("test-03-release");
-  // console.log(`Creating release "${appName}"`);
-  // await releaseNameLocator.fill(appName);
+  // Deploy package
+  await page.click('cds-button:has-text("Deploy")');
+  await page.selectOption('select[name="package-versions"]', "8.6.2");
+  const releaseNameLocator = page.locator("#releaseName");
+  await releaseNameLocator.waitFor();
+  await expect(releaseNameLocator).toHaveText("");
+  const appName = utils.getRandomName("test-03-release");
+  console.log(`Creating release "${appName}"`);
+  await releaseNameLocator.fill(appName);
 
-  // // Select version and deploy
-  // await page.locator('select[name="package-versions"]').selectOption("8.6.2");
-  // await page.locator('cds-button:has-text("Deploy")').click();
+  // Select version and deploy
+  await page.locator('select[name="package-versions"]').selectOption("8.6.2");
+  await page.locator('cds-button:has-text("Deploy")').click();
 
-  // // Assertions
-  // // Wait for the app to be deployed and select it from "Applications"
-  // await page.waitForTimeout(5000);
-  // await page.click('a.nav-link:has-text("Applications")');
-  // await page.waitForTimeout(3000); // Sometimes typing was too fast to get the result shown
-  // await page.locator("input#search").fill(appName);
-  // await page.waitForTimeout(3000);
-  // await page.click(`a .card-title:has-text("${appName}")`);
+  // Assertions
+  // Wait for the app to be deployed and select it from "Applications"
+  await page.waitForTimeout(5000);
+  await page.click('a.nav-link:has-text("Applications")');
+  await page.waitForTimeout(3000); // Sometimes typing was too fast to get the result shown
+  await page.locator("input#search").fill(appName);
+  await page.waitForTimeout(3000);
+  await page.click(`a .card-title:has-text("${appName}")`);
 
-  // await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
-  //   timeout: deployTimeout,
-  // });
-  // await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
-  //   timeout: deployTimeout,
-  // });
+  await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
+    timeout: deployTimeout,
+  });
+  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
+    timeout: deployTimeout,
+  });
 
-  // // Prepare and verify the upgrade
-  // await page.waitForSelector('cds-button:has-text("Upgrade")');
-  // await page.click('cds-button:has-text("Upgrade")');
+  // Prepare and verify the upgrade
+  await page.waitForSelector('cds-button:has-text("Upgrade")');
+  await page.click('cds-button:has-text("Upgrade")');
 
-  // // Check first current installed version
-  // await page.waitForSelector('select[name="package-versions"]');
-  // const packageVersionValue = await page.inputValue('select[name="package-versions"]');
-  // expect(packageVersionValue).toEqual("8.6.2");
+  // Check first current installed version
+  await page.waitForSelector('select[name="package-versions"]');
+  const packageVersionValue = await page.inputValue('select[name="package-versions"]');
+  expect(packageVersionValue).toEqual("8.6.2");
 
-  // // Select new version
-  // await page.selectOption('select[name="package-versions"]', "8.6.3");
+  // Select new version
+  await page.selectOption('select[name="package-versions"]', "8.6.3");
 
-  // // Ensure that the new value is selected
-  // await page.waitForSelector('select[name="package-versions"]');
-  // const newPackageVersionValue = await page.inputValue('select[name="package-versions"]');
-  // expect(newPackageVersionValue).toEqual("8.6.3");
-  // await page.click('li:has-text("Changes")');
-  // await expect(page.locator("section#deployment-form-body-tabs-panel2")).toContainText(
-  //   "tag: 2.4.48-debian-10-r75",
-  // );
+  // Ensure that the new value is selected
+  await page.waitForSelector('select[name="package-versions"]');
+  const newPackageVersionValue = await page.inputValue('select[name="package-versions"]');
+  expect(newPackageVersionValue).toEqual("8.6.3");
+  await page.click('li:has-text("Changes")');
+  await expect(page.locator("section#deployment-form-body-tabs-panel2")).toContainText(
+    "tag: 2.4.48-debian-10-r75",
+  );
 
-  // // Deploy upgrade
-  // await page.click('cds-button:has-text("Deploy")');
+  // Deploy upgrade
+  await page.click('cds-button:has-text("Deploy")');
 
-  // // Check upgrade result
-  // await page.waitForSelector(".left-menu");
-  // // Wait for the app to be deployed and select it from "Applications"
-  // await expect(page.locator(".left-menu")).toContainText("Up to date", { timeout: deployTimeout });
-  // await page.waitForTimeout(5000);
-  // await page.click('a.nav-link:has-text("Applications")');
-  // await page.waitForTimeout(3000); // Sometimes typing was too fast to get the result shown
-  // await page.locator("input#search").fill(appName);
-  // await page.waitForTimeout(3000);
-  // await page.click(`a .card-title:has-text("${appName}")`);
-  // await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
-  //   timeout: deployTimeout,
-  // });
-  // await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
-  //   timeout: deployTimeout,
-  // });
+  // Check upgrade result
+  await page.waitForSelector(".left-menu");
+  // Wait for the app to be deployed and select it from "Applications"
+  await expect(page.locator(".left-menu")).toContainText("Up to date", { timeout: deployTimeout });
+  await page.waitForTimeout(5000);
+  await page.click('a.nav-link:has-text("Applications")');
+  await page.waitForTimeout(3000); // Sometimes typing was too fast to get the result shown
+  await page.locator("input#search").fill(appName);
+  await page.waitForTimeout(3000);
+  await page.click(`a .card-title:has-text("${appName}")`);
+  await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
+    timeout: deployTimeout,
+  });
+  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
+    timeout: deployTimeout,
+  });
 
-  // // Clean up
-  // await page.locator('cds-button:has-text("Delete")').click();
-  // await page.locator('cds-modal-actions button:has-text("Delete")').click();
+  // Clean up
+  await page.locator('cds-button:has-text("Delete")').click();
+  await page.locator('cds-modal-actions button:has-text("Delete")').click();
 });

--- a/integration/tests/main/10-deploy-package-with-private-image.spec.js
+++ b/integration/tests/main/10-deploy-package-with-private-image.spec.js
@@ -27,7 +27,10 @@ test("Deploy a chart using a private container image", async ({ page }) => {
   console.log(`Creating package repository "${repoName}"`);
   await page.locator("text=Add Package Repository >> div").click();
   await page.fill("input#kubeapps-repo-name", repoName);
-  await page.fill("input#kubeapps-repo-url", "http://chartmuseum.chart-museum.svc.cluster.local:8080");
+  await page.fill(
+    "input#kubeapps-repo-url",
+    "http://chartmuseum.chart-museum.svc.cluster.local:8080",
+  );
   await page.locator("text=Helm Charts").first().click();
   await page.locator("text=Helm Repository").click();
 
@@ -56,42 +59,42 @@ test("Deploy a chart using a private container image", async ({ page }) => {
   // For now, disabling the this test case temporarily.
 
   // Wait for new packages to be indexed
-  // await page.waitForTimeout(5000);
+  await page.waitForTimeout(5000);
 
-  // // Check if our package shows up in catalog
-  // await page.click(`a:has-text("${repoName}")`);
-  // await page.click('a:has-text("simplechart")');
+  // Check if our package shows up in catalog
+  await page.click(`a:has-text("${repoName}")`);
+  await page.click('a:has-text("simplechart")');
 
-  // // Deploy package
-  // await page.click('cds-button:has-text("Deploy")');
-  // await page.selectOption('select[name="package-versions"]', "0.1.0");
-  // const releaseNameLocator = page.locator("#releaseName");
-  // await releaseNameLocator.waitFor();
-  // await expect(releaseNameLocator).toHaveText("");
-  // const appName = utils.getRandomName("test-10-release");
-  // console.log(`Creating release "${appName}"`);
-  // await releaseNameLocator.fill(appName);
+  // Deploy package
+  await page.click('cds-button:has-text("Deploy")');
+  await page.selectOption('select[name="package-versions"]', "0.1.0");
+  const releaseNameLocator = page.locator("#releaseName");
+  await releaseNameLocator.waitFor();
+  await expect(releaseNameLocator).toHaveText("");
+  const appName = utils.getRandomName("test-10-release");
+  console.log(`Creating release "${appName}"`);
+  await releaseNameLocator.fill(appName);
 
-  // // Select version and deploy
-  // await page.locator('cds-button:has-text("Deploy")').click();
+  // Select version and deploy
+  await page.locator('cds-button:has-text("Deploy")').click();
 
-  // // Assertions
-  // // Wait for the app to be deployed and select it from "Applications"
-  // await page.waitForTimeout(5000);
-  // await page.click('a.nav-link:has-text("Applications")');
-  // await page.waitForTimeout(3000); // Sometimes typing was too fast to get the result shown
-  // await page.locator("input#search").fill(appName);
-  // await page.waitForTimeout(3000);
-  // await page.click(`a .card-title:has-text("${appName}")`);
+  // Assertions
+  // Wait for the app to be deployed and select it from "Applications"
+  await page.waitForTimeout(5000);
+  await page.click('a.nav-link:has-text("Applications")');
+  await page.waitForTimeout(3000); // Sometimes typing was too fast to get the result shown
+  await page.locator("input#search").fill(appName);
+  await page.waitForTimeout(3000);
+  await page.click(`a .card-title:has-text("${appName}")`);
 
-  // await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
-  //   timeout: deployTimeout,
-  // });
-  // await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
-  //   timeout: deployTimeout,
-  // });
+  await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
+    timeout: deployTimeout,
+  });
+  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
+    timeout: deployTimeout,
+  });
 
-  // // Clean up
-  // await page.locator('cds-button:has-text("Delete")').click();
-  // await page.locator('cds-modal-actions button:has-text("Delete")').click();
+  // Clean up
+  await page.locator('cds-button:has-text("Delete")').click();
+  await page.locator('cds-modal-actions button:has-text("Delete")').click();
 });


### PR DESCRIPTION
### Description of the change

In previous PRs we have been extensively working on the new repos API and UI. However, the integration wasn't fully working due to several blocking issues.
This PR is to re-enable some commented-out test cases we had disabled.

### Benefits

 Once passing, we should be able to start creating the PR against `main`, as, in theory, it wouldn't break the current UX.

### Possible drawbacks

If they don't work, we might discover additional issues we have to fix 😝 

### Applicable issues

- fixes #4876

### Additional information

N/A