### PR TITLE
Debounce isFetching in the catalog ui

### DIFF
--- a/dashboard/src/actions/availablepackages.test.tsx
+++ b/dashboard/src/actions/availablepackages.test.tsx
@@ -69,7 +69,11 @@ const defaultAvailablePackageDetail: AvailablePackageDetail = {
 };
 
 beforeEach(() => {
-  store = mockStore();
+  store = mockStore({
+    packages: {
+      isFetching: false,
+    },
+  });
 });
 
 afterEach(() => {

--- a/dashboard/src/actions/availablepackages.ts
+++ b/dashboard/src/actions/availablepackages.ts
@@ -107,9 +107,15 @@ export function fetchAvailablePackageSummaries(
   size: number,
   query?: string,
 ): ThunkAction<Promise<void>, IStoreState, null, PackagesAction> {
-  return async dispatch => {
-    dispatch(requestAvailablePackageSummaries(paginationToken));
+  return async (dispatch, getState) => {
+    const {
+      packages: { isFetching },
+    } = getState();
     try {
+      if (isFetching) {
+        throw Error("unexpected request, it was already fetching data");
+      }
+      dispatch(requestAvailablePackageSummaries(paginationToken));
       const response = await PackagesService.getAvailablePackageSummaries(
         cluster,
         namespace,

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -450,13 +450,17 @@ describe("pagination and package fetching", () => {
   const refFalse = { current: {} };
   const refTrue = { current: {} };
   Object.defineProperty(refFalse, "current", {
-    set(_current) {},
+    set(_current) {
+      // do nothing
+    },
     get() {
       return false;
     },
   });
   Object.defineProperty(refTrue, "current", {
-    set(_current) {},
+    set(_current) {
+      // do nothing
+    },
     get() {
       return true;
     },

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -101,12 +101,15 @@ export default function Catalog() {
   const [pageNum, setPageNum] = React.useState(0);
   const [hasRequestedFirstPage, setHasRequestedFirstPage] = React.useState(false);
   const [hasLoadedFirstPage, setHasLoadedFirstPage] = React.useState(false);
+  const localIsFetchingRef = React.useRef(isFetching);
 
   const csvs = operators.csvs;
 
   // Only one search filter can be set
   const searchFilter = filters[filterNames.SEARCH]?.toString().replace(tmpStrRegex, ",") || "";
   const reposFilter = filters[filterNames.REPO]?.join(",") || "";
+
+  const timeout = (ms: number) => new Promise(r => setTimeout(r, ms));
 
   // Detect changes in cluster/ns/repos/search and reset the current package
   // list Note: useEffect is called on every render - the initial render and any
@@ -140,22 +143,39 @@ export default function Catalog() {
     });
   }, [location.search]);
 
+  // using the local reference to the isFetching state to avoid re-rendering on each isFetching actual change
   useEffect(() => {
-    if (hasFinishedFetching) {
-      return;
-    }
-    dispatch(
-      actions.availablepackages.fetchAvailablePackageSummaries(
-        cluster,
-        namespace,
-        reposFilter,
-        nextPageToken,
-        size,
-        searchFilter,
-      ),
-    );
+    localIsFetchingRef.current = isFetching;
+  }, [isFetching]);
+
+  useEffect(() => {
+    const isFetchingAwareFetching = async () => {
+      if (hasFinishedFetching) {
+        return;
+      }
+      // if the local isFetching is true, we need to wait for the rest of the actions to take effect.
+      // this state seldom happens (eg. clicking buttons quickly) but it is possible, so we need to wait,
+      // otherwise the UI will be in an inconsistent state due to race conditions
+      // Note that the "receiveAvailablePackageSummaries" is ignoring the received data if it wasn't previously fetching.
+      if (localIsFetchingRef.current) {
+        await timeout(1500);
+        localIsFetchingRef.current = false;
+      }
+      dispatch(
+        actions.availablepackages.fetchAvailablePackageSummaries(
+          cluster,
+          namespace,
+          reposFilter,
+          nextPageToken,
+          size,
+          searchFilter,
+        ),
+      );
+    };
+    isFetchingAwareFetching();
   }, [
     dispatch,
+    localIsFetchingRef,
     nextPageToken,
     size,
     cluster,
@@ -488,7 +508,7 @@ export default function Catalog() {
                       namespace={namespace}
                       isFirstPage={pageNum === 1}
                       hasLoadedFirstPage={hasLoadedFirstPage}
-                      hasFinishedFetching={hasFinishedFetching}
+                      hasFinishedFetching={hasFinishedFetching && !localIsFetchingRef.current}
                     />
                     {!hasFinishedFetching &&
                       (!filters[filterNames.TYPE].length ||

--- a/dashboard/src/reducers/availablepackages.test.ts
+++ b/dashboard/src/reducers/availablepackages.test.ts
@@ -58,7 +58,7 @@ describe("packageReducer", () => {
   const error = new Error("Boom");
 
   it("unsets an error when changing namespace", () => {
-    const state = packageReducer(undefined, {
+    const state = packageReducer(initialState, {
       type: getType(actions.availablepackages.createErrorPackage) as any,
       payload: error,
     });
@@ -72,14 +72,14 @@ describe("packageReducer", () => {
     });
 
     expect(
-      packageReducer(undefined, {
+      packageReducer(initialState, {
         type: getType(actions.namespace.setNamespaceState) as any,
       }),
     ).toEqual({ ...initialState });
   });
 
   it("requestAvailablePackageSummaries (without page)", () => {
-    const state = packageReducer(undefined, {
+    const state = packageReducer(initialState, {
       type: getType(actions.availablepackages.requestAvailablePackageSummaries) as any,
     });
     expect(state).toEqual({
@@ -89,7 +89,7 @@ describe("packageReducer", () => {
   });
 
   it("requestAvailablePackageSummaries (with page)", () => {
-    const state = packageReducer(undefined, {
+    const state = packageReducer(initialState, {
       type: getType(actions.availablepackages.requestAvailablePackageSummaries) as any,
       payload: "currentPageToken",
     });
@@ -482,7 +482,7 @@ describe("packageReducer", () => {
   });
 
   it("resetAvailablePackageSummaries resets to the initial", () => {
-    const state = packageReducer(undefined, {
+    const state = packageReducer(initialState, {
       type: getType(actions.availablepackages.resetAvailablePackageSummaries) as any,
     });
     expect(state).toEqual({
@@ -491,7 +491,7 @@ describe("packageReducer", () => {
   });
 
   it("createErrorPackage resets to the initial state", () => {
-    const state = packageReducer(undefined, {
+    const state = packageReducer(initialState, {
       type: getType(actions.availablepackages.createErrorPackage) as any,
     });
     expect(state).toEqual({


### PR DESCRIPTION
### Description of the change

- Even if we implement the other mitigations, there are still some edge cases where the state remains inconsistent. For instance, when selecting a repo filter, scrolling down (to trigger pagination), or selecting another repo filter (to unmount the component)... would lead to a request made to the API when the app is in an `isFetching=true` state.
  - The proposed solution is twofold:
    - Absorb small race conditions with a dummy wait: this will prevent most of the errors to appear, because it will simply retry the request in 1 or 2 seconds. It requires storing a local copy (component's state) of the `isFetching` global state var.
    - Return an error if a "request_packages" request arrives at the state reducer while in an `isFetching=true` state. The UI will simply show a "try again" button, and the user can click on it. This check is to ensure no inconsistent data is shown to the user. 



### Benefits

No more "no data found" because of inconsistent requests coming.

### Possible drawbacks

The UI will simply show a "try again" button with an error when the error happens. This check is to ensure no inconsistent data is shown to the user, but still could be seen as a con.

### Applicable issues

- related #5165

### Additional information

![image](https://user-images.githubusercontent.com/11535726/183107709-37b83e22-4fd8-4b1f-b3a1-0cb6af2c5b25.png)
