### PR TITLE
Added Helm global secret for namespaced repos

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/globals_vars_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/globals_vars_test.go
@@ -88,34 +88,7 @@ var (
 		},
 	}
 
-	addRepoAuthHeaderPassCredentials = v1alpha1.AppRepository{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       AppRepositoryKind,
-			APIVersion: AppRepositoryApi,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "bar",
-			Namespace:       "foo",
-			ResourceVersion: "1",
-		},
-		Spec: v1alpha1.AppRepositorySpec{
-			URL:  "http://example.com",
-			Type: "helm",
-			Auth: v1alpha1.AppRepositoryAuth{
-				Header: &v1alpha1.AppRepositoryAuthHeader{
-					SecretKeyRef: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
-							Name: "apprepo-bar",
-						},
-						Key: "authorizationHeader",
-					},
-				},
-			},
-			PassCredentials: true,
-		},
-	}
-
-	addRepoAuthHeaderWithSecretRef = func(secretName string) *v1alpha1.AppRepository {
+	addRepoAuthHeaderPassCredentials = func(namespace string) *v1alpha1.AppRepository {
 		return &v1alpha1.AppRepository{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       AppRepositoryKind,
@@ -123,7 +96,36 @@ var (
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "bar",
-				Namespace:       "foo",
+				Namespace:       namespace,
+				ResourceVersion: "1",
+			},
+			Spec: v1alpha1.AppRepositorySpec{
+				URL:  "http://example.com",
+				Type: "helm",
+				Auth: v1alpha1.AppRepositoryAuth{
+					Header: &v1alpha1.AppRepositoryAuthHeader{
+						SecretKeyRef: v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "apprepo-bar",
+							},
+							Key: "authorizationHeader",
+						},
+					},
+				},
+				PassCredentials: true,
+			},
+		}
+	}
+
+	addRepoAuthHeaderWithSecretRef = func(namespace, secretName string) *v1alpha1.AppRepository {
+		return &v1alpha1.AppRepository{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       AppRepositoryKind,
+				APIVersion: AppRepositoryApi,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "bar",
+				Namespace:       namespace,
 				ResourceVersion: "1",
 			},
 			Spec: v1alpha1.AppRepositorySpec{
@@ -361,10 +363,10 @@ var (
 		}
 	}
 
-	addRepoReqAuthWithSecret = func(authType corev1.PackageRepositoryAuth_PackageRepositoryAuthType, secretName string) *corev1.AddPackageRepositoryRequest {
+	addRepoReqAuthWithSecret = func(authType corev1.PackageRepositoryAuth_PackageRepositoryAuthType, namespace, secretName string) *corev1.AddPackageRepositoryRequest {
 		return &corev1.AddPackageRepositoryRequest{
 			Name:            "bar",
-			Context:         &corev1.Context{Namespace: "foo", Cluster: KubeappsCluster},
+			Context:         &corev1.Context{Namespace: namespace, Cluster: KubeappsCluster},
 			Type:            "helm",
 			Url:             "http://example.com",
 			NamespaceScoped: true,
@@ -496,7 +498,7 @@ var (
 	}
 
 	addRepoExpectedGlobalResp = &corev1.AddPackageRepositoryResponse{
-		PackageRepoRef: repoRef("bar", KubeappsCluster, "kubeapps"),
+		PackageRepoRef: repoRef("bar", KubeappsCluster, globalPackagingNamespace),
 	}
 
 	packageRepoSecretBasicAuth = func(secretName string) *corev1.PackageRepositoryAuth {

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+
 	apprepov1alpha1 "github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	corev1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
@@ -72,7 +73,7 @@ func (s *Server) newRepo(ctx context.Context, repo *HelmRepository) (*corev1.Pac
 			return nil, err
 		}
 	}
-	// Copy secret to global namespace if needed
+	// Copy secret to global namespace if needed. See issue #5129.
 	if repo.name.Namespace != s.globalPackagingNamespace && secret != nil {
 		if err = s.copyRepositorySecret(typedClient, secret, repo.name); err != nil {
 			return nil, err
@@ -326,7 +327,7 @@ func (s *Server) updateRepo(ctx context.Context, repo *HelmRepository) (*corev1.
 			return nil, err
 		}
 	}
-	// Copy secret to global namespace if needed
+	// Copy secret to global namespace if needed. See issue #5129.
 	if repo.name.Namespace != s.globalPackagingNamespace && secret != nil {
 		if err = s.copyRepositorySecret(typedClient, secret, repo.name); err != nil {
 			return nil, err

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
@@ -72,6 +72,10 @@ func (s *Server) newRepo(ctx context.Context, repo *HelmRepository) (*corev1.Pac
 			return nil, err
 		}
 	}
+	// Copy secret to global namespace if needed
+	if repo.name.Namespace != s.globalPackagingNamespace && secret != nil {
+		s.copyRepositorySecret(typedClient, secret, repo.name)
+	}
 
 	// Handle imagesPullSecret if any
 	imagePullSecret, _, err := handleImagesPullSecret(ctx, typedClient, s.pluginConfig.UserManagedSecrets, repo, true)
@@ -319,6 +323,10 @@ func (s *Server) updateRepo(ctx context.Context, repo *HelmRepository) (*corev1.
 		if secret, updateRepoSecret, err = s.updateKubeappsManagedRepoSecret(ctx, repo, secretRef); err != nil {
 			return nil, err
 		}
+	}
+	// Copy secret to global namespace if needed
+	if repo.name.Namespace != s.globalPackagingNamespace && secret != nil {
+		s.copyRepositorySecret(typedClient, secret, repo.name)
 	}
 
 	// Handle imagesPullSecret if any

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
@@ -74,7 +74,9 @@ func (s *Server) newRepo(ctx context.Context, repo *HelmRepository) (*corev1.Pac
 	}
 	// Copy secret to global namespace if needed
 	if repo.name.Namespace != s.globalPackagingNamespace && secret != nil {
-		s.copyRepositorySecret(typedClient, secret, repo.name)
+		if err = s.copyRepositorySecret(typedClient, secret, repo.name); err != nil {
+			return nil, err
+		}
 	}
 
 	// Handle imagesPullSecret if any
@@ -326,7 +328,9 @@ func (s *Server) updateRepo(ctx context.Context, repo *HelmRepository) (*corev1.
 	}
 	// Copy secret to global namespace if needed
 	if repo.name.Namespace != s.globalPackagingNamespace && secret != nil {
-		s.copyRepositorySecret(typedClient, secret, repo.name)
+		if err = s.copyRepositorySecret(typedClient, secret, repo.name); err != nil {
+			return nil, err
+		}
 	}
 
 	// Handle imagesPullSecret if any

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	"net/http"
 	"net/http/httptest"
@@ -198,6 +199,7 @@ func TestAddPackageRepository(t *testing.T) {
 		expectedCreatedSecret *apiv1.Secret
 		userManagedSecrets    bool
 		repoClientGetter      newRepoClient
+		expectedGlobalSecret  *apiv1.Secret
 	}{
 		{
 			name:       "returns error if no namespace is provided",
@@ -259,6 +261,7 @@ func TestAddPackageRepository(t *testing.T) {
 			expectedResponse:      addRepoExpectedResp,
 			expectedRepo:          &addRepoWithTLSCA,
 			expectedCreatedSecret: setSecretOwnerRef("bar", newTlsSecret("apprepo-bar", "foo", nil, nil, ca)),
+			expectedGlobalSecret:  newTlsSecret("foo-apprepo-bar", globalPackagingNamespace, nil, nil, ca),
 			statusCode:            codes.OK,
 		},
 		{
@@ -267,19 +270,20 @@ func TestAddPackageRepository(t *testing.T) {
 			statusCode: codes.InvalidArgument,
 		},
 		{
-			name:               "package repository with secret key reference",
-			request:            addRepoReqTLSSecretRef,
-			expectedResponse:   addRepoExpectedResp,
-			expectedRepo:       &addRepoTLSSecret,
-			statusCode:         codes.OK,
-			existingSecret:     newTlsSecret("secret-1", "foo", nil, nil, ca),
-			userManagedSecrets: true,
+			name:                 "package repository with secret key reference",
+			request:              addRepoReqTLSSecretRef,
+			userManagedSecrets:   true,
+			existingSecret:       newTlsSecret("secret-1", "foo", nil, nil, ca),
+			expectedResponse:     addRepoExpectedResp,
+			expectedRepo:         &addRepoTLSSecret,
+			expectedGlobalSecret: newTlsSecret("foo-apprepo-bar", globalPackagingNamespace, nil, nil, ca),
+			statusCode:           codes.OK,
 		},
 		{
 			name:               "fails when package repository links to non-existing secret",
 			request:            addRepoReqTLSSecretRef,
-			statusCode:         codes.NotFound,
 			userManagedSecrets: true,
+			statusCode:         codes.NotFound,
 		},
 		{
 			name:       "fails when package repository links to non-existing secret (kubeapps managed secrets)",
@@ -288,11 +292,36 @@ func TestAddPackageRepository(t *testing.T) {
 		},
 		// BASIC AUTH
 		{
-			name:                  "package repository with basic auth and pass_credentials flag",
+			name:                  "[kubeapps managed secrets] package repository with basic auth and pass_credentials flag",
 			request:               addRepoReqBasicAuth("baz", "zot"),
 			expectedResponse:      addRepoExpectedResp,
-			expectedRepo:          &addRepoAuthHeaderPassCredentials,
+			expectedRepo:          addRepoAuthHeaderPassCredentials("foo"),
 			expectedCreatedSecret: setSecretOwnerRef("bar", newBasicAuthSecret("apprepo-bar", "foo", "baz", "zot")),
+			expectedGlobalSecret:  newBasicAuthSecret("foo-apprepo-bar", globalPackagingNamespace, "baz", "zot"),
+			statusCode:            codes.OK,
+		},
+		{
+			name: "[kubeapps managed secrets] package repository with basic auth and pass_credentials flag in global namespace",
+			request: &corev1.AddPackageRepositoryRequest{
+				Name:            "bar",
+				Context:         &corev1.Context{Namespace: globalPackagingNamespace, Cluster: KubeappsCluster},
+				Type:            "helm",
+				Url:             "http://example.com",
+				NamespaceScoped: false,
+				Auth: &corev1.PackageRepositoryAuth{
+					Type: corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BASIC_AUTH,
+					PackageRepoAuthOneOf: &corev1.PackageRepositoryAuth_UsernamePassword{
+						UsernamePassword: &corev1.UsernamePassword{
+							Username: "the-user",
+							Password: "the-pwd",
+						},
+					},
+					PassCredentials: true,
+				},
+			},
+			expectedResponse:      addRepoExpectedGlobalResp,
+			expectedRepo:          addRepoAuthHeaderPassCredentials(globalPackagingNamespace),
+			expectedCreatedSecret: setSecretOwnerRef("bar", newBasicAuthSecret("apprepo-bar", globalPackagingNamespace, "the-user", "the-pwd")),
 			statusCode:            codes.OK,
 		},
 		{
@@ -307,17 +336,41 @@ func TestAddPackageRepository(t *testing.T) {
 			statusCode:         codes.InvalidArgument,
 		},
 		{
-			name:               "package repository basic auth with existing secret (user managed secrets)",
-			request:            addRepoReqAuthWithSecret(corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BASIC_AUTH, "secret-basic"),
-			expectedResponse:   addRepoExpectedResp,
-			expectedRepo:       addRepoAuthHeaderWithSecretRef("secret-basic"),
-			existingSecret:     newBasicAuthSecret("secret-basic", "foo", "baz-user", "zot-pwd"),
-			statusCode:         codes.OK,
+			name:                 "[user managed secrets] package repository basic auth with existing secret",
+			request:              addRepoReqAuthWithSecret(corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BASIC_AUTH, "foo", "secret-basic"),
+			userManagedSecrets:   true,
+			existingSecret:       newBasicAuthSecret("secret-basic", "foo", "baz-user", "zot-pwd"),
+			expectedResponse:     addRepoExpectedResp,
+			expectedRepo:         addRepoAuthHeaderWithSecretRef("foo", "secret-basic"),
+			expectedGlobalSecret: newBasicAuthSecret("foo-apprepo-bar", globalPackagingNamespace, "baz-user", "zot-pwd"),
+			statusCode:           codes.OK,
+		},
+		{
+			name: "[user managed secrets] add repository to global namespace does not create global secret",
+			request: &corev1.AddPackageRepositoryRequest{
+				Name:            "bar",
+				Context:         &corev1.Context{Namespace: globalPackagingNamespace, Cluster: KubeappsCluster},
+				Type:            "helm",
+				Url:             "http://example.com",
+				NamespaceScoped: false,
+				Auth: &corev1.PackageRepositoryAuth{
+					Type: corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BASIC_AUTH,
+					PackageRepoAuthOneOf: &corev1.PackageRepositoryAuth_SecretRef{
+						SecretRef: &corev1.SecretKeyReference{
+							Name: "secret-basic",
+						},
+					},
+				},
+			},
 			userManagedSecrets: true,
+			existingSecret:     newBasicAuthSecret("secret-basic", globalPackagingNamespace, "baz-user", "zot-pwd"),
+			expectedResponse:   addRepoExpectedGlobalResp,
+			expectedRepo:       addRepoAuthHeaderWithSecretRef(globalPackagingNamespace, "secret-basic"),
+			statusCode:         codes.OK,
 		},
 		{
 			name:       "package repository basic auth with existing secret (kubeapps managed secrets)",
-			request:    addRepoReqAuthWithSecret(corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BASIC_AUTH, "secret-basic"), //addRepoReq13,
+			request:    addRepoReqAuthWithSecret(corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BASIC_AUTH, "foo", "secret-basic"), //addRepoReq13,
 			statusCode: codes.InvalidArgument,
 		},
 		// BEARER TOKEN
@@ -325,17 +378,19 @@ func TestAddPackageRepository(t *testing.T) {
 			name:                  "package repository with bearer token w/o prefix",
 			request:               addRepoReqBearerToken("the-token", false),
 			expectedResponse:      addRepoExpectedResp,
-			expectedRepo:          addRepoAuthHeaderWithSecretRef("apprepo-bar"),
-			statusCode:            codes.OK,
+			expectedRepo:          addRepoAuthHeaderWithSecretRef("foo", "apprepo-bar"),
 			expectedCreatedSecret: setSecretOwnerRef("bar", newAuthTokenSecret("apprepo-bar", "foo", "Bearer the-token")),
+			expectedGlobalSecret:  newAuthTokenSecret("foo-apprepo-bar", globalPackagingNamespace, "Bearer the-token"),
+			statusCode:            codes.OK,
 		},
 		{
 			name:                  "package repository with bearer token w/ prefix",
 			request:               addRepoReqBearerToken("the-token", true),
 			expectedResponse:      addRepoExpectedResp,
-			expectedRepo:          addRepoAuthHeaderWithSecretRef("apprepo-bar"),
-			statusCode:            codes.OK,
+			expectedRepo:          addRepoAuthHeaderWithSecretRef("foo", "apprepo-bar"),
 			expectedCreatedSecret: setSecretOwnerRef("bar", newAuthTokenSecret("apprepo-bar", "foo", "Bearer the-token")),
+			expectedGlobalSecret:  newAuthTokenSecret("foo-apprepo-bar", globalPackagingNamespace, "Bearer the-token"),
+			statusCode:            codes.OK,
 		},
 		{
 			name:       "package repository with no bearer token",
@@ -343,17 +398,18 @@ func TestAddPackageRepository(t *testing.T) {
 			statusCode: codes.InvalidArgument,
 		},
 		{
-			name:               "package repository bearer token with secret (user managed secrets)",
-			request:            addRepoReqAuthWithSecret(corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BEARER, "secret-bearer"),
-			expectedResponse:   addRepoExpectedResp,
-			expectedRepo:       addRepoAuthHeaderWithSecretRef("secret-bearer"),
-			userManagedSecrets: true,
-			existingSecret:     newAuthTokenSecret("secret-bearer", "foo", "Bearer the-token"),
-			statusCode:         codes.OK,
+			name:                 "package repository bearer token with secret (user managed secrets)",
+			request:              addRepoReqAuthWithSecret(corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BEARER, "foo", "secret-bearer"),
+			userManagedSecrets:   true,
+			existingSecret:       newAuthTokenSecret("secret-bearer", "foo", "Bearer the-token"),
+			expectedResponse:     addRepoExpectedResp,
+			expectedRepo:         addRepoAuthHeaderWithSecretRef("foo", "secret-bearer"),
+			expectedGlobalSecret: newAuthTokenSecret("foo-apprepo-bar", globalPackagingNamespace, "Bearer the-token"),
+			statusCode:           codes.OK,
 		},
 		{
 			name:       "package repository bearer token with secret (kubeapps managed secrets)",
-			request:    addRepoReqAuthWithSecret(corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BEARER, "secret-bearer"),
+			request:    addRepoReqAuthWithSecret(corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BEARER, "foo", "secret-bearer"),
 			statusCode: codes.InvalidArgument,
 		},
 		{
@@ -367,18 +423,43 @@ func TestAddPackageRepository(t *testing.T) {
 			name:                  "package repository with custom auth",
 			request:               addRepoReqCustomAuth,
 			expectedResponse:      addRepoExpectedResp,
-			expectedRepo:          addRepoAuthHeaderWithSecretRef("apprepo-bar"),
-			statusCode:            codes.OK,
+			expectedRepo:          addRepoAuthHeaderWithSecretRef("foo", "apprepo-bar"),
 			expectedCreatedSecret: setSecretOwnerRef("bar", newAuthTokenSecret("apprepo-bar", "foo", "foobarzot")),
+			expectedGlobalSecret:  newAuthTokenSecret("foo-apprepo-bar", globalPackagingNamespace, "foobarzot"),
+			statusCode:            codes.OK,
 		},
 		{
-			name:               "package repository custom auth with existing secret (user managed secrets)",
-			request:            addRepoReqAuthWithSecret(corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_AUTHORIZATION_HEADER, "secret-custom"),
-			expectedResponse:   addRepoExpectedResp,
-			expectedRepo:       addRepoAuthHeaderWithSecretRef("secret-custom"),
-			existingSecret:     newBasicAuthSecret("secret-custom", "foo", "baz", "zot"),
-			statusCode:         codes.OK,
+			name:                 "package repository custom auth with existing secret (user managed secrets)",
+			request:              addRepoReqAuthWithSecret(corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_AUTHORIZATION_HEADER, "foo", "secret-custom"),
+			userManagedSecrets:   true,
+			existingSecret:       newBasicAuthSecret("secret-custom", "foo", "baz", "zot"),
+			expectedResponse:     addRepoExpectedResp,
+			expectedRepo:         addRepoAuthHeaderWithSecretRef("foo", "secret-custom"),
+			expectedGlobalSecret: newBasicAuthSecret("foo-apprepo-bar", globalPackagingNamespace, "baz", "zot"),
+			statusCode:           codes.OK,
+		},
+		{
+			name: "global package repository custom auth with existing secret does not generate copied global secret (user managed secrets)",
+			request: &corev1.AddPackageRepositoryRequest{
+				Name:            "bar",
+				Context:         &corev1.Context{Namespace: globalPackagingNamespace, Cluster: KubeappsCluster},
+				Type:            "helm",
+				Url:             "http://example.com",
+				NamespaceScoped: false,
+				Auth: &corev1.PackageRepositoryAuth{
+					Type: corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_AUTHORIZATION_HEADER,
+					PackageRepoAuthOneOf: &corev1.PackageRepositoryAuth_SecretRef{
+						SecretRef: &corev1.SecretKeyReference{
+							Name: "secret-custom",
+						},
+					},
+				},
+			},
 			userManagedSecrets: true,
+			existingSecret:     newBasicAuthSecret("secret-custom", globalPackagingNamespace, "baz", "zot"),
+			expectedResponse:   addRepoExpectedGlobalResp,
+			expectedRepo:       addRepoAuthHeaderWithSecretRef(globalPackagingNamespace, "secret-custom"),
+			statusCode:         codes.OK,
 		},
 		// DOCKER AUTH
 		{
@@ -394,17 +475,21 @@ func TestAddPackageRepository(t *testing.T) {
 			expectedCreatedSecret: setSecretOwnerRef("bar",
 				newAuthDockerSecret("apprepo-bar", "foo",
 					dockerAuthJson("https://docker-server", "the-user", "the-password", "foo@bar.com", "dGhlLXVzZXI6dGhlLXBhc3N3b3Jk"))),
+			expectedGlobalSecret: newAuthDockerSecret("foo-apprepo-bar", globalPackagingNamespace,
+				dockerAuthJson("https://docker-server", "the-user", "the-password", "foo@bar.com", "dGhlLXVzZXI6dGhlLXBhc3N3b3Jk")),
 			statusCode: codes.OK,
 		},
 		{
 			name:               "package repository with Docker auth (user managed secrets)",
-			request:            addRepoReqAuthWithSecret(corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_DOCKER_CONFIG_JSON, "secret-docker"),
-			expectedResponse:   addRepoExpectedResp,
+			request:            addRepoReqAuthWithSecret(corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_DOCKER_CONFIG_JSON, "foo", "secret-docker"),
 			userManagedSecrets: true,
 			existingSecret: newAuthDockerSecret("secret-docker", "foo",
 				dockerAuthJson("https://docker-server", "the-user", "the-password", "foo@bar.com", "dGhlLXVzZXI6dGhlLXBhc3N3b3Jk")),
-			expectedRepo: addRepoAuthDocker("secret-docker"),
-			statusCode:   codes.OK,
+			expectedResponse: addRepoExpectedResp,
+			expectedRepo:     addRepoAuthDocker("secret-docker"),
+			expectedGlobalSecret: newAuthDockerSecret("foo-apprepo-bar", globalPackagingNamespace,
+				dockerAuthJson("https://docker-server", "the-user", "the-password", "foo@bar.com", "dGhlLXVzZXI6dGhlLXBhc3N3b3Jk")),
+			statusCode: codes.OK,
 		},
 		// Others
 		{
@@ -427,7 +512,7 @@ func TestAddPackageRepository(t *testing.T) {
 		},
 		{
 			name:               "package repository with reference to malformed secret",
-			request:            addRepoReqAuthWithSecret(corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BASIC_AUTH, "secret-basic"),
+			request:            addRepoReqAuthWithSecret(corev1.PackageRepositoryAuth_PACKAGE_REPOSITORY_AUTH_TYPE_BASIC_AUTH, "foo", "secret-basic"),
 			existingSecret:     newTlsSecret("secret-basic", "foo", nil, nil, nil), // Creates empty secret
 			userManagedSecrets: true,
 			statusCode:         codes.Internal,
@@ -700,7 +785,7 @@ func TestAddPackageRepository(t *testing.T) {
 				if err = ctrlClient.Get(ctx, nsname, &actualRepo); err != nil {
 					t.Fatal(err)
 				} else {
-					checkRepoSecrets(s, t, nsname.Namespace, tc.userManagedSecrets, &actualRepo, tc.expectedRepo, tc.expectedCreatedSecret)
+					checkRepoSecrets(s, t, tc.userManagedSecrets, &actualRepo, tc.expectedRepo, tc.expectedCreatedSecret, tc.expectedGlobalSecret)
 				}
 			}
 		})
@@ -1034,6 +1119,7 @@ func TestUpdatePackageRepository(t *testing.T) {
 		existingSecret         *apiv1.Secret
 		expectedSecret         *apiv1.Secret
 		userManagedSecrets     bool
+		expectedGlobalSecret   *apiv1.Secret
 	}{
 		{
 			name: "invalid package repo ref",
@@ -1095,9 +1181,10 @@ func TestUpdatePackageRepository(t *testing.T) {
 				repository.Spec.URL = "https://new-repo-url"
 				return &repository
 			},
-			expectedRef:        defaultRef,
-			expectedSecret:     setSecretOwnerRef("repo-1", newTlsSecret("apprepo-repo-1", "ns-1", nil, nil, ca)),
-			expectedStatusCode: codes.OK,
+			expectedRef:          defaultRef,
+			expectedSecret:       setSecretOwnerRef("repo-1", newTlsSecret("apprepo-repo-1", "ns-1", nil, nil, ca)),
+			expectedGlobalSecret: newTlsSecret("ns-1-apprepo-repo-1", globalPackagingNamespace, nil, nil, ca),
+			expectedStatusCode:   codes.OK,
 		},
 		{
 			name:           "update removing tsl config",
@@ -1153,9 +1240,10 @@ func TestUpdatePackageRepository(t *testing.T) {
 				repository.Spec.URL = "https://new-repo-url"
 				return &repository
 			},
-			expectedRef:        defaultRef,
-			expectedSecret:     setSecretOwnerRef("repo-1", newAuthTokenSecret("apprepo-repo-1", "ns-1", "Bearer foobarzot")),
-			expectedStatusCode: codes.OK,
+			expectedRef:          defaultRef,
+			expectedSecret:       setSecretOwnerRef("repo-1", newAuthTokenSecret("apprepo-repo-1", "ns-1", "Bearer foobarzot")),
+			expectedGlobalSecret: newAuthTokenSecret("ns-1-apprepo-repo-1", globalPackagingNamespace, "Bearer foobarzot"),
+			expectedStatusCode:   codes.OK,
 		},
 		{
 			name: "update adding auth (user managed secrets)",
@@ -1186,9 +1274,9 @@ func TestUpdatePackageRepository(t *testing.T) {
 				repository.Spec.URL = "https://new-repo-url"
 				return &repository
 			},
-			expectedRef: defaultRef,
-			//expectedSecret:     setSecretOwnerRef("repo-1", newAuthTokenSecret("apprepo-repo-1", "ns-1", "Bearer foobarzot")),
-			expectedStatusCode: codes.OK,
+			expectedRef:          defaultRef,
+			expectedGlobalSecret: newAuthTokenSecret("ns-1-apprepo-repo-1", globalPackagingNamespace, "Bearer foobarzot"),
+			expectedStatusCode:   codes.OK,
 		},
 		{
 			name:           "update removing auth",
@@ -1470,9 +1558,7 @@ func TestUpdatePackageRepository(t *testing.T) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, opts))
 			}
 
-			if tc.expectedSecret != nil {
-				checkRepoSecrets(s, t, tc.expectedRef.Context.Namespace, tc.userManagedSecrets, appRepo, expectedRepository, tc.expectedSecret)
-			}
+			checkRepoSecrets(s, t, tc.userManagedSecrets, appRepo, expectedRepository, tc.expectedSecret, tc.expectedGlobalSecret)
 		})
 	}
 }
@@ -1543,8 +1629,9 @@ func TestDeletePackageRepository(t *testing.T) {
 	}
 }
 
-func checkRepoSecrets(s *Server, t *testing.T, namespace string, userManagedSecrets bool,
-	actualRepo *appRepov1alpha1.AppRepository, expectedRepo *appRepov1alpha1.AppRepository, expectedSecret *apiv1.Secret) {
+func checkRepoSecrets(s *Server, t *testing.T, userManagedSecrets bool,
+	actualRepo *appRepov1alpha1.AppRepository, expectedRepo *appRepov1alpha1.AppRepository,
+	expectedSecret *apiv1.Secret, expectedGlobalSecret *apiv1.Secret) {
 	ctx := context.Background()
 	if userManagedSecrets {
 		if expectedSecret != nil {
@@ -1580,6 +1667,35 @@ func checkRepoSecrets(s *Server, t *testing.T, namespace string, userManagedSecr
 			t.Fatalf("Expected no secret, but found CustomCA: [%v]", actualRepo.Spec.Auth.CustomCA.SecretKeyRef)
 		} else if expectedRepo.Spec.Auth.Header != nil {
 			t.Fatalf("Error: unexpected state")
+		}
+	}
+	checkGlobalSecret(s, t, expectedRepo, expectedGlobalSecret, expectedSecret != nil || expectedRepo.Spec.Auth.Header != nil || expectedRepo.Spec.Auth.CustomCA != nil)
+}
+
+func checkGlobalSecret(s *Server, t *testing.T, expectedRepo *appRepov1alpha1.AppRepository, expectedGlobalSecret *apiv1.Secret, checkNoGlobalSecret bool) {
+	ctx := context.Background()
+	typedClient, err := s.clientGetter.Typed(ctx, s.kubeappsCluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoGlobalSecretName := fmt.Sprintf("%s-apprepo-%s", expectedRepo.Namespace, expectedRepo.Name)
+	if expectedGlobalSecret != nil {
+		// Check for copied secret to global namespace
+		actualGlobalSecret, err := typedClient.CoreV1().Secrets(s.globalPackagingNamespace).Get(ctx, repoGlobalSecretName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := actualGlobalSecret, expectedGlobalSecret; !cmp.Equal(want, got) {
+			t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+		}
+	} else if checkNoGlobalSecret {
+		// Check that global secret does not exist
+		secret, err := typedClient.CoreV1().Secrets(s.globalPackagingNamespace).Get(ctx, repoGlobalSecretName, metav1.GetOptions{})
+		if err != nil && !k8sErrors.IsNotFound(err) {
+			t.Fatal(err)
+		}
+		if secret != nil {
+			t.Errorf("global secret was found")
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

This PR adds the handling of global secrets that affects to namespaced package repositories with secrets related.
Asset-syncer spings up the sync jobs **in the global namespace** and therefore it is requiring every namespace repo's secret to be copied to that location. Otherwise, private repos won't sync. 

This management wasn't implemented yet in the new package repos API logic.

This wasn't, and isn't the best solution (cloning secrets into the global ns) but for now we have followed the same approach as in the old implementation.

### Benefits

Repos controller can find now the secret for namespaced repositories in the global namespace.

### Possible drawbacks

Maybe some edge cases not yet detected where repository controller needs the global secret? Can't think of any now. 

### Applicable issues

- fixes #5129

