### PR TITLE
 Add filtering by repos in carvel pkgs

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
@@ -54,82 +54,86 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 	// Filter the package metadatas using any specified filter.
 	pkgMetadatas = FilterMetadatas(pkgMetadatas, request.GetFilterOptions())
 
-	// Update the slice to be the correct page of results.
-	startAt := 0
-	if pageSize > 0 {
-		startAt = itemOffset
-		if startAt > len(pkgMetadatas) {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid pagination arguments %v", request.GetPaginationOptions())
-		}
-		pkgMetadatas = pkgMetadatas[startAt:]
-		if len(pkgMetadatas) > int(pageSize) {
-			pkgMetadatas = pkgMetadatas[:pageSize]
-		}
-	}
-
-	// Create a channel to receive all packages available in the namespace.
-	// Using a buffered channel so that we don't block the network request if we
-	// can't process fast enough.
-	getPkgsChannel := make(chan *datapackagingv1alpha1.Package, PACKAGES_CHANNEL_BUFFER_SIZE)
-	var getPkgsError error
-	go func() {
-		getPkgsError = s.getPkgs(ctx, cluster, namespace, getPkgsChannel)
-	}()
-
-	// Skip through the packages until we get to the first item in our
-	// paginated results.
-	currentPkg := <-getPkgsChannel
-	for currentPkg != nil && len(pkgMetadatas) > 0 && currentPkg.Spec.RefName != pkgMetadatas[0].Name {
-		currentPkg = <-getPkgsChannel
-	}
-
-	availablePackageSummaries := make([]*corev1.AvailablePackageSummary, len(pkgMetadatas))
+	availablePackageSummaries := []*corev1.AvailablePackageSummary{}
 	categories := []string{}
