### PR TITLE
Add support for setting target architecture for images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,14 @@ GOFMT = /usr/bin/env gofmt
 IMAGE_TAG ?= dev-$(shell date +%FT%H-%M-%S-%Z)
 VERSION ?= $$(git rev-parse HEAD)
 TARGET_ARCHITECTURE ?= amd64
+SUPPORTED_ARCHITECTURES := amd64 arm64 riscv64 ppc64le s390x 386 arm/v7 arm/v6
+
+ifeq ($(filter $(TARGET_ARCHITECTURE),$(SUPPORTED_ARCHITECTURES)),)
+COMMA:=,
+EMPTY:=
+WHITESPACE:=$(EMPTY) $(EMPTY)
+$(error The provided TARGET_ARCHITECTURE '$(TARGET_ARCHITECTURE)' is not supported, provide one of '$(subst $(WHITESPACE),$(COMMA)$(WHITESPACE),$(SUPPORTED_ARCHITECTURES))')
+endif
 
 default: all
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GO = /usr/bin/env go
 GOFMT = /usr/bin/env gofmt
 IMAGE_TAG ?= dev-$(shell date +%FT%H-%M-%S-%Z)
 VERSION ?= $$(git rev-parse HEAD)
+TARGET_ARCHITECTURE ?= amd64
 
 default: all
 
@@ -27,10 +28,10 @@ all: kubeapps/dashboard kubeapps/apprepository-controller kubeapps/kubeops kubea
 # Currently the go projects include the whole repository as the docker context
 # only because the shared pkg/ directories?
 kubeapps/%:
-	DOCKER_BUILDKIT=1 docker build -t kubeapps/$*$(IMG_MODIFIER):$(IMAGE_TAG) --build-arg "VERSION=${VERSION}" -f cmd/$*/Dockerfile .
+	DOCKER_BUILDKIT=1 docker build --platform "linux/$(TARGET_ARCHITECTURE)" -t kubeapps/$*$(IMG_MODIFIER):$(IMAGE_TAG) --build-arg "VERSION=${VERSION}" -f cmd/$*/Dockerfile .
 
 kubeapps/dashboard:
-	docker build -t kubeapps/dashboard$(IMG_MODIFIER):$(IMAGE_TAG) -f dashboard/Dockerfile dashboard/
+	docker build --platform "linux/$(TARGET_ARCHITECTURE)" -t kubeapps/dashboard$(IMG_MODIFIER):$(IMAGE_TAG) -f dashboard/Dockerfile dashboard/
 
 test:
 	$(GO) test $(GO_PACKAGES)


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This PR adds support for specifying the target CPU architecture for the docker images through a parameter in the call to the corresponding make target. This PR doesn't modify the CI, it just adds support for building the docker images for different platforms through `Make`.

### Benefits

Docker images can be built for different CPU architectures (others than AMD64), so developers using computers with those architectures can take advantage of it.

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Helps fix #5208 

### Additional information

N/A
