### PR TITLE
[Helm plugin] Changed repo secrets copied now to Kubeapps namespace

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/globals_vars_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/globals_vars_test.go
@@ -235,7 +235,7 @@ var (
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "bar",
-			Namespace:       "kubeapps",
+			Namespace:       globalPackagingNamespace,
 			ResourceVersion: "1",
 		},
 		Spec: v1alpha1.AppRepositorySpec{
@@ -259,7 +259,7 @@ var (
 
 	addRepoReqGlobal = &corev1.AddPackageRepositoryRequest{
 		Name:            "bar",
-		Context:         &corev1.Context{Namespace: "kubeapps", Cluster: KubeappsCluster},
+		Context:         &corev1.Context{Namespace: globalPackagingNamespace, Cluster: KubeappsCluster},
 		Type:            "helm",
 		Url:             "http://example.com",
 		NamespaceScoped: false,

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
@@ -73,9 +73,11 @@ func (s *Server) newRepo(ctx context.Context, repo *HelmRepository) (*corev1.Pac
 			return nil, err
 		}
 	}
-	// Copy secret to global namespace if needed. See issue #5129.
-	if repo.name.Namespace != s.globalPackagingNamespace && secret != nil {
-		if err = s.copyRepositorySecret(typedClient, secret, repo.name); err != nil {
+	// Copy secret to the namespace of asset syncer if needed. See issue #5129.
+	if repo.name.Namespace != s.kubeappsNamespace && secret != nil {
+		// Target namespace must be the same as the asset syncer job,
+		// otherwise the job won't be able to access the secret
+		if err = s.copyRepositorySecret(typedClient, s.kubeappsNamespace, secret, repo.name); err != nil {
 			return nil, err
 		}
 	}
@@ -327,9 +329,11 @@ func (s *Server) updateRepo(ctx context.Context, repo *HelmRepository) (*corev1.
 			return nil, err
 		}
 	}
-	// Copy secret to global namespace if needed. See issue #5129.
-	if repo.name.Namespace != s.globalPackagingNamespace && secret != nil {
-		if err = s.copyRepositorySecret(typedClient, secret, repo.name); err != nil {
+	// Copy secret to the namespace of asset syncer if needed. See issue #5129.
+	if repo.name.Namespace != s.kubeappsNamespace && secret != nil {
+		// Target namespace must be the same as the asset syncer job,
+		// otherwise the job won't be able to access the secret
+		if err = s.copyRepositorySecret(typedClient, s.kubeappsNamespace, secret, repo.name); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_auth.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_auth.go
@@ -286,8 +286,7 @@ func deleteSecret(ctx context.Context, secretsInterface v1.SecretInterface, secr
 	return nil
 }
 
-func (s *Server) copyRepositorySecret(typedClient kubernetes.Interface, secret *k8scorev1.Secret, repoName types.NamespacedName) error {
-	targetNamespace := s.globalPackagingNamespace
+func (s *Server) copyRepositorySecret(typedClient kubernetes.Interface, targetNamespace string, secret *k8scorev1.Secret, repoName types.NamespacedName) error {
 	globalSecret := &k8scorev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      namespacedSecretNameForRepo(repoName.Name, repoName.Namespace),

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_auth.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_auth.go
@@ -286,8 +286,8 @@ func deleteSecret(ctx context.Context, secretsInterface v1.SecretInterface, secr
 	return nil
 }
 
-func (s *Server) copyRepositorySecret(typedClient kubernetes.Interface, targetNamespace string, secret *k8scorev1.Secret, repoName types.NamespacedName) error {
-	globalSecret := &k8scorev1.Secret{
+func (s *Server) copyRepositorySecretToNamespace(typedClient kubernetes.Interface, targetNamespace string, secret *k8scorev1.Secret, repoName types.NamespacedName) (copiedSecret *k8scorev1.Secret, err error) {
+	newSecret := &k8scorev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      namespacedSecretNameForRepo(repoName.Name, repoName.Namespace),
 			Namespace: targetNamespace,
@@ -295,11 +295,19 @@ func (s *Server) copyRepositorySecret(typedClient kubernetes.Interface, targetNa
 		Type: secret.Type,
 		Data: secret.Data,
 	}
-	_, err := typedClient.CoreV1().Secrets(targetNamespace).Create(context.TODO(), globalSecret, metav1.CreateOptions{})
+	copiedSecret, err = typedClient.CoreV1().Secrets(targetNamespace).Create(context.TODO(), newSecret, metav1.CreateOptions{})
 	if err != nil && k8sErrors.IsAlreadyExists(err) {
-		_, err = typedClient.CoreV1().Secrets(targetNamespace).Update(context.TODO(), globalSecret, metav1.UpdateOptions{})
+		copiedSecret, err = typedClient.CoreV1().Secrets(targetNamespace).Update(context.TODO(), newSecret, metav1.UpdateOptions{})
 	}
-	return err
+	return copiedSecret, err
+}
+
+func (s *Server) deleteRepositorySecretFromNamespace(typedClient kubernetes.Interface, targetNamespace, secretName string) error {
+	secretsInterface := typedClient.CoreV1().Secrets(targetNamespace)
+	if deleteErr := deleteSecret(context.TODO(), secretsInterface, secretName); deleteErr != nil {
+		return deleteErr
+	}
+	return nil
 }
 
 func updateKubeappsManagedImagesPullSecret(ctx context.Context, typedClient kubernetes.Interface,

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
@@ -261,7 +261,7 @@ func TestAddPackageRepository(t *testing.T) {
 			expectedResponse:      addRepoExpectedResp,
 			expectedRepo:          &addRepoWithTLSCA,
 			expectedCreatedSecret: setSecretOwnerRef("bar", newTlsSecret("apprepo-bar", "foo", nil, nil, ca)),
-			expectedGlobalSecret:  newTlsSecret("foo-apprepo-bar", globalPackagingNamespace, nil, nil, ca),
+			expectedGlobalSecret:  newTlsSecret("foo-apprepo-bar", kubeappsNamespace, nil, nil, ca), // Global secrets must reside in the Kubeapps (asset syncer) namespace
 			statusCode:            codes.OK,
 		},
 		{
@@ -276,7 +276,7 @@ func TestAddPackageRepository(t *testing.T) {
 			existingSecret:       newTlsSecret("secret-1", "foo", nil, nil, ca),
 			expectedResponse:     addRepoExpectedResp,
 			expectedRepo:         &addRepoTLSSecret,
-			expectedGlobalSecret: newTlsSecret("foo-apprepo-bar", globalPackagingNamespace, nil, nil, ca),
+			expectedGlobalSecret: newTlsSecret("foo-apprepo-bar", kubeappsNamespace, nil, nil, ca),
 			statusCode:           codes.OK,
 		},
 		{
@@ -297,14 +297,14 @@ func TestAddPackageRepository(t *testing.T) {
 			expectedResponse:      addRepoExpectedResp,
 			expectedRepo:          addRepoAuthHeaderPassCredentials("foo"),
 			expectedCreatedSecret: setSecretOwnerRef("bar", newBasicAuthSecret("apprepo-bar", "foo", "baz", "zot")),
-			expectedGlobalSecret:  newBasicAuthSecret("foo-apprepo-bar", globalPackagingNamespace, "baz", "zot"),
+			expectedGlobalSecret:  newBasicAuthSecret("foo-apprepo-bar", kubeappsNamespace, "baz", "zot"),
 			statusCode:            codes.OK,
 		},
 		{
-			name: "[kubeapps managed secrets] package repository with basic auth and pass_credentials flag in global namespace",
+			name: "[kubeapps managed secrets] package repository with basic auth and pass_credentials flag in global namespace copies secret to kubeapps ns",
 			request: &corev1.AddPackageRepositoryRequest{
 				Name:            "bar",
-				Context:         &corev1.Context{Namespace: globalPackagingNamespace, Cluster: KubeappsCluster},
+				Context:         &corev1.Context{Cluster: KubeappsCluster, Namespace: globalPackagingNamespace},
 				Type:            "helm",
 				Url:             "http://example.com",
 				NamespaceScoped: false,
@@ -322,6 +322,7 @@ func TestAddPackageRepository(t *testing.T) {
 			expectedResponse:      addRepoExpectedGlobalResp,
 			expectedRepo:          addRepoAuthHeaderPassCredentials(globalPackagingNamespace),
 			expectedCreatedSecret: setSecretOwnerRef("bar", newBasicAuthSecret("apprepo-bar", globalPackagingNamespace, "the-user", "the-pwd")),
+			expectedGlobalSecret:  newBasicAuthSecret("kubeapps-repos-global-apprepo-bar", kubeappsNamespace, "the-user", "the-pwd"),
 			statusCode:            codes.OK,
 		},
 		{
@@ -342,11 +343,11 @@ func TestAddPackageRepository(t *testing.T) {
 			existingSecret:       newBasicAuthSecret("secret-basic", "foo", "baz-user", "zot-pwd"),
 			expectedResponse:     addRepoExpectedResp,
 			expectedRepo:         addRepoAuthHeaderWithSecretRef("foo", "secret-basic"),
-			expectedGlobalSecret: newBasicAuthSecret("foo-apprepo-bar", globalPackagingNamespace, "baz-user", "zot-pwd"),
+			expectedGlobalSecret: newBasicAuthSecret("foo-apprepo-bar", kubeappsNamespace, "baz-user", "zot-pwd"),
 			statusCode:           codes.OK,
 		},
 		{
-			name: "[user managed secrets] add repository to global namespace does not create global secret",
+			name: "[user managed secrets] add repository to global namespace creates secret in kubeapps namespace for syncer",
 			request: &corev1.AddPackageRepositoryRequest{
 				Name:            "bar",
 				Context:         &corev1.Context{Namespace: globalPackagingNamespace, Cluster: KubeappsCluster},
@@ -362,11 +363,12 @@ func TestAddPackageRepository(t *testing.T) {
 					},
 				},
 			},
-			userManagedSecrets: true,
-			existingSecret:     newBasicAuthSecret("secret-basic", globalPackagingNamespace, "baz-user", "zot-pwd"),
-			expectedResponse:   addRepoExpectedGlobalResp,
-			expectedRepo:       addRepoAuthHeaderWithSecretRef(globalPackagingNamespace, "secret-basic"),
-			statusCode:         codes.OK,
+			userManagedSecrets:   true,
+			existingSecret:       newBasicAuthSecret("secret-basic", globalPackagingNamespace, "baz-user", "zot-pwd"),
+			expectedResponse:     addRepoExpectedGlobalResp,
+			expectedRepo:         addRepoAuthHeaderWithSecretRef(globalPackagingNamespace, "secret-basic"),
+			expectedGlobalSecret: newBasicAuthSecret("kubeapps-repos-global-apprepo-bar", kubeappsNamespace, "baz-user", "zot-pwd"),
+			statusCode:           codes.OK,
 		},
 		{
 			name:       "package repository basic auth with existing secret (kubeapps managed secrets)",
@@ -380,7 +382,7 @@ func TestAddPackageRepository(t *testing.T) {
 			expectedResponse:      addRepoExpectedResp,
 			expectedRepo:          addRepoAuthHeaderWithSecretRef("foo", "apprepo-bar"),
 			expectedCreatedSecret: setSecretOwnerRef("bar", newAuthTokenSecret("apprepo-bar", "foo", "Bearer the-token")),
-			expectedGlobalSecret:  newAuthTokenSecret("foo-apprepo-bar", globalPackagingNamespace, "Bearer the-token"),
+			expectedGlobalSecret:  newAuthTokenSecret("foo-apprepo-bar", kubeappsNamespace, "Bearer the-token"),
 			statusCode:            codes.OK,
 		},
 		{
@@ -389,7 +391,7 @@ func TestAddPackageRepository(t *testing.T) {
 			expectedResponse:      addRepoExpectedResp,
 			expectedRepo:          addRepoAuthHeaderWithSecretRef("foo", "apprepo-bar"),
 			expectedCreatedSecret: setSecretOwnerRef("bar", newAuthTokenSecret("apprepo-bar", "foo", "Bearer the-token")),
-			expectedGlobalSecret:  newAuthTokenSecret("foo-apprepo-bar", globalPackagingNamespace, "Bearer the-token"),
+			expectedGlobalSecret:  newAuthTokenSecret("foo-apprepo-bar", kubeappsNamespace, "Bearer the-token"),
 			statusCode:            codes.OK,
 		},
 		{
@@ -404,7 +406,7 @@ func TestAddPackageRepository(t *testing.T) {
 			existingSecret:       newAuthTokenSecret("secret-bearer", "foo", "Bearer the-token"),
 			expectedResponse:     addRepoExpectedResp,
 			expectedRepo:         addRepoAuthHeaderWithSecretRef("foo", "secret-bearer"),
-			expectedGlobalSecret: newAuthTokenSecret("foo-apprepo-bar", globalPackagingNamespace, "Bearer the-token"),
+			expectedGlobalSecret: newAuthTokenSecret("foo-apprepo-bar", kubeappsNamespace, "Bearer the-token"),
 			statusCode:           codes.OK,
 		},
 		{
@@ -425,7 +427,7 @@ func TestAddPackageRepository(t *testing.T) {
 			expectedResponse:      addRepoExpectedResp,
 			expectedRepo:          addRepoAuthHeaderWithSecretRef("foo", "apprepo-bar"),
 			expectedCreatedSecret: setSecretOwnerRef("bar", newAuthTokenSecret("apprepo-bar", "foo", "foobarzot")),
-			expectedGlobalSecret:  newAuthTokenSecret("foo-apprepo-bar", globalPackagingNamespace, "foobarzot"),
+			expectedGlobalSecret:  newAuthTokenSecret("foo-apprepo-bar", kubeappsNamespace, "foobarzot"),
 			statusCode:            codes.OK,
 		},
 		{
@@ -435,7 +437,7 @@ func TestAddPackageRepository(t *testing.T) {
 			existingSecret:       newBasicAuthSecret("secret-custom", "foo", "baz", "zot"),
 			expectedResponse:     addRepoExpectedResp,
 			expectedRepo:         addRepoAuthHeaderWithSecretRef("foo", "secret-custom"),
-			expectedGlobalSecret: newBasicAuthSecret("foo-apprepo-bar", globalPackagingNamespace, "baz", "zot"),
+			expectedGlobalSecret: newBasicAuthSecret("foo-apprepo-bar", kubeappsNamespace, "baz", "zot"),
 			statusCode:           codes.OK,
 		},
 		{
@@ -455,11 +457,12 @@ func TestAddPackageRepository(t *testing.T) {
 					},
 				},
 			},
-			userManagedSecrets: true,
-			existingSecret:     newBasicAuthSecret("secret-custom", globalPackagingNamespace, "baz", "zot"),
-			expectedResponse:   addRepoExpectedGlobalResp,
-			expectedRepo:       addRepoAuthHeaderWithSecretRef(globalPackagingNamespace, "secret-custom"),
-			statusCode:         codes.OK,
+			userManagedSecrets:   true,
+			existingSecret:       newBasicAuthSecret("secret-custom", globalPackagingNamespace, "baz", "zot"),
+			expectedResponse:     addRepoExpectedGlobalResp,
+			expectedRepo:         addRepoAuthHeaderWithSecretRef(globalPackagingNamespace, "secret-custom"),
+			expectedGlobalSecret: newBasicAuthSecret("kubeapps-repos-global-apprepo-bar", kubeappsNamespace, "baz", "zot"),
+			statusCode:           codes.OK,
 		},
 		// DOCKER AUTH
 		{
@@ -475,7 +478,7 @@ func TestAddPackageRepository(t *testing.T) {
 			expectedCreatedSecret: setSecretOwnerRef("bar",
 				newAuthDockerSecret("apprepo-bar", "foo",
 					dockerAuthJson("https://docker-server", "the-user", "the-password", "foo@bar.com", "dGhlLXVzZXI6dGhlLXBhc3N3b3Jk"))),
-			expectedGlobalSecret: newAuthDockerSecret("foo-apprepo-bar", globalPackagingNamespace,
+			expectedGlobalSecret: newAuthDockerSecret("foo-apprepo-bar", kubeappsNamespace,
 				dockerAuthJson("https://docker-server", "the-user", "the-password", "foo@bar.com", "dGhlLXVzZXI6dGhlLXBhc3N3b3Jk")),
 			statusCode: codes.OK,
 		},
@@ -487,7 +490,7 @@ func TestAddPackageRepository(t *testing.T) {
 				dockerAuthJson("https://docker-server", "the-user", "the-password", "foo@bar.com", "dGhlLXVzZXI6dGhlLXBhc3N3b3Jk")),
 			expectedResponse: addRepoExpectedResp,
 			expectedRepo:     addRepoAuthDocker("secret-docker"),
-			expectedGlobalSecret: newAuthDockerSecret("foo-apprepo-bar", globalPackagingNamespace,
+			expectedGlobalSecret: newAuthDockerSecret("foo-apprepo-bar", kubeappsNamespace,
 				dockerAuthJson("https://docker-server", "the-user", "the-password", "foo@bar.com", "dGhlLXVzZXI6dGhlLXBhc3N3b3Jk")),
 			statusCode: codes.OK,
 		},
@@ -1183,7 +1186,7 @@ func TestUpdatePackageRepository(t *testing.T) {
 			},
 			expectedRef:          defaultRef,
 			expectedSecret:       setSecretOwnerRef("repo-1", newTlsSecret("apprepo-repo-1", "ns-1", nil, nil, ca)),
-			expectedGlobalSecret: newTlsSecret("ns-1-apprepo-repo-1", globalPackagingNamespace, nil, nil, ca),
+			expectedGlobalSecret: newTlsSecret("ns-1-apprepo-repo-1", kubeappsNamespace, nil, nil, ca),
 			expectedStatusCode:   codes.OK,
 		},
 		{
@@ -1242,7 +1245,7 @@ func TestUpdatePackageRepository(t *testing.T) {
 			},
 			expectedRef:          defaultRef,
 			expectedSecret:       setSecretOwnerRef("repo-1", newAuthTokenSecret("apprepo-repo-1", "ns-1", "Bearer foobarzot")),
-			expectedGlobalSecret: newAuthTokenSecret("ns-1-apprepo-repo-1", globalPackagingNamespace, "Bearer foobarzot"),
+			expectedGlobalSecret: newAuthTokenSecret("ns-1-apprepo-repo-1", kubeappsNamespace, "Bearer foobarzot"),
 			expectedStatusCode:   codes.OK,
 		},
 		{
@@ -1275,7 +1278,7 @@ func TestUpdatePackageRepository(t *testing.T) {
 				return &repository
 			},
 			expectedRef:          defaultRef,
-			expectedGlobalSecret: newAuthTokenSecret("ns-1-apprepo-repo-1", globalPackagingNamespace, "Bearer foobarzot"),
+			expectedGlobalSecret: newAuthTokenSecret("ns-1-apprepo-repo-1", kubeappsNamespace, "Bearer foobarzot"),
 			expectedStatusCode:   codes.OK,
 		},
 		{
@@ -1681,7 +1684,7 @@ func checkGlobalSecret(s *Server, t *testing.T, expectedRepo *appRepov1alpha1.Ap
 	repoGlobalSecretName := fmt.Sprintf("%s-apprepo-%s", expectedRepo.Namespace, expectedRepo.Name)
 	if expectedGlobalSecret != nil {
 		// Check for copied secret to global namespace
-		actualGlobalSecret, err := typedClient.CoreV1().Secrets(s.globalPackagingNamespace).Get(ctx, repoGlobalSecretName, metav1.GetOptions{})
+		actualGlobalSecret, err := typedClient.CoreV1().Secrets(s.kubeappsNamespace).Get(ctx, repoGlobalSecretName, metav1.GetOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1690,12 +1693,12 @@ func checkGlobalSecret(s *Server, t *testing.T, expectedRepo *appRepov1alpha1.Ap
 		}
 	} else if checkNoGlobalSecret {
 		// Check that global secret does not exist
-		secret, err := typedClient.CoreV1().Secrets(s.globalPackagingNamespace).Get(ctx, repoGlobalSecretName, metav1.GetOptions{})
+		secret, err := typedClient.CoreV1().Secrets(s.kubeappsNamespace).Get(ctx, repoGlobalSecretName, metav1.GetOptions{})
 		if err != nil && !k8sErrors.IsNotFound(err) {
 			t.Fatal(err)
 		}
 		if secret != nil {
-			t.Errorf("global secret was found")
+			t.Errorf("global secret was found: %v", secret)
 		}
 	}
 }

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -75,6 +75,7 @@ type Server struct {
 	chartClientFactory       chartutils.ChartClientFactoryInterface
 	createReleaseFunc        createRelease
 	kubeappsCluster          string // Specifies the cluster on which Kubeapps is installed.
+	kubeappsNamespace        string // Namespace in which Kubeapps is installed
 	pluginConfig             *common.HelmPluginConfig
 	repoClientGetter         newRepoClient
 }
@@ -86,6 +87,12 @@ func NewServer(configGetter core.KubernetesConfigGetter, globalPackagingCluster 
 	var ASSET_SYNCER_DB_NAME = os.Getenv("ASSET_SYNCER_DB_NAME")
 	var ASSET_SYNCER_DB_USERNAME = os.Getenv("ASSET_SYNCER_DB_USERNAME")
 	var ASSET_SYNCER_DB_USERPASSWORD = os.Getenv("ASSET_SYNCER_DB_USERPASSWORD")
+
+	// Namespace where Kubeapps is installed to be in line with the asset syncer
+	kubeappsNamespace := os.Getenv("POD_NAMESPACE")
+	if kubeappsNamespace == "" {
+		log.Fatal("POD_NAMESPACE environment variable should be defined")
+	}
 
 	var dbConfig = dbutils.Config{URL: ASSET_SYNCER_DB_URL, Database: ASSET_SYNCER_DB_NAME, Username: ASSET_SYNCER_DB_USERNAME, Password: ASSET_SYNCER_DB_USERPASSWORD}
 
@@ -134,6 +141,7 @@ func NewServer(configGetter core.KubernetesConfigGetter, globalPackagingCluster 
 			return fn(ctx, pkgContext.GetNamespace())
 		},
 		manager:                  manager,
+		kubeappsNamespace:        kubeappsNamespace,
 		globalPackagingNamespace: globalReposNamespace,
 		globalPackagingCluster:   globalPackagingCluster,
 		chartClientFactory:       &chartutils.ChartClientFactory{},

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -57,7 +57,8 @@ import (
 )
 
 const (
-	globalPackagingNamespace = "kubeapps"
+	globalPackagingNamespace = "kubeapps-repos-global"
+	kubeappsNamespace        = "kubeapps"
 	globalPackagingCluster   = "default"
 	DefaultAppVersion        = "1.2.6"
 	DefaultReleaseRevision   = 1
@@ -265,6 +266,7 @@ func makeServer(t *testing.T, authorized bool, actionConfig *action.Configuratio
 	return &Server{
 		clientGetter:             clientGetter,
 		manager:                  manager,
+		kubeappsNamespace:        kubeappsNamespace,
 		globalPackagingNamespace: globalPackagingNamespace,
 		globalPackagingCluster:   globalPackagingCluster,
 		actionConfigGetter: func(context.Context, *corev1.Context) (*action.Configuration, error) {
@@ -331,6 +333,7 @@ func newServerWithSecretsAndRepos(t *testing.T, secrets []k8sruntime.Object, uns
 
 	return &Server{
 		clientGetter:             clientGetter,
+		kubeappsNamespace:        kubeappsNamespace,
 		globalPackagingNamespace: globalPackagingNamespace,
 		globalPackagingCluster:   globalPackagingCluster,
 		chartClientFactory:       &fake.ChartClientFactory{},


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

With the introduction of #5140, the secret for namespaced repos was being copied to the global namespace, which is incorrect.
The right one is the **kubeapps** namespace. Both are equal by default, but when `apprepository.globalReposNamespaceSuffix` is specified, syncer job runs in kubeapps namespace, and secrets are being created in the global namespace. This leads the syncer job creation to fail with error: `Error: secret "test-apprepo-example-repo" not found`.

This PR changes logic when creating and updating package repos so that secrets are copied to the `kubeapps` namespace if repo wasn't created in that namespace. In this way, we make sure that asset syncer has the secret available.

### Benefits

Namespaced repos can be synced correctly now.

### Possible drawbacks

We need to differentiate between *global* repos (in the Kubeapps global namespace, e.g. `kubeapps-repos-global`) and repos in `kubeapps` namespace (which might not be global).

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #5140
- fixes #5129

### Additional information

This bug was found to be the origin of the problem mentioned in [this comment](https://github.com/vmware-tanzu/kubeapps/pull/5115#issuecomment-1208243856) of 5115.