### PR TITLE
Rename Pinniped Proxy TLS values in chart

### DIFF
--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -471,13 +471,13 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `pinnipedProxy.image.tag`                             | Pinniped Proxy image tag (immutable tags are recommended)                                    | `latest`                  |
 | `pinnipedProxy.image.pullPolicy`                      | Pinniped Proxy image pull policy                                                             | `IfNotPresent`            |
 | `pinnipedProxy.image.pullSecrets`                     | Pinniped Proxy image pull secrets                                                            | `[]`                      |
-| `pinnipedProxy.defaultPinnipedNamespace`              | Specify the (default) namespace in which pinniped concierge is installed                     | `pinniped-concierge`      |
-| `pinnipedProxy.defaultAuthenticatorType`              | Specify the (default) authenticator type                                                     | `JWTAuthenticator`        |
-| `pinnipedProxy.defaultAuthenticatorName`              | Specify the (default) authenticator name                                                     | `jwt-authenticator`       |
-| `pinnipedProxy.defaultPinnipedAPISuffix`              | Specify the (default) API suffix                                                             | `pinniped.dev`            |
-| `pinnipedProxy.TLSSecret`                             | Specify an optional TLS secret with which to proxy requests                                  | `""`                      |
-| `pinnipedProxy.CACert`                                | Specify the TLS CA cert config map which                                                     | `""`                      |
-| `pinnipedProxy.lifecycleHooks`                        | for the Pinniped Proxy container(s) to automate configuration before or after startup        | `{}`                      |
+| `pinnipedProxy.defaultPinnipedNamespace`              | Namespace in which pinniped concierge is installed                                           | `pinniped-concierge`      |
+| `pinnipedProxy.defaultAuthenticatorType`              | Authenticator type                                                                           | `JWTAuthenticator`        |
+| `pinnipedProxy.defaultAuthenticatorName`              | Authenticator name                                                                           | `jwt-authenticator`       |
+| `pinnipedProxy.defaultPinnipedAPISuffix`              | API suffix                                                                                   | `pinniped.dev`            |
+| `pinnipedProxy.tls.existingSecret`                    | TLS secret with which to proxy requests                                                      | `""`                      |
+| `pinnipedProxy.tls.caCertificate`                     | TLS CA cert config map which clients of pinniped proxy should use with TLS requests          | `""`                      |
+| `pinnipedProxy.lifecycleHooks`                        | For the Pinniped Proxy container(s) to automate configuration before or after startup        | `{}`                      |
 | `pinnipedProxy.command`                               | Override default container command (useful when using custom images)                         | `[]`                      |
 | `pinnipedProxy.args`                                  | Override default container args (useful when using custom images)                            | `[]`                      |
 | `pinnipedProxy.extraEnvVars`                          | Array with extra environment variables to add to Pinniped Proxy container(s)                 | `[]`                      |

--- a/chart/kubeapps/templates/frontend/deployment.yaml
+++ b/chart/kubeapps/templates/frontend/deployment.yaml
@@ -236,7 +236,7 @@ spec:
           {{- else }}
           command:
             - pinniped-proxy
-            {{- if .Values.pinnipedProxy.TLSSecret }}
+            {{- if .Values.pinnipedProxy.tls.existingSecret }}
             - --proxy-tls-cert=/etc/pinniped-tls/tls.crt
             - --proxy-tls-cert-key=/etc/pinniped-tls/tls.key
             {{- end }}
@@ -279,7 +279,7 @@ spec:
           resources: {{- toYaml .Values.pinnipedProxy.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if .Values.pinnipedProxy.TLSSecret }}
+            {{- if .Values.pinnipedProxy.tls.existingSecret }}
             - name: pinniped-tls-secret
               mountPath: "/etc/pinniped-tls"
               readOnly: true
@@ -295,10 +295,10 @@ spec:
         - name: vhost
           configMap:
             name: {{ template "kubeapps.frontend-config.fullname" . }}
-        {{- if .Values.pinnipedProxy.TLSSecret }}
+        {{- if .Values.pinnipedProxy.tls.existingSecret }}
         - name: pinniped-tls-secret
           secret:
-            secretName: {{ .Values.pinnipedProxy.TLSSecret }}
+            secretName: {{ .Values.pinnipedProxy.tls.existingSecret }}
         {{- end }}
         {{- if .Values.frontend.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.frontend.extraVolumes "context" $) | nindent 8 }}

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -103,8 +103,8 @@ spec:
             - --plugin-config-path=/config/kubeapps-apis/plugins.conf
             {{- end }}
             {{- if .Values.pinnipedProxy.enabled }}
