### PR TITLE
Fixed E2E tests reporting output

### DIFF
--- a/integration/playwright.config.js
+++ b/integration/playwright.config.js
@@ -27,8 +27,8 @@ const config = {
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  reporter: [["list"], ["html", { open: "never", outputFolder: "reports-html/" }]],
-  outputDir: "reports/",
+  reporter: [["list"], ["html", { open: "never", outputFolder: "reports/html" }]],
+  outputDir: "reports/tests",
 };
 
 module.exports = config;


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

E2E tests output in CI shows a red error message saying

```
Configuration Error: HTML reporter output folder clashes with the tests output folder:

    html reporter folder: /app/reports-html
    test results folder: /app/reports

HTML reporter will clear its output directory prior to being generated, which will lead to the artifact loss.
```

![image](https://user-images.githubusercontent.com/67455978/181568714-cffd633e-cdb4-4cb9-ba47-9b555206ebbb.png)

This might be due to some path pattern usage that Playwright does.
Both paths have been made different with this PR.

### Benefits

E2E CI tests not display the red message about wrong report path anymore.

### Possible drawbacks

N/A

### Applicable issues

N/A