-	pkgsForMeta := []*datapackagingv1alpha1.Package{}
-	for i, pkgMetadata := range pkgMetadatas {
-		// currentPkg will be nil if the channel is closed and there's no
-		// more items to consume.
-		if currentPkg == nil {
-			return nil, statuserror.FromK8sError("get", "Package", pkgMetadata.Name, fmt.Errorf("no package versions for the package %q", pkgMetadata.Name))
-		}
-		// The kapp-controller returns both packages and package metadata
-		// in order. But some repositories have invalid data (TAP 1.0.2)
-		// where a package is present *without* corresponding metadata.
-		for currentPkg.Spec.RefName != pkgMetadata.Name {
-			if currentPkg.Spec.RefName > pkgMetadata.Name {
-				return nil, status.Errorf(codes.Internal, fmt.Sprintf("unexpected order for kapp-controller packages, expected %q, found %q", pkgMetadata.Name, currentPkg.Spec.RefName))
+
+	if len(pkgMetadatas) > 0 {
+		// Update the slice to be the correct page of results.
+		startAt := 0
+		if pageSize > 0 {
+			startAt = itemOffset
+			if startAt > len(pkgMetadatas) {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid pagination arguments %v", request.GetPaginationOptions())
 			}
-			log.Errorf("Package %q did not have a corresponding metadata (want %q)", currentPkg.Spec.RefName, pkgMetadata.Name)
+			pkgMetadatas = pkgMetadatas[startAt:]
+			if len(pkgMetadatas) > int(pageSize) {
+				pkgMetadatas = pkgMetadatas[:pageSize]
+			}
+		}
+
+		// Create a channel to receive all packages available in the namespace.
+		// Using a buffered channel so that we don't block the network request if we
+		// can't process fast enough.
+		getPkgsChannel := make(chan *datapackagingv1alpha1.Package, PACKAGES_CHANNEL_BUFFER_SIZE)
+		var getPkgsError error
+		go func() {
+			getPkgsError = s.getPkgs(ctx, cluster, namespace, getPkgsChannel)
+		}()
+
+		// Skip through the packages until we get to the first item in our
+		// paginated results.
+		currentPkg := <-getPkgsChannel
+		for currentPkg != nil && len(pkgMetadatas) > 0 && currentPkg.Spec.RefName != pkgMetadatas[0].Name {
 			currentPkg = <-getPkgsChannel
 		}
-		// Collect the packages for a particular refName to be able to send the
-		// latest semver version. For the moment, kapp-controller just returns
-		// CRs with the default alpha sorting of the CR name.
-		// Ref https://kubernetes.slack.com/archives/CH8KCCKA5/p1646285201181119
-		pkgsForMeta = append(pkgsForMeta, currentPkg)
-		currentPkg = <-getPkgsChannel
-		for currentPkg != nil && currentPkg.Spec.RefName == pkgMetadata.Name {
+
+		availablePackageSummaries = make([]*corev1.AvailablePackageSummary, len(pkgMetadatas))
+		pkgsForMeta := []*datapackagingv1alpha1.Package{}
+		for i, pkgMetadata := range pkgMetadatas {
+			// currentPkg will be nil if the channel is closed and there's no
+			// more items to consume.
+			if currentPkg == nil {
+				return nil, statuserror.FromK8sError("get", "Package", pkgMetadata.Name, fmt.Errorf("no package versions for the package %q", pkgMetadata.Name))
+			}
+			// The kapp-controller returns both packages and package metadata
+			// in order. But some repositories have invalid data (TAP 1.0.2)
+			// where a package is present *without* corresponding metadata.
+			for currentPkg.Spec.RefName != pkgMetadata.Name {
+				if currentPkg.Spec.RefName > pkgMetadata.Name {
+					return nil, status.Errorf(codes.Internal, fmt.Sprintf("unexpected order for kapp-controller packages, expected %q, found %q", pkgMetadata.Name, currentPkg.Spec.RefName))
+				}
+				log.Errorf("Package %q did not have a corresponding metadata (want %q)", currentPkg.Spec.RefName, pkgMetadata.Name)
+				currentPkg = <-getPkgsChannel
+			}
+			// Collect the packages for a particular refName to be able to send the
+			// latest semver version. For the moment, kapp-controller just returns
+			// CRs with the default alpha sorting of the CR name.
+			// Ref https://kubernetes.slack.com/archives/CH8KCCKA5/p1646285201181119
 			pkgsForMeta = append(pkgsForMeta, currentPkg)
 			currentPkg = <-getPkgsChannel
-		}
-		// At this point, we have all the packages collected that match
-		// this ref name, and currentPkg is for the next meta name.
-		pkgVersionMap, err := getPkgVersionsMap(pkgsForMeta)
-		if err != nil || len(pkgVersionMap[pkgMetadata.Name]) == 0 {
-			return nil, status.Errorf(codes.Internal, fmt.Sprintf("unable to calculate package versions map for packages: %v, err: %v", pkgsForMeta, err))
-		}
-		latestVersion := pkgVersionMap[pkgMetadata.Name][0].version.String()
-		availablePackageSummary := s.buildAvailablePackageSummary(pkgMetadata, latestVersion, cluster)
-		availablePackageSummaries[i] = availablePackageSummary
-		categories = append(categories, availablePackageSummary.Categories...)
+			for currentPkg != nil && currentPkg.Spec.RefName == pkgMetadata.Name {
+				pkgsForMeta = append(pkgsForMeta, currentPkg)
+				currentPkg = <-getPkgsChannel
+			}
+			// At this point, we have all the packages collected that match
+			// this ref name, and currentPkg is for the next meta name.
+			pkgVersionMap, err := getPkgVersionsMap(pkgsForMeta)
+			if err != nil || len(pkgVersionMap[pkgMetadata.Name]) == 0 {
+				return nil, status.Errorf(codes.Internal, fmt.Sprintf("unable to calculate package versions map for packages: %v, err: %v", pkgsForMeta, err))
+			}
+			latestVersion := pkgVersionMap[pkgMetadata.Name][0].version.String()
+			availablePackageSummary := s.buildAvailablePackageSummary(pkgMetadata, latestVersion, cluster)
+			availablePackageSummaries[i] = availablePackageSummary
+			categories = append(categories, availablePackageSummary.Categories...)
 
-		// Reset the packages for the current meta name.
-		pkgsForMeta = pkgsForMeta[:0]
-	}
+			// Reset the packages for the current meta name.
+			pkgsForMeta = pkgsForMeta[:0]
+		}
 
-	// Verify no error during go routine.
-	if getPkgsError != nil {
-		return nil, statuserror.FromK8sError("get", "Package", "", err)
+		// Verify no error during go routine.
+		if getPkgsError != nil {
+			return nil, statuserror.FromK8sError("get", "Package", "", err)
+		}
 	}
 
 	// Only return a next page token if the request was for pagination and

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
@@ -1076,6 +1076,93 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "it returns empty carvel package summaries if not matching the filters",
+			filterOptions: corev1.FilterOptions{
+				Query:        "foo",
+				Repositories: []string{"foo"},
+				Categories:   []string{"foo"},
+			},
+			existingObjects: []k8sruntime.Object{
+				&datapackagingv1alpha1.PackageMetadata{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       pkgMetadataResource,
+						APIVersion: datapackagingAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tetris.foo.example.com",
+					},
+					Spec: datapackagingv1alpha1.PackageMetadataSpec{
+						DisplayName:        "Classic Tetris",
+						IconSVGBase64:      "Tm90IHJlYWxseSBTVkcK",
+						ShortDescription:   "A great game for arcade gamers",
+						LongDescription:    "A few sentences but not really a readme",
+						Categories:         []string{"logging", "daemon-set"},
+						Maintainers:        []datapackagingv1alpha1.Maintainer{{Name: "person1"}, {Name: "person2"}},
+						SupportDescription: "Some support information",
+						ProviderName:       "Tetris inc.",
+					},
+				},
+				&datapackagingv1alpha1.PackageMetadata{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       pkgMetadataResource,
+						APIVersion: datapackagingAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tombi.foo.example.com",
+					},
+					Spec: datapackagingv1alpha1.PackageMetadataSpec{
+						DisplayName:        "Tombi!",
+						IconSVGBase64:      "Tm90IHJlYWxseSBTVkcK",
+						ShortDescription:   "An awesome game from the 90's",
+						LongDescription:    "Tombi! is an open world platform-adventure game with RPG elements.",
+						Categories:         []string{"platforms", "rpg"},
+						Maintainers:        []datapackagingv1alpha1.Maintainer{{Name: "person1"}, {Name: "person2"}},
+						SupportDescription: "Some support information",
+						ProviderName:       "Tombi!",
+					},
+				},
+				&datapackagingv1alpha1.Package{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       pkgResource,
+						APIVersion: datapackagingAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tetris.foo.example.com.1.2.3",
+					},
+					Spec: datapackagingv1alpha1.PackageSpec{
+						RefName:                         "tetris.foo.example.com",
+						Version:                         "1.2.3",
+						Licenses:                        []string{"my-license"},
+						ReleaseNotes:                    "release notes",
+						CapactiyRequirementsDescription: "capacity description",
+						ReleasedAt:                      metav1.Time{Time: time.Date(1984, time.June, 6, 0, 0, 0, 0, time.UTC)},
+					},
+				},
+				&datapackagingv1alpha1.Package{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       pkgResource,
+						APIVersion: datapackagingAPIVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tombi.foo.example.com.1.2.5",
+					},
+					Spec: datapackagingv1alpha1.PackageSpec{
+						RefName:                         "tombi.foo.example.com",
+						Version:                         "1.2.5",
+						Licenses:                        []string{"my-license"},
+						ReleaseNotes:                    "release notes",
+						CapactiyRequirementsDescription: "capacity description",
+						ReleasedAt:                      metav1.Time{Time: time.Date(1997, time.December, 25, 0, 0, 0, 0, time.UTC)},
+					},
+				},
+			},
+			expectedPackages: []*corev1.AvailablePackageSummary{},
+		},
 	}
 
 	//nolint:govet

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
@@ -141,20 +141,24 @@ func buildReadme(pkgMetadata *datapackagingv1alpha1.PackageMetadata, foundPkgSem
 
 // buildPackageIdentifier generates the package identifier (repoName/pkgName) for a given package
 func buildPackageIdentifier(pkgMetadata *datapackagingv1alpha1.PackageMetadata) string {
-	// default repo name if using kapp controller < v0.36.1
-	repoName := DEFAULT_REPO_NAME
+	repoName := getRepoNameFromAnnotation(pkgMetadata.Annotations[REPO_REF_ANNOTATION])
+	return fmt.Sprintf("%s/%s", repoName, pkgMetadata.Name)
+}
 
+// getRepoNameFromAnnotation gets the repo name from a string with the format "namespace/repoName",
+// for instance "default/tce-repo", and retuns just the "repoName" part, e.g., "tce-repo"
+func getRepoNameFromAnnotation(repoRefAnnotation string) string {
+	// falling back to a "default" repo name if using kapp controller < v0.36.1
 	// See https://github.com/vmware-tanzu/carvel-kapp-controller/pull/532
-	if repoRefAnnotation := pkgMetadata.Annotations[REPO_REF_ANNOTATION]; repoRefAnnotation != "" {
-		// this annotation returns "namespace/reponame", for instance "default/tce-repo",
-		// but we just want the "reponame" part
+	repoName := DEFAULT_REPO_NAME
+	if repoRefAnnotation != "" {
 		splitRepoRefAnnotation := strings.Split(repoRefAnnotation, "/")
 		// just change the repo name if we have a valid annotation
 		if len(splitRepoRefAnnotation) == 2 {
 			repoName = strings.Split(repoRefAnnotation, "/")[1]
 		}
 	}
-	return fmt.Sprintf("%s/%s", repoName, pkgMetadata.Name)
+	return repoName
 }
 
 // buildPostInstallationNotes generates the installation notes based on the application status

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
@@ -282,25 +282,24 @@ func (f *ConfigurableConfigFactoryImpl) RESTConfig() (*rest.Config, error) {
 // FilterMetadatas returns a slice where the content has been filtered
 // according to the provided filter options.
 func FilterMetadatas(metadatas []*datapackagingv1alpha1.PackageMetadata, filterOptions *corev1.FilterOptions) []*datapackagingv1alpha1.PackageMetadata {
-	// Currently we support filtering by query or category but not by repository
-	// (UX doesn't yet display carvel repo in filter options).
-	// Once the UX does, we should be able to filter by repository
-	// also as its now an annotation:
-	// https://github.com/vmware-tanzu/carvel-kapp-controller/pull/532
-	if filterOptions != nil && filterOptions.Query == "" && len(filterOptions.Categories) == 0 {
-		return metadatas
-	}
-	filteredMeta := []*datapackagingv1alpha1.PackageMetadata{}
-	for _, metadata := range metadatas {
-		if filterOptions != nil {
-			matchesQuery := filterOptions.Query != "" && testMetadataMatchesQuery(metadata, filterOptions.Query)
-			matchesCategories := len(filterOptions.Categories) > 0 && testMetadataMatchesCategories(metadata, filterOptions.Categories)
-			if matchesQuery || matchesCategories {
-				filteredMeta = append(filteredMeta, metadata)
+	filteredMetadatas := metadatas
+	if filterOptions != nil {
+		filteredMetadatas = []*datapackagingv1alpha1.PackageMetadata{}
+
+		skipQueryFilter := filterOptions.Query == ""
+		skipCategoriesFilter := len(filterOptions.Categories) == 0
+		skipRepositoriesFilter := len(filterOptions.Repositories) == 0
+
+		for _, metadata := range metadatas {
+			matchesQuery := skipQueryFilter || testMetadataMatchesQuery(metadata, filterOptions.Query)
+			matchesCategories := skipCategoriesFilter || testMetadataMatchesCategories(metadata, filterOptions.Categories)
+			matchesRepos := skipRepositoriesFilter || testMetadataMatchesRepos(metadata, filterOptions.Repositories)
+			if matchesRepos && matchesQuery && matchesCategories {
+				filteredMetadatas = append(filteredMetadatas, metadata)
 			}
 		}
 	}
-	return filteredMeta
+	return filteredMetadatas
 }
 
 func testMetadataMatchesQuery(metadata *datapackagingv1alpha1.PackageMetadata, query string) bool {
@@ -323,6 +322,18 @@ func testMetadataMatchesCategories(metadata *datapackagingv1alpha1.PackageMetada
 	}
 
 	return intersection
+}
+
+// testMetadataMatchesRepos returns true if the metadata matches the provided repositories.
+func testMetadataMatchesRepos(metadata *datapackagingv1alpha1.PackageMetadata, repositories []string) bool {
+	metadataRepoName := getRepoNameFromAnnotation(metadata.Annotations[REPO_REF_ANNOTATION])
+	// if the package is from one of the given repositories, it matches
+	for _, repo := range repositories {
+		if metadataRepoName == repo {
+			return true
+		}
+	}
+	return false
 }
 
 //

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
@@ -611,6 +611,25 @@ func TestBuildPackageIdentifier(t *testing.T) {
 		})
 	}
 }
+func TestGetRepoNameFromAnnotation(t *testing.T) {
+	tests := []struct {
+		name              string
+		repoRefAnnotation string
+		expected          string
+	}{
+		{"empty", "", "unknown"},
+		{"a valid annotation", "default/tce-repo", "tce-repo"},
+		{"an invalid annotation", "default/foo/tce-repo", "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoName := getRepoNameFromAnnotation(tt.repoRefAnnotation)
+			if want, got := tt.expected, repoName; !cmp.Equal(want, got) {
+				t.Errorf("in %s: mismatch (-want +got):\n%s", tt.name, cmp.Diff(want, got))
+			}
+		})
+	}
+}
 
 func TestPrereleasesVersionSelection(t *testing.T) {
 	tests := []struct {

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
@@ -838,6 +838,162 @@ func TestFilterMetadatas(t *testing.T) {
 			},
 			expectedMetadatas: []*datapackagingv1alpha1.PackageMetadata{},
 		},
+		{
+			name: "does not match unless metadata has all categories from filter",
+			metadatas: []*datapackagingv1alpha1.PackageMetadata{
+				{
+					Spec: datapackagingv1alpha1.PackageMetadataSpec{
+						Categories: []string{"category1", "category2", "category3"},
+					},
+				},
+				{
+					Spec: datapackagingv1alpha1.PackageMetadataSpec{
+						Categories: []string{"category4", "category5", "category6"},
+					},
+				},
+			},
+			filterOptions: corev1.FilterOptions{
+				Categories: []string{"category6", "category3"},
+			},
+			expectedMetadatas: []*datapackagingv1alpha1.PackageMetadata{},
+		},
+		{
+			name: "does match if metadata has a repo from filter",
+			metadatas: []*datapackagingv1alpha1.PackageMetadata{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tetris.foo.example.com",
+						Annotations: map[string]string{
+							REPO_REF_ANNOTATION: "default/tce-repo",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tetris.foo.example.com",
+						Annotations: map[string]string{
+							REPO_REF_ANNOTATION: "default/another-repo",
+						},
+					},
+				},
+			},
+			filterOptions: corev1.FilterOptions{
+				Repositories: []string{"tce-repo"},
+			},
+			expectedMetadatas: []*datapackagingv1alpha1.PackageMetadata{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tetris.foo.example.com",
+						Annotations: map[string]string{
+							REPO_REF_ANNOTATION: "default/tce-repo",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "does not match if metadata has an unkown repo",
+			metadatas: []*datapackagingv1alpha1.PackageMetadata{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tetris.foo.example.com",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tetris.foo.example.com",
+						Annotations: map[string]string{
+							REPO_REF_ANNOTATION: "default/another-repo",
+						},
+					},
+				},
+			},
+			filterOptions: corev1.FilterOptions{
+				Repositories: []string{"tce-repo"},
+			},
+			expectedMetadatas: []*datapackagingv1alpha1.PackageMetadata{},
+		},
+		{
+			name: "does match if every filterOptions is met",
+			metadatas: []*datapackagingv1alpha1.PackageMetadata{
+				{
+					Spec: datapackagingv1alpha1.PackageMetadataSpec{
+						DisplayName: "match-pkg",
+						Categories:  []string{"match-category"},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tetris.foo.example.com",
+						Annotations: map[string]string{
+							REPO_REF_ANNOTATION: "default/match-repo",
+						},
+					},
+				},
+				{
+					Spec: datapackagingv1alpha1.PackageMetadataSpec{
+						DisplayName: "non-match-by-display-name",
+						Categories:  []string{"match-category"},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tetris.foo.example.com",
+						Annotations: map[string]string{
+							REPO_REF_ANNOTATION: "default/match-repo",
+						},
+					},
+				},
+				{
+					Spec: datapackagingv1alpha1.PackageMetadataSpec{
+						DisplayName: "match-pkg",
+						Categories:  []string{"non-match-by-category"},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tetris.foo.example.com",
+						Annotations: map[string]string{
+							REPO_REF_ANNOTATION: "default/match-repo",
+						},
+					},
+				},
+				{
+					Spec: datapackagingv1alpha1.PackageMetadataSpec{
+						DisplayName: "match-pkg",
+						Categories:  []string{"match-category"},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "tetris.foo.example.com",
+						Annotations: map[string]string{
+							REPO_REF_ANNOTATION: "default/non-match-by-repo",
+						},
+					},
+				},
+			},
+			filterOptions: corev1.FilterOptions{
+				Query:        "match-pkg",
+				Categories:   []string{"match-category"},
+				Repositories: []string{"match-repo"},
+			},
+			expectedMetadatas: []*datapackagingv1alpha1.PackageMetadata{{
+				Spec: datapackagingv1alpha1.PackageMetadataSpec{
+					DisplayName: "match-pkg",
+					Categories:  []string{"match-category"},
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "tetris.foo.example.com",
+					Annotations: map[string]string{
+						REPO_REF_ANNOTATION: "default/match-repo",
+					},
+				},
+			},
+			},
+		},
 	}
 
 	//nolint:govet


### PR DESCRIPTION
### Description of the change

As stated in https://github.com/vmware-tanzu/kubeapps/issues/5165, we were not filtering by repos in the carvel plugin. This PR is merely to implement it and handle the scenario of an empty result.

### Benefits

The filter by repo will actually work in backend (so no unnecessary data will be sent over the wire when requesting pkg from a repo).

### Possible drawbacks

N/A

### Applicable issues

- fixes #5168

### Additional information

N/A