-            - --pinniped-proxy-url={{ printf "http%s://%s.%s:%d" (eq .Values.pinnipedProxy.CACert "" | ternary "" "s") (include "kubeapps.pinniped-proxy.fullname" .) .Release.Namespace (int .Values.pinnipedProxy.service.ports.pinnipedProxy) }}
-            {{- if .Values.pinnipedProxy.CACert }}
+            - --pinniped-proxy-url={{ printf "http%s://%s.%s:%d" (eq .Values.pinnipedProxy.tls.caCertificate "" | ternary "" "s") (include "kubeapps.pinniped-proxy.fullname" .) .Release.Namespace (int .Values.pinnipedProxy.service.ports.pinnipedProxy) }}
+            {{- if .Values.pinnipedProxy.tls.caCertificate }}
             - --pinniped-proxy-ca-cert=/etc/pinniped-proxy-tls/ca.crt
             {{- end }}
             {{- end }}
@@ -212,7 +212,7 @@ spec:
             - name: plugins-config
               mountPath: /config/kubeapps-apis
           {{- end }}
-          {{- if .Values.pinnipedProxy.CACert }}
+          {{- if .Values.pinnipedProxy.tls.caCertificate }}
             - name: pinniped-proxy-ca-cert
               mountPath: /etc/pinniped-proxy-tls
           {{- end }}
@@ -235,10 +235,10 @@ spec:
           configMap:
             name: {{ template "kubeapps.kubeappsapis.fullname" . }}-configmap
       {{- end }}
-      {{- if .Values.pinnipedProxy.CACert }}
+      {{- if .Values.pinnipedProxy.tls.caCertificate }}
         - name: pinniped-proxy-ca-cert
           configMap:
-            name: {{ .Values.pinnipedProxy.CACert }}
+            name: {{ .Values.pinnipedProxy.tls.caCertificate }}
       {{- end }}
       {{- if .Values.kubeappsapis.extraVolumes }}
       {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.extraVolumes "context" $) | nindent 8 }}

--- a/chart/kubeapps/templates/kubeops/deployment.yaml
+++ b/chart/kubeapps/templates/kubeops/deployment.yaml
@@ -93,8 +93,8 @@ spec:
             - --clusters-config-path=/config/clusters.conf
             {{- end }}
             {{- if .Values.pinnipedProxy.enabled }}
-            - --pinniped-proxy-url={{ printf "http%s://%s.%s:%d" (eq .Values.pinnipedProxy.CACert "" | ternary "" "s") (include "kubeapps.pinniped-proxy.fullname" .) .Release.Namespace (int .Values.pinnipedProxy.service.ports.pinnipedProxy) }}
-            {{- if .Values.pinnipedProxy.CACert }}
+            - --pinniped-proxy-url={{ printf "http%s://%s.%s:%d" (eq .Values.pinnipedProxy.tls.caCertificate "" | ternary "" "s") (include "kubeapps.pinniped-proxy.fullname" .) .Release.Namespace (int .Values.pinnipedProxy.service.ports.pinnipedProxy) }}
+            {{- if .Values.pinnipedProxy.tls.caCertificate }}
             - --pinniped-proxy-ca-cert=/etc/pinniped-proxy-tls/ca.crt
             {{- end }}
             {{- end }}
