### PR TITLE
Simplify instructions in getting-started.md

### DIFF
--- a/site/content/docs/latest/howto/syncing-apprepository-webhook.md
+++ b/site/content/docs/latest/howto/syncing-apprepository-webhook.md
@@ -84,7 +84,7 @@ EOF
 The `<TOKEN>` for the ServiceAccount _apprepositories-refresh_ is retrieved:
 
 ```bash
-kubectl get secret $(kubectl get serviceaccount apprepositories-refresh -o jsonpath='{range .secrets[*]}{.name}{"\n"}{end}' | grep apprepositories-refresh) -o jsonpath='{.data.token}' -o go-template='{{.data.token | base64decode}}' && echo
+kubectl get secret $(kubectl get serviceaccount apprepositories-refresh -o jsonpath='{range .secrets[*]}{.name}{"\n"}{end}' | grep apprepositories-refresh) -o go-template='{{.data.token | base64decode}}'
 ```
 
 This value will be the Bearer token to be passed in the `Authentication` HTTP header.

--- a/site/content/docs/latest/tutorials/getting-started.md
+++ b/site/content/docs/latest/tutorials/getting-started.md
@@ -48,7 +48,7 @@ To retrieve the token,
 ### On Linux/macOS
 
 ```bash
-kubectl get --namespace default secret kubeapps-operator-token -o jsonpath='{.data.token}' -o go-template='{{.data.token | base64decode}}' && echo
+kubectl get --namespace default secret kubeapps-operator-token -o go-template='{{.data.token | base64decode}}'
 ```
 
 ### On Windows

--- a/site/content/docs/latest/tutorials/kubeapps-on-tce/02-TCE-unmanaged-cluster.md
+++ b/site/content/docs/latest/tutorials/kubeapps-on-tce/02-TCE-unmanaged-cluster.md
@@ -125,7 +125,7 @@ Keep the obtained token for later steps of the tutorial.
 #### On Linux/macOS
 
 ```bash
-kubectl get --namespace default secret kubeapps-operator-token -o jsonpath='{.data.token}' -o go-template='{{.data.token | base64decode}}' && echo
+kubectl get --namespace default secret kubeapps-operator-token -o go-template='{{.data.token | base64decode}}'
 ```
 
 #### On Windows

--- a/site/themes/template/layouts/partials/use-cases.html
+++ b/site/themes/template/layouts/partials/use-cases.html
@@ -29,7 +29,7 @@
   </div>
   {{ end -}}
 
-</br>
+<br>
 
   <div class="grid two">
     <div class="col image">
@@ -83,7 +83,7 @@
 
       <div class="home-snippet">
         {{ highlight `
-    kubectl get --namespace default secret kubeapps-operator-token -o jsonpath='{.data.token}' -o go-template='{{.data.token | base64decode}}' && echo
+    kubectl get --namespace default secret kubeapps-operator-token -o go-template='{{.data.token | base64decode}}'
         ` "" "" }}
       </div>
     </div>


### PR DESCRIPTION
This commit simplifies some of the instructions to run kubeapps locally.

Signed-off-by: Jesús Miguel Benito Calzada <beni0888@hotmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Removes a redundant/overwritten parameter in a CLI command. 

### Benefits

Makes the instructions clearer.