### PR TITLE
Add filtering by repos in carvel pkgs

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
@@ -54,82 +54,86 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 	// Filter the package metadatas using any specified filter.
 	pkgMetadatas = FilterMetadatas(pkgMetadatas, request.GetFilterOptions())
 
-	// Update the slice to be the correct page of results.
-	startAt := 0
-	if pageSize > 0 {
-		startAt = itemOffset
-		if startAt > len(pkgMetadatas) {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid pagination arguments %v", request.GetPaginationOptions())
-		}
-		pkgMetadatas = pkgMetadatas[startAt:]
-		if len(pkgMetadatas) > int(pageSize) {
-			pkgMetadatas = pkgMetadatas[:pageSize]
-		}
-	}
-
-	// Create a channel to receive all packages available in the namespace.
-	// Using a buffered channel so that we don't block the network request if we
-	// can't process fast enough.
-	getPkgsChannel := make(chan *datapackagingv1alpha1.Package, PACKAGES_CHANNEL_BUFFER_SIZE)
-	var getPkgsError error
-	go func() {
-		getPkgsError = s.getPkgs(ctx, cluster, namespace, getPkgsChannel)
-	}()
-
-	// Skip through the packages until we get to the first item in our
-	// paginated results.
-	currentPkg := <-getPkgsChannel
-	for currentPkg != nil && len(pkgMetadatas) > 0 && currentPkg.Spec.RefName != pkgMetadatas[0].Name {
-		currentPkg = <-getPkgsChannel
-	}
-
-	availablePackageSummaries := make([]*corev1.AvailablePackageSummary, len(pkgMetadatas))
+	availablePackageSummaries := []*corev1.AvailablePackageSummary{}
 	categories := []string{}