@@ -174,7 +174,7 @@ spec:
             {{- if .Values.kubeops.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.kubeops.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
-            {{- if .Values.pinnipedProxy.CACert }}
+            {{- if .Values.pinnipedProxy.tls.caCertificate }}
             - name: pinniped-proxy-ca-cert
               mountPath: /etc/pinniped-proxy-tls
             {{- end }}
@@ -189,10 +189,10 @@ spec:
         - name: ca-certs
           emptyDir: {}
         {{- end }}
-        {{- if .Values.pinnipedProxy.CACert }}
+        {{- if .Values.pinnipedProxy.tls.caCertificate }}
         - name: pinniped-proxy-ca-cert
           configMap:
-            name: {{ .Values.pinnipedProxy.CACert }}
+            name: {{ .Values.pinnipedProxy.tls.caCertificate }}
         {{- end }}
         {{- if .Values.kubeops.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.kubeops.extraVolumes "context" $) | nindent 8 }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1574,27 +1574,30 @@ pinnipedProxy:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-  ## @param pinnipedProxy.defaultPinnipedNamespace Specify the (default) namespace in which pinniped concierge is installed
+  ## @param pinnipedProxy.defaultPinnipedNamespace Namespace in which pinniped concierge is installed
   ##
   defaultPinnipedNamespace: pinniped-concierge
-  ## @param pinnipedProxy.defaultAuthenticatorType Specify the (default) authenticator type
+  ## @param pinnipedProxy.defaultAuthenticatorType Authenticator type
   ##
   defaultAuthenticatorType: JWTAuthenticator
-  ## @param pinnipedProxy.defaultAuthenticatorName Specify the (default) authenticator name
+  ## @param pinnipedProxy.defaultAuthenticatorName Authenticator name
   ##
   defaultAuthenticatorName: jwt-authenticator
-  ## @param pinnipedProxy.defaultPinnipedAPISuffix Specify the (default) API suffix
+  ## @param pinnipedProxy.defaultPinnipedAPISuffix API suffix
   ##
   defaultPinnipedAPISuffix: pinniped.dev
-  ## @param pinnipedProxy.TLSSecret Specify an optional TLS secret with which to proxy requests
+  ## TLS settings for Pinniped Proxy
+  ## @param pinnipedProxy.tls.existingSecret TLS secret with which to proxy requests
+  ## @param pinnipedProxy.tls.caCertificate TLS CA cert config map which clients of pinniped proxy should use with TLS requests
+  ## This config map must contain a ca.crt key with the CA cert content as the value.
   ##
-  TLSSecret: ""
-  ## @param pinnipedProxy.CACert Specify the TLS CA cert config map which
-  ## clients of pinniped proxy should use with tls requests. This config map
-  ## must contain a ca.crt key with the CA cert content as the value.
-  ##
-  CACert: ""
-  ## @param pinnipedProxy.lifecycleHooks for the Pinniped Proxy container(s) to automate configuration before or after startup
+  tls:
+    ## Optional TLS secret with which to proxy requests
+    existingSecret: ""
+    ## TLS CA cert config map which clients of pinniped proxy should use with tls requests.
+    ## This config map must contain a ca.crt key with the CA cert content as the value.
+    caCertificate: ""
+  ## @param pinnipedProxy.lifecycleHooks For the Pinniped Proxy container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
   ## @param pinnipedProxy.command Override default container command (useful when using custom images)

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1587,15 +1587,15 @@ pinnipedProxy:
   ##
   defaultPinnipedAPISuffix: pinniped.dev
   ## TLS settings for Pinniped Proxy
-  ## @param pinnipedProxy.tls.existingSecret TLS secret with which to proxy requests
-  ## @param pinnipedProxy.tls.caCertificate TLS CA cert config map which clients of pinniped proxy should use with TLS requests
-  ## This config map must contain a ca.crt key with the CA cert content as the value.
+  ## ref: https://kubeapps.dev/docs/latest/howto/oidc/using-an-oidc-provider-with-pinniped/#running-the-pinniped-proxy-service-over-tls
   ##
   tls:
-    ## Optional TLS secret with which to proxy requests
+    ## @param pinnipedProxy.tls.existingSecret TLS secret with which to proxy requests
+    ##
     existingSecret: ""
-    ## TLS CA cert config map which clients of pinniped proxy should use with tls requests.
+    ## @param pinnipedProxy.tls.caCertificate TLS CA cert config map which clients of pinniped proxy should use with TLS requests
     ## This config map must contain a ca.crt key with the CA cert content as the value.
+    ##
     caCertificate: ""
   ## @param pinnipedProxy.lifecycleHooks For the Pinniped Proxy container(s) to automate configuration before or after startup
   ##

--- a/site/content/docs/latest/howto/OIDC/using-an-OIDC-provider-with-pinniped.md
+++ b/site/content/docs/latest/howto/OIDC/using-an-OIDC-provider-with-pinniped.md
@@ -144,8 +144,9 @@ and finally configure Kubeapps' `pinniped-proxy` service to use TLS and the back
 
 ```yaml
 pinnipedProxy:
-  tlsSecret: pinniped-proxy-tls
-  CACert: pinniped-proxy-ca
+  tls:
+    existingSecret: pinniped-proxy-tls
+    caCertificate: pinniped-proxy-ca
 ```
 
 Note that this does not eliminate internal clear-text communication of credentials within the cluster because currently the `oauth2-proxy` service communicates with the `kubeapps-apis` backend over http with the user `id_token` in the headers.


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

Renames a couple of chart values regarding TLS for Pinniped proxy.

```
pinnipedProxy.TLSSecret --> pinnipedProxy.tls.existingSecret
pinnipedProxy.CACert    --> pinnipedProxy.tls.caCertificate
```

### Benefits

Kubeapps chart is in line with TLS parameters used by Bitnami.

### Possible drawbacks

N/A

### Applicable issues

- fixes #5191

