### PR TITLE
Fix DeploymentForm app name regular expression

### DIFF
--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -217,7 +217,7 @@ export default function DeploymentForm() {
                   <label>Name</label>
                   <input
                     id="releaseName"
-                    pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+                    pattern="[a-z]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
                     title="Use lowercase alphanumeric characters, '-' or '.'"
                     onChange={handleReleaseNameChange}
                     value={releaseName}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change
Fix first word in regular expressions of DeploymentForm release name not to contain number

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
If the release name starts with number, it seems to be created in kubeapps(-we can click the create button-), but the actual creation fails because it does not match the naming convention of Kubernetes. This change can prevent this kind of creation failure.

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
I think there's no drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
I cannot find related issue. (Do I need to register as an issue first?)

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
N/A