### PR TITLE
Fixed Pinniped makefile instructions

### DIFF
--- a/script/makefiles/deploy-dev-for-pinniped.mk
+++ b/script/makefiles/deploy-dev-for-pinniped.mk
@@ -52,7 +52,6 @@ delete-pinniped-jwt-authenticator:
 	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} delete -f ./site/content/docs/latest/reference/manifests/kubeapps-pinniped-jwt-authenticator.yaml
 	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} delete -f ./site/content/docs/latest/reference/manifests/kubeapps-pinniped-jwt-authenticator.yaml
 
-# Using old version for deletion due to error for missing secret "pinniped-concierge-impersonation-proxy" not found
 delete-pinniped:
 	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} delete -f https://get.pinniped.dev/${PINNIPED_VERSION}/install-pinniped-concierge-resources.yaml
 	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} delete -f https://get.pinniped.dev/${PINNIPED_VERSION}/install-pinniped-concierge-crds.yaml

--- a/script/makefiles/deploy-dev-for-pinniped.mk
+++ b/script/makefiles/deploy-dev-for-pinniped.mk
@@ -36,11 +36,11 @@ deploy-dependencies-for-pinniped: deploy-dex-for-pinniped deploy-openldap-for-pi
 
 deploy-pinniped:
 	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/${PINNIPED_VERSION}/install-pinniped-concierge-crds.yaml
-	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/${PINNIPED_VERSION}/install-pinniped-concierge.yaml
+	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/${PINNIPED_VERSION}/install-pinniped-concierge-resources.yaml
 
 deploy-pinniped-additional:
 	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/${PINNIPED_VERSION}/install-pinniped-concierge-crds.yaml
-	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/${PINNIPED_VERSION}/install-pinniped-concierge.yaml
+	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/${PINNIPED_VERSION}/install-pinniped-concierge-resources.yaml
 
 add-pinniped-jwt-authenticator:
 	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} apply -f ./site/content/docs/latest/reference/manifests/kubeapps-pinniped-jwt-authenticator.yaml
@@ -54,8 +54,8 @@ delete-pinniped-jwt-authenticator:
 
 # Using old version for deletion due to error for missing secret "pinniped-concierge-impersonation-proxy" not found
 delete-pinniped:
-	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} delete -f https://get.pinniped.dev/v0.7.0/install-pinniped-concierge.yaml
-	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} delete -f https://get.pinniped.dev/v0.7.0/install-pinniped-concierge.yaml
+	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} delete -f https://get.pinniped.dev/${PINNIPED_VERSION}/install-pinniped-concierge-resources.yaml
+	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} delete -f https://get.pinniped.dev/${PINNIPED_VERSION}/install-pinniped-concierge-crds.yaml
 
 deploy-dev-kubeapps-for-pinniped:
 	helm --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} upgrade --install kubeapps ./chart/kubeapps --namespace kubeapps --create-namespace \


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

Trivial PR fixing the instructions to deploy/undeploy Pinniped that exist in the makefile.
Based on input from [this Pinniped issue.](https://github.com/vmware-tanzu/pinniped/issues/1251#issuecomment-1210935999)

### Benefits

Pinniped can be correctly deployed and undeployed using Makefile.

### Possible drawbacks

N/A

### Applicable issues

- related #5189
