### PR TITLE
Skip re-fetching deleted installedPkgs status

### DIFF
--- a/dashboard/src/actions/installedpackages.test.tsx
+++ b/dashboard/src/actions/installedpackages.test.tsx
@@ -3,41 +3,41 @@
 
 import {
   AvailablePackageDetail,
-  InstalledPackageDetail,
-  InstalledPackageSummary,
   GetInstalledPackageSummariesResponse,
+  InstalledPackageDetail,
   InstalledPackageReference,
   InstalledPackageStatus,
-  VersionReference,
-  ReconciliationOptions,
   InstalledPackageStatus_StatusReason,
+  InstalledPackageSummary,
+  ReconciliationOptions,
+  VersionReference,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
-import configureMockStore from "redux-mock-store";
-import thunk from "redux-thunk";
 import { InstalledPackage } from "shared/InstalledPackage";
-import { IInstalledPackageState, UnprocessableEntity, UpgradeError } from "shared/types";
+import { getStore, initialState } from "shared/specs/mountWrapper";
+import { IStoreState, UnprocessableEntity, UpgradeError } from "shared/types";
 import { PluginNames } from "shared/utils";
 import { getType } from "typesafe-actions";
 import actions from ".";
 
-const mockStore = configureMockStore([thunk]);
-
 let store: any;
 
 beforeEach(() => {
-  const state: IInstalledPackageState = {
-    isFetching: false,
-    items: [],
-  };
-  store = mockStore({
+  store = getStore({
     apps: {
-      state,
+      ...initialState.apps,
+      isFetching: false,
+      items: [],
     },
     config: {
+      ...initialState.config,
       namespace: "kubeapps-ns",
     },
-  });
+    kube: {
+      ...initialState.kube,
+      subscriptions: { "default-c/default-ns/my-release": {} } as any,
+    },
+  } as Partial<IStoreState>);
 });
 
 describe("fetches installed packages", () => {


### PR DESCRIPTION
### Description of the change

This PR adds a check before getting the installed pkg status: "if there is not an active subscription, skip the process". This way, when unmounting components, like when we are deleting a package (we get redirected to the apps view), the fetch won't happen. 

### Benefits

If the app had been deleted, the fetch would have failed, showing an unpleasant error back to the user. 

### Possible drawbacks

N/A

### Applicable issues

- fixes #5205

### Additional information

N/A