### PR TITLE
Fixed repo mgmt buttons showing in additional clusters

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -31,3 +31,6 @@ telepresence.log
 
 # Use yarn for package management
 package-lock.json
+
+# React-app proxy
+src/setupProxy.js

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -133,15 +133,19 @@ function AppRepoList() {
     <>
       <PageHeader
         title="Package Repositories"
-        buttons={[
-          <AppRepoAddButton
-            title="Add a Package Repository"
-            key="add-repo-button"
-            namespace={currentNamespace}
-            kubeappsNamespace={globalReposNamespace}
-          />,
-          <AppRepoRefreshAllButton key="refresh-all-button" />,
-        ]}
+        buttons={
+          supportedCluster
+            ? [
+                <AppRepoAddButton
+                  title="Add a Package Repository"
+                  key="add-repo-button"
+                  namespace={currentNamespace}
+                  kubeappsNamespace={globalReposNamespace}
+                />,
+                <AppRepoRefreshAllButton key="refresh-all-button" />,
+              ]
+            : []
+        }
         filter={
           canSetAllNS ? (
             <CdsToggleGroup className="flex-v-center">


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

Trivial PR that fixes issue in the multicluster mode that was showing buttons for managing repos when on additional clusters. This actions are not valid in that scenario.

![image](https://user-images.githubusercontent.com/67455978/183403057-00ae01ca-b7ae-4400-8151-674ad6eb7f16.png)

Those buttons are not appearing anymore in additional clusters.
![image](https://user-images.githubusercontent.com/67455978/183403181-75e20347-792c-4ca1-bb4a-dcc6d520c099.png)


### Benefits

Users will not get the repository creation dialog on additional clusters -a feature not available in Kubeapps so far- and thus will not get an error when trying to create a repo.
![image](https://user-images.githubusercontent.com/67455978/183403552-e15f7cf2-22eb-4d27-b869-403d51efd14f.png)

### Possible drawbacks

N/A