-	pkgsForMeta := []*datapackagingv1alpha1.Package{}
-	for i, pkgMetadata := range pkgMetadatas {
-		// currentPkg will be nil if the channel is closed and there's no
-		// more items to consume.
-		if currentPkg == nil {
-			return nil, statuserror.FromK8sError("get", "Package", pkgMetadata.Name, fmt.Errorf("no package versions for the package %q", pkgMetadata.Name))
-		}
-		// The kapp-controller returns both packages and package metadata
-		// in order. But some repositories have invalid data (TAP 1.0.2)
-		// where a package is present *without* corresponding metadata.
-		for currentPkg.Spec.RefName != pkgMetadata.Name {
-			if currentPkg.Spec.RefName > pkgMetadata.Name {
-				return nil, status.Errorf(codes.Internal, fmt.Sprintf("unexpected order for kapp-controller packages, expected %q, found %q", pkgMetadata.Name, currentPkg.Spec.RefName))
+
+	if len(pkgMetadatas) > 0 {
+		// Update the slice to be the correct page of results.
+		startAt := 0
+		if pageSize > 0 {
+			startAt = itemOffset
+			if startAt > len(pkgMetadatas) {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid pagination arguments %v", request.GetPaginationOptions(), "startAt", startAt, "total", len(pkgMetadatas))
 			}
-			log.Errorf("Package %q did not have a corresponding metadata (want %q)", currentPkg.Spec.RefName, pkgMetadata.Name)
+			pkgMetadatas = pkgMetadatas[startAt:]
+			if len(pkgMetadatas) > int(pageSize) {
+				pkgMetadatas = pkgMetadatas[:pageSize]
+			}
+		}
+
+		// Create a channel to receive all packages available in the namespace.
+		// Using a buffered channel so that we don't block the network request if we
+		// can't process fast enough.
+		getPkgsChannel := make(chan *datapackagingv1alpha1.Package, PACKAGES_CHANNEL_BUFFER_SIZE)
+		var getPkgsError error
+		go func() {
+			getPkgsError = s.getPkgs(ctx, cluster, namespace, getPkgsChannel)
+		}()
+
+		// Skip through the packages until we get to the first item in our
+		// paginated results.
+		currentPkg := <-getPkgsChannel
+		for currentPkg != nil && len(pkgMetadatas) > 0 && currentPkg.Spec.RefName != pkgMetadatas[0].Name {
 			currentPkg = <-getPkgsChannel
 		}
-		// Collect the packages for a particular refName to be able to send the
-		// latest semver version. For the moment, kapp-controller just returns
-		// CRs with the default alpha sorting of the CR name.
-		// Ref https://kubernetes.slack.com/archives/CH8KCCKA5/p1646285201181119
-		pkgsForMeta = append(pkgsForMeta, currentPkg)
-		currentPkg = <-getPkgsChannel
-		for currentPkg != nil && currentPkg.Spec.RefName == pkgMetadata.Name {
+
+		availablePackageSummaries = make([]*corev1.AvailablePackageSummary, len(pkgMetadatas))
+		pkgsForMeta := []*datapackagingv1alpha1.Package{}
+		for i, pkgMetadata := range pkgMetadatas {
+			// currentPkg will be nil if the channel is closed and there's no
+			// more items to consume.
+			if currentPkg == nil {
+				return nil, statuserror.FromK8sError("get", "Package", pkgMetadata.Name, fmt.Errorf("no package versions for the package %q", pkgMetadata.Name))
+			}
+			// The kapp-controller returns both packages and package metadata
+			// in order. But some repositories have invalid data (TAP 1.0.2)
+			// where a package is present *without* corresponding metadata.
+			for currentPkg.Spec.RefName != pkgMetadata.Name {
+				if currentPkg.Spec.RefName > pkgMetadata.Name {
+					return nil, status.Errorf(codes.Internal, fmt.Sprintf("unexpected order for kapp-controller packages, expected %q, found %q", pkgMetadata.Name, currentPkg.Spec.RefName))
+				}
+				log.Errorf("Package %q did not have a corresponding metadata (want %q)", currentPkg.Spec.RefName, pkgMetadata.Name)
+				currentPkg = <-getPkgsChannel
+			}
+			// Collect the packages for a particular refName to be able to send the
+			// latest semver version. For the moment, kapp-controller just returns
+			// CRs with the default alpha sorting of the CR name.
+			// Ref https://kubernetes.slack.com/archives/CH8KCCKA5/p1646285201181119
 			pkgsForMeta = append(pkgsForMeta, currentPkg)
 			currentPkg = <-getPkgsChannel
-		}
-		// At this point, we have all the packages collected that match
-		// this ref name, and currentPkg is for the next meta name.
-		pkgVersionMap, err := getPkgVersionsMap(pkgsForMeta)
-		if err != nil || len(pkgVersionMap[pkgMetadata.Name]) == 0 {
-			return nil, status.Errorf(codes.Internal, fmt.Sprintf("unable to calculate package versions map for packages: %v, err: %v", pkgsForMeta, err))
-		}
-		latestVersion := pkgVersionMap[pkgMetadata.Name][0].version.String()
-		availablePackageSummary := s.buildAvailablePackageSummary(pkgMetadata, latestVersion, cluster)
-		availablePackageSummaries[i] = availablePackageSummary
-		categories = append(categories, availablePackageSummary.Categories...)
+			for currentPkg != nil && currentPkg.Spec.RefName == pkgMetadata.Name {
+				pkgsForMeta = append(pkgsForMeta, currentPkg)
+				currentPkg = <-getPkgsChannel
+			}
+			// At this point, we have all the packages collected that match
+			// this ref name, and currentPkg is for the next meta name.
+			pkgVersionMap, err := getPkgVersionsMap(pkgsForMeta)
+			if err != nil || len(pkgVersionMap[pkgMetadata.Name]) == 0 {
+				return nil, status.Errorf(codes.Internal, fmt.Sprintf("unable to calculate package versions map for packages: %v, err: %v", pkgsForMeta, err))
+			}
+			latestVersion := pkgVersionMap[pkgMetadata.Name][0].version.String()
+			availablePackageSummary := s.buildAvailablePackageSummary(pkgMetadata, latestVersion, cluster)
+			availablePackageSummaries[i] = availablePackageSummary
+			categories = append(categories, availablePackageSummary.Categories...)
 
-		// Reset the packages for the current meta name.
-		pkgsForMeta = pkgsForMeta[:0]
-	}
+			// Reset the packages for the current meta name.
+			pkgsForMeta = pkgsForMeta[:0]
+		}
 
-	// Verify no error during go routine.
-	if getPkgsError != nil {
-		return nil, statuserror.FromK8sError("get", "Package", "", err)
+		// Verify no error during go routine.
+		if getPkgsError != nil {
+			return nil, statuserror.FromK8sError("get", "Package", "", err)
+		}
 	}
 
 	// Only return a next page token if the request was for pagination and

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
@@ -63,7 +63,7 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 		if pageSize > 0 {
 			startAt = itemOffset
 			if startAt > len(pkgMetadatas) {
-				return nil, status.Errorf(codes.InvalidArgument, "invalid pagination arguments %v", request.GetPaginationOptions(), "startAt", startAt, "total", len(pkgMetadatas))
+				return nil, status.Errorf(codes.InvalidArgument, "invalid pagination arguments %v", request.GetPaginationOptions())
 			}
 			pkgMetadatas = pkgMetadatas[startAt:]
 			if len(pkgMetadatas) > int(pageSize) {

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
@@ -143,18 +143,22 @@ func buildReadme(pkgMetadata *datapackagingv1alpha1.PackageMetadata, foundPkgSem
 func buildPackageIdentifier(pkgMetadata *datapackagingv1alpha1.PackageMetadata) string {
 	// default repo name if using kapp controller < v0.36.1
 	repoName := DEFAULT_REPO_NAME
-
 	// See https://github.com/vmware-tanzu/carvel-kapp-controller/pull/532
 	if repoRefAnnotation := pkgMetadata.Annotations[REPO_REF_ANNOTATION]; repoRefAnnotation != "" {
-		// this annotation returns "namespace/reponame", for instance "default/tce-repo",
-		// but we just want the "reponame" part
-		splitRepoRefAnnotation := strings.Split(repoRefAnnotation, "/")
-		// just change the repo name if we have a valid annotation
-		if len(splitRepoRefAnnotation) == 2 {
-			repoName = strings.Split(repoRefAnnotation, "/")[1]
-		}
+		repoName = getRepoNameFromAnnotation(repoRefAnnotation)
 	}
 	return fmt.Sprintf("%s/%s", repoName, pkgMetadata.Name)
+}
+
+func getRepoNameFromAnnotation(repoRefAnnotation string) string {
+	// this annotation returns "namespace/reponame", for instance "default/tce-repo",
+	// but we just want the "reponame" part
+	splitRepoRefAnnotation := strings.Split(repoRefAnnotation, "/")
+	// just change the repo name if we have a valid annotation
+	if len(splitRepoRefAnnotation) == 2 {
+		return strings.Split(repoRefAnnotation, "/")[1]
+	}
+	return ""
 }
 
 // buildPostInstallationNotes generates the installation notes based on the application status

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
@@ -141,24 +141,24 @@ func buildReadme(pkgMetadata *datapackagingv1alpha1.PackageMetadata, foundPkgSem
 
 // buildPackageIdentifier generates the package identifier (repoName/pkgName) for a given package
 func buildPackageIdentifier(pkgMetadata *datapackagingv1alpha1.PackageMetadata) string {
-	// default repo name if using kapp controller < v0.36.1
-	repoName := DEFAULT_REPO_NAME
-	// See https://github.com/vmware-tanzu/carvel-kapp-controller/pull/532
-	if repoRefAnnotation := pkgMetadata.Annotations[REPO_REF_ANNOTATION]; repoRefAnnotation != "" {
-		repoName = getRepoNameFromAnnotation(repoRefAnnotation)
-	}
+	repoName := getRepoNameFromAnnotation(pkgMetadata.Annotations[REPO_REF_ANNOTATION])
 	return fmt.Sprintf("%s/%s", repoName, pkgMetadata.Name)
 }
 
+// getRepoNameFromAnnotation gets the repo name from a string with the format "namespace/repoName",
+// for instance "default/tce-repo", and retuns just the "repoName" part, e.g., "tce-repo"
 func getRepoNameFromAnnotation(repoRefAnnotation string) string {
-	// this annotation returns "namespace/reponame", for instance "default/tce-repo",
-	// but we just want the "reponame" part
-	splitRepoRefAnnotation := strings.Split(repoRefAnnotation, "/")
-	// just change the repo name if we have a valid annotation
-	if len(splitRepoRefAnnotation) == 2 {
-		return strings.Split(repoRefAnnotation, "/")[1]
+	// falling back to a "default" repo name if using kapp controller < v0.36.1
+	// See https://github.com/vmware-tanzu/carvel-kapp-controller/pull/532
+	repoName := DEFAULT_REPO_NAME
+	if repoRefAnnotation != "" {
+		splitRepoRefAnnotation := strings.Split(repoRefAnnotation, "/")
+		// just change the repo name if we have a valid annotation
+		if len(splitRepoRefAnnotation) == 2 {
+			repoName = strings.Split(repoRefAnnotation, "/")[1]
+		}
 	}
-	return ""
+	return repoName
 }
 
 // buildPostInstallationNotes generates the installation notes based on the application status
@@ -282,30 +282,24 @@ func (f *ConfigurableConfigFactoryImpl) RESTConfig() (*rest.Config, error) {
 // FilterMetadatas returns a slice where the content has been filtered
 // according to the provided filter options.
 func FilterMetadatas(metadatas []*datapackagingv1alpha1.PackageMetadata, filterOptions *corev1.FilterOptions) []*datapackagingv1alpha1.PackageMetadata {
-	if filterOptions == nil {
-		return metadatas
-	}
+	filteredMetadatas := metadatas
+	if filterOptions != nil {
+		filteredMetadatas = []*datapackagingv1alpha1.PackageMetadata{}
 
-	skipQueryFilter := filterOptions.Query == ""
-	skipCategoriesFilter := len(filterOptions.Categories) == 0
-	skipRepositoriesFilter := len(filterOptions.Repositories) == 0
+		skipQueryFilter := filterOptions.Query == ""
+		skipCategoriesFilter := len(filterOptions.Categories) == 0
+		skipRepositoriesFilter := len(filterOptions.Repositories) == 0
 
-	if filterOptions != nil && skipQueryFilter && skipCategoriesFilter && len(filterOptions.Repositories) == 0 {
-		return metadatas
-	}
-
-	filteredMeta := []*datapackagingv1alpha1.PackageMetadata{}
-	for _, metadata := range metadatas {
-		if filterOptions != nil {
-			matchesQuery := skipQueryFilter || (!skipQueryFilter && testMetadataMatchesQuery(metadata, filterOptions.Query))
-			matchesCategories := skipCategoriesFilter || (!skipCategoriesFilter && testMetadataMatchesCategories(metadata, filterOptions.Categories))
-			matchesRepos := skipRepositoriesFilter || (!skipRepositoriesFilter && testMetadataMatchesRepos(metadata, filterOptions.Repositories))
-			if matchesRepos && (matchesQuery || matchesCategories) {
-				filteredMeta = append(filteredMeta, metadata)
+		for _, metadata := range metadatas {
+			matchesQuery := skipQueryFilter || testMetadataMatchesQuery(metadata, filterOptions.Query)
+			matchesCategories := skipCategoriesFilter || testMetadataMatchesCategories(metadata, filterOptions.Categories)
+			matchesRepos := skipRepositoriesFilter || testMetadataMatchesRepos(metadata, filterOptions.Repositories)
+			if matchesRepos && matchesQuery && matchesCategories {
+				filteredMetadatas = append(filteredMetadatas, metadata)
 			}
 		}
 	}
-	return filteredMeta
+	return filteredMetadatas
 }
 
 func testMetadataMatchesQuery(metadata *datapackagingv1alpha1.PackageMetadata, query string) bool {
@@ -330,8 +324,10 @@ func testMetadataMatchesCategories(metadata *datapackagingv1alpha1.PackageMetada
 	return intersection
 }
 
+// testMetadataMatchesRepos returns true if the metadata matches the provided repositories.
 func testMetadataMatchesRepos(metadata *datapackagingv1alpha1.PackageMetadata, repositories []string) bool {
 	metadataRepoName := getRepoNameFromAnnotation(metadata.Annotations[REPO_REF_ANNOTATION])
+	// if the package is from one of the given repositories, it matches
 	for _, repo := range repositories {
 		if metadataRepoName == repo {
 			return true


### PR DESCRIPTION
### Description of the change

As stated in https://github.com/vmware-tanzu/kubeapps/issues/5165, we were not filtering by repos in the carvel plugin. This PR is merely to implement it and handle the scenario of an empty result.

### Benefits

The filter by repo will actually work.

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #5168
- related #5165

### Additional information

~Tests are still pending, but I want to make sure it solves the issue with the e2e tests first.~
No, it does not... 