### PR TITLE
Make ChartMuseum CI version configurable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ parameters:
   OLM_VERSION:
     type: "string"
     default: "v0.21.2"
+  CHARTMUSEUM_VERSION:
+    type: "string"
+    default: "3.9.0"
   KAPP_CONTROLLER_VERSION:
     type: "string"
     default: "v0.38.0"
@@ -506,7 +509,7 @@ run_e2e_tests: &run_e2e_tests
         DEV_TAG=${latest/v/}
         IMG_MODIFIER=""
       fi
-      if ./script/e2e-test.sh $USE_MULTICLUSTER_OIDC_ENV $OLM_VERSION $DEV_TAG $IMG_MODIFIER $TEST_TIMEOUT_MINUTES $DEFAULT_DEX_IP $ADDITIONAL_CLUSTER_IP $KAPP_CONTROLLER_VERSION; then
+      if ./script/e2e-test.sh $USE_MULTICLUSTER_OIDC_ENV $OLM_VERSION $DEV_TAG $IMG_MODIFIER $TEST_TIMEOUT_MINUTES $DEFAULT_DEX_IP $ADDITIONAL_CLUSTER_IP $KAPP_CONTROLLER_VERSION $CHARTMUSEUM_VERSION; then
         # Test success
         echo "export TEST_RESULT=$?" >> $BASH_ENV
       else

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 IMPORT_PATH:= github.com/vmware-tanzu/kubeapps
 GO = /usr/bin/env go
 GOFMT = /usr/bin/env gofmt
-IMAGE_TAG ?= latest
+IMAGE_TAG ?= dev-$(shell date +%FT%H-%M-%S-%Z)
 VERSION ?= $$(git rev-parse HEAD)
 
 default: all

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 IMPORT_PATH:= github.com/vmware-tanzu/kubeapps
 GO = /usr/bin/env go
 GOFMT = /usr/bin/env gofmt
-IMAGE_TAG ?= dev-$(shell date +%FT%H-%M-%S-%Z)
+IMAGE_TAG ?= latest
 VERSION ?= $$(git rev-parse HEAD)
 
 default: all

--- a/integration/.gitignore
+++ b/integration/.gitignore
@@ -5,3 +5,5 @@ node_modules
 # Reports
 reports/screenshots
 use-cases/reports
+reports
+reports-html

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -17,7 +17,7 @@ TEST_TIMEOUT_MINUTES=${5:-"4"}
 DEX_IP=${6:-"172.18.0.2"}
 ADDITIONAL_CLUSTER_IP=${7:-"172.18.0.3"}
 KAPP_CONTROLLER_VERSION=${8:-"v0.32.0"}
-CM_VERSION=${9:-"2.14.2"}
+CHARTMUSEUM_VERSION=${9:-"2.14.2"}
 
 # TODO(andresmgot): While we work with beta releases, the Bitnami pipeline
 # removes the pre-release part of the tag
@@ -39,7 +39,7 @@ fi
 info "Root dir: ${ROOT_DIR}"
 info "Use multicluster+OIDC: ${USE_MULTICLUSTER_OIDC_ENV}"
 info "OLM version: ${OLM_VERSION}"
-info "ChartMuseum version: ${CM_VERSION}"
+info "ChartMuseum version: ${CHARTMUSEUM_VERSION}"
 info "Image tag: ${DEV_TAG}"
 info "Image repo suffix: ${IMG_MODIFIER}"
 info "Dex IP: ${DEX_IP}"
@@ -328,7 +328,7 @@ fi
 installOrUpgradeKubeapps "${ROOT_DIR}/chart/kubeapps"
 info "Waiting for Kubeapps components to be ready (local chart)..."
 k8s_wait_for_deployment kubeapps kubeapps-ci
-installChartmuseum admin password "${CM_VERSION}"
+installChartmuseum admin password "${CHARTMUSEUM_VERSION}"
 pushChart apache 8.6.2 admin password
 pushChart apache 8.6.3 admin password
 

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -17,6 +17,7 @@ TEST_TIMEOUT_MINUTES=${5:-"4"}
 DEX_IP=${6:-"172.18.0.2"}
 ADDITIONAL_CLUSTER_IP=${7:-"172.18.0.3"}
 KAPP_CONTROLLER_VERSION=${8:-"v0.32.0"}
+CM_VERSION=${9:-"2.14.2"}
 
 # TODO(andresmgot): While we work with beta releases, the Bitnami pipeline
 # removes the pre-release part of the tag
@@ -38,6 +39,7 @@ fi
 info "Root dir: ${ROOT_DIR}"
 info "Use multicluster+OIDC: ${USE_MULTICLUSTER_OIDC_ENV}"
 info "OLM version: ${OLM_VERSION}"
+info "ChartMuseum version: ${CM_VERSION}"
 info "Image tag: ${DEV_TAG}"
 info "Image repo suffix: ${IMG_MODIFIER}"
 info "Dex IP: ${DEX_IP}"
@@ -137,8 +139,10 @@ installOLM() {
 installChartmuseum() {
   local user=$1
   local password=$2
-  info "Installing ChartMuseum ..."
-  helm install chartmuseum --namespace kubeapps https://github.com/chartmuseum/charts/releases/download/chartmuseum-2.14.2/chartmuseum-2.14.2.tgz \
+  local version=$3
+  info "Installing ChartMuseum ${version}..."
+  helm install chartmuseum --namespace kubeapps https://github.com/chartmuseum/charts/releases/download/chartmuseum-3.9.0/chartmuseum-3.9.0.tgz \
+  helm install chartmuseum --namespace kubeapps "https://github.com/chartmuseum/charts/releases/download/chartmuseum-${version}/chartmuseum-${version}.tgz" \
     --set env.open.DISABLE_API=false \
     --set persistence.enabled=true \
     --set secret.AUTH_USER=$user \
@@ -324,7 +328,7 @@ fi
 installOrUpgradeKubeapps "${ROOT_DIR}/chart/kubeapps"
 info "Waiting for Kubeapps components to be ready (local chart)..."
 k8s_wait_for_deployment kubeapps kubeapps-ci
-installChartmuseum admin password
+installChartmuseum admin password "${CM_VERSION}"
 pushChart apache 8.6.2 admin password
 pushChart apache 8.6.3 admin password
 

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -134,6 +134,7 @@ installOLM() {
 # Arguments:
 #   $1: Username
 #   $2: Password
+#   $3: ChartMuseum version
 # Returns: None
 #########################
 installChartmuseum() {
@@ -141,7 +142,6 @@ installChartmuseum() {
   local password=$2
   local version=$3
   info "Installing ChartMuseum ${version}..."
-  helm install chartmuseum --namespace kubeapps https://github.com/chartmuseum/charts/releases/download/chartmuseum-3.9.0/chartmuseum-3.9.0.tgz \
   helm install chartmuseum --namespace kubeapps "https://github.com/chartmuseum/charts/releases/download/chartmuseum-${version}/chartmuseum-${version}.tgz" \
     --set env.open.DISABLE_API=false \
     --set persistence.enabled=true \

--- a/site/content/docs/latest/reference/developer/release-process.md
+++ b/site/content/docs/latest/reference/developer/release-process.md
@@ -44,6 +44,7 @@ The versions used there _must_ match the ones used for building the container im
 - `HELM_VERSION_MIN` _must_ match the one listed in the [Bitnami Application Catalog prerequisites](https://github.com/bitnami/charts#prerequisites).
 - `HELM_VERSION_STABLE` should be updated with the [latest stable version from the Helm releases](https://github.com/helm/helm/releases).
 - `OLM_VERSION` should be updated with the [latest stable version from the OLM releases](https://github.com/operator-framework/operator-lifecycle-manager/releases).
+- `CHARTMUSEUM_VERSION` should be updated with the [latest stable version from the chartmuseum/charts releases](https://github.com/chartmuseum/charts/releases).
 - `KAPP_CONTROLLER_VERSION` should be updated with the [latest stable version from the Kapp Controller releases](https://github.com/vmware-tanzu/carvel-kapp-controller/releases).
 - `MKCERT_VERSION` should be updated with the [latest stable version from the mkcert releases](https://github.com/FiloSottile/mkcert/releases).
 - `KUBECTL_VERSION` _should_ match the Kubernetes minor version (or minor version +1) used in `GKE_REGULAR_VERSION_XX` and listed in the [Kubernetes releases page](https://kubernetes.io/releases/).


### PR DESCRIPTION
### Description of the change

While working on the e2e tests I noticed we had a hardcoded CharMuseum version, this PR is extracting the version into a separate variable so that we can properly update it.

### Benefits

CM cersion management will be aligned with the rest of the CI component's

### Possible drawbacks

N/A

### Applicable issues

- fixes #5118

### Additional information

N/A