### PR TITLE
Add types to the state used in tests

### DIFF
--- a/dashboard/src/actions/auth.test.tsx
+++ b/dashboard/src/actions/auth.test.tsx
@@ -6,6 +6,8 @@ import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { Auth } from "shared/Auth";
 import Namespace, * as NS from "shared/Namespace";
+import { initialState } from "shared/specs/mountWrapper";
+import { IStoreState } from "shared/types";
 import { getType } from "typesafe-actions";
 import actions from ".";
 
@@ -35,12 +37,14 @@ beforeEach(() => {
 
   store = mockStore({
     auth: {
+      ...initialState.auth,
       state,
     },
     config: {
+      ...initialState.config,
       oauthLogoutURI: "/log/out",
     },
-  });
+  } as Partial<IStoreState>);
 });
 
 afterEach(() => {

--- a/dashboard/src/actions/availablepackages.test.tsx
+++ b/dashboard/src/actions/availablepackages.test.tsx
@@ -14,7 +14,7 @@ import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import PackagesService from "shared/PackagesService";
-import { FetchError, IReceivePackagesActionPayload } from "shared/types";
+import { FetchError, IReceivePackagesActionPayload, IStoreState } from "shared/types";
 import { getType } from "typesafe-actions";
 import actions from ".";
 
@@ -73,7 +73,7 @@ beforeEach(() => {
     packages: {
       isFetching: false,
     },
-  });
+  } as Partial<IStoreState>);
 });
 
 afterEach(() => {

--- a/dashboard/src/actions/kube.test.tsx
+++ b/dashboard/src/actions/kube.test.tsx
@@ -1,17 +1,17 @@
 // Copyright 2018-2022 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
-import configureMockStore from "redux-mock-store";
-import thunk from "redux-thunk";
-import { Kube } from "shared/Kube";
-import { IKubeState, IResource } from "shared/types";
-import { getType } from "typesafe-actions";
-import actions from ".";
 import {
   InstalledPackageReference,
   ResourceRef as APIResourceRef,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { GetResourcesResponse } from "gen/kubeappsapis/plugins/resources/v1alpha1/resources";
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+import { Kube } from "shared/Kube";
+import { IKubeState, IResource, IStoreState } from "shared/types";
+import { getType } from "typesafe-actions";
+import actions from ".";
 
 const mockStore = configureMockStore([thunk]);
 
@@ -22,7 +22,7 @@ const makeStore = (operatorsEnabled: boolean) => {
     kinds: {},
   };
   const config = operatorsEnabled ? { featureFlags: { operators: true } } : {};
-  return mockStore({ kube: state, config: config });
+  return mockStore({ kube: state, config: config } as Partial<IStoreState>);
 };
 
 let store: any;

--- a/dashboard/src/actions/operators.test.tsx
+++ b/dashboard/src/actions/operators.test.tsx
@@ -4,7 +4,7 @@
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { Operators } from "shared/Operators";
-import { IResource } from "shared/types";
+import { IResource, IStoreState } from "shared/types";
 import { getType } from "typesafe-actions";
 import actions from ".";
 
@@ -14,7 +14,7 @@ const mockStore = configureMockStore([thunk]);
 let store: any;
 
 beforeEach(() => {
-  store = mockStore({});
+  store = mockStore({} as Partial<IStoreState>);
 });
 
 afterEach(jest.restoreAllMocks);

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -24,7 +24,7 @@ import thunk from "redux-thunk";
 import { PackageRepositoriesService } from "shared/PackageRepositoriesService";
 import PackagesService from "shared/PackagesService";
 import { initialState } from "shared/specs/mountWrapper";
-import { IPkgRepoFormData, NotFoundError, RepositoryStorageTypes } from "shared/types";
+import { IPkgRepoFormData, IStoreState, NotFoundError, RepositoryStorageTypes } from "shared/types";
 import { getType } from "typesafe-actions";
 import actions from ".";
 import { convertPkgRepoDetailToSummary } from "./repos";

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -23,6 +23,7 @@ import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { PackageRepositoriesService } from "shared/PackageRepositoriesService";
 import PackagesService from "shared/PackagesService";
+import { initialState } from "shared/specs/mountWrapper";
 import { IPkgRepoFormData, NotFoundError, RepositoryStorageTypes } from "shared/types";
 import { getType } from "typesafe-actions";
 import actions from ".";
@@ -211,14 +212,17 @@ describe("deleteRepo", () => {
     it("dispatches requestRepoSummaries with current namespace", async () => {
       const storeWithFlag: any = mockStore({
         clusters: {
+          ...initialState.clusters,
           currentCluster: "defaultCluster",
           clusters: {
+            ...initialState.clusters.clusters,
             defaultCluster: {
+              ...initialState.clusters.clusters[initialState.clusters.currentCluster],
               currentNamespace,
             },
           },
         },
-      });
+      } as Partial<IStoreState>);
       await storeWithFlag.dispatch(
         repoActions.deleteRepo({
           context: { cluster: "default", namespace: "my-namespace" },

--- a/dashboard/src/components/AppUpgrade/AppUpgrade.test.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.test.tsx
@@ -29,6 +29,7 @@ import {
   FetchError,
   IInstalledPackageState,
   IPackageState,
+  IStoreState,
   UpgradeError,
 } from "shared/types";
 import { PluginNames } from "shared/utils";
@@ -132,7 +133,7 @@ it("renders the repo selection form if not introduced", () => {
     } as IInstalledPackageState,
   };
   const wrapper = mountWrapper(
-    getStore({ ...defaultStore, ...state }),
+    getStore({ ...defaultStore, ...state } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
         <AppUpgrade />,
@@ -157,7 +158,7 @@ it("renders the repo selection form if not introduced when the app is loaded", (
     getStore({
       ...defaultStore,
       ...state,
-    }),
+    } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
         <AppUpgrade />,
@@ -180,7 +181,7 @@ describe("when an error exists", () => {
       getStore({
         ...defaultStore,
         ...state,
-      }),
+      } as Partial<IStoreState>),
       <MemoryRouter initialEntries={[routePathParam]}>
         <Route path={routePath}>
           <AppUpgrade />,
@@ -210,7 +211,7 @@ describe("when an error exists", () => {
       getStore({
         ...defaultStore,
         ...state,
-      }),
+      } as Partial<IStoreState>),
       <MemoryRouter initialEntries={[routePathParam]}>
         <Route path={routePath}>
           <AppUpgrade />,
@@ -238,7 +239,7 @@ describe("when an error exists", () => {
       getStore({
         ...defaultStore,
         ...state,
-      }),
+      } as Partial<IStoreState>),
       <MemoryRouter initialEntries={[routePathParam]}>
         <Route path={routePath}>
           <AppUpgrade />,
@@ -273,7 +274,7 @@ it("renders the upgrade form when the repo is available, clears state and fetche
     getStore({
       ...defaultStore,
       ...state,
-    }),
+    } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
         <AppUpgrade />,
@@ -309,7 +310,7 @@ it("renders the upgrade form with the version property", () => {
     getStore({
       ...defaultStore,
       ...state,
-    }),
+    } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam + "/0.0.1"]}>
       <Route path={routePath + "/:version"}>
         <AppUpgrade />,
@@ -337,7 +338,7 @@ it("skips the repo selection form if the app contains upgrade info", () => {
     getStore({
       ...defaultStore,
       ...state,
-    }),
+    } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
         <AppUpgrade />,

--- a/dashboard/src/components/AppView/AppControls/DeleteButton/DeleteButton.test.tsx
+++ b/dashboard/src/components/AppView/AppControls/DeleteButton/DeleteButton.test.tsx
@@ -14,7 +14,7 @@ import { act } from "react-dom/test-utils";
 import * as ReactRedux from "react-redux";
 import ReactTooltip from "react-tooltip";
 import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
-import { DeleteError } from "shared/types";
+import { DeleteError, IInstalledPackageState, IStoreState } from "shared/types";
 import DeleteButton from "./DeleteButton";
 
 const defaultProps = {
@@ -63,7 +63,9 @@ it("deletes an application", async () => {
 });
 
 it("renders an error", async () => {
-  const store = getStore({ apps: { error: new DeleteError("Boom!") } });
+  const store = getStore({
+    apps: { error: new DeleteError("Boom!") } as Partial<IInstalledPackageState>,
+  } as Partial<IStoreState>);
   const wrapper = mountWrapper(store, <DeleteButton {...defaultProps} />);
   // Open modal
   act(() => {

--- a/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackButton.test.tsx
+++ b/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackButton.test.tsx
@@ -15,7 +15,7 @@ import { act } from "react-dom/test-utils";
 import * as ReactRedux from "react-redux";
 import ReactTooltip from "react-tooltip";
 import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
-import { RollbackError } from "shared/types";
+import { IInstalledPackageState, RollbackError } from "shared/types";
 import RollbackButton from "./RollbackButton";
 
 const defaultProps = {
@@ -70,7 +70,9 @@ it("rolls back an application", async () => {
 });
 
 it("renders an error", async () => {
-  const store = getStore({ apps: { error: new RollbackError("Boom!") } });
+  const store = getStore({
+    apps: { error: new RollbackError("Boom!") },
+  } as Partial<IInstalledPackageState>);
   const wrapper = mountWrapper(store, <RollbackButton {...defaultProps} />);
   // Open modal
   act(() => {

--- a/dashboard/src/components/AppView/AppSecrets/AppSecrets.test.tsx
+++ b/dashboard/src/components/AppView/AppSecrets/AppSecrets.test.tsx
@@ -3,8 +3,8 @@
 
 import { keyForResourceRef } from "shared/ResourceRef";
 import { ResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
-import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
-import { ISecret } from "shared/types";
+import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
+import { ISecret, IStoreState } from "shared/types";
 import SecretItemDatum from "../ResourceTable/ResourceItem/SecretItem/SecretItemDatum";
 import AppSecrets from "./AppSecrets";
 
@@ -38,15 +38,18 @@ it("shows a message if there are no secrets", () => {
 it("renders a secretItemDatum per secret", () => {
   const key = keyForResourceRef(sampleResourceRef);
   const state = getStore({
+    ...initialState,
     kube: {
+      ...initialState.kube,
       items: {
+        ...initialState.kube.items,
         [key]: {
           isFetching: false,
           item: secret,
         },
       },
     },
-  });
+  } as Partial<IStoreState>);
   const wrapper = mountWrapper(state, <AppSecrets secretRefs={[sampleResourceRef]} />);
   expect(wrapper.find(SecretItemDatum)).toHaveLength(2);
 });

--- a/dashboard/src/components/AppView/AppValues/AppValues.test.tsx
+++ b/dashboard/src/components/AppView/AppValues/AppValues.test.tsx
@@ -3,7 +3,8 @@
 
 import AceEditor from "react-ace";
 import { SupportedThemes } from "shared/Config";
-import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
+import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
+import { IStoreState } from "shared/types";
 import AppValues from "./AppValues";
 
 it("includes values", () => {
@@ -26,7 +27,7 @@ it("sets light theme by default", () => {
 
 it("changes theme", () => {
   const wrapper = mountWrapper(
-    getStore({ config: { theme: SupportedThemes.dark } }),
+    getStore({ ...initialState, config: { theme: SupportedThemes.dark } } as Partial<IStoreState>),
     <AppValues values="foo: bar" />,
   );
   expect(wrapper.find(AceEditor).prop("theme")).toBe("solarized_dark");

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -28,7 +28,7 @@ import { IConfigState } from "reducers/config";
 import { InstalledPackage } from "shared/InstalledPackage";
 import PackagesService from "shared/PackagesService";
 import { getStore, mountWrapper } from "shared/specs/mountWrapper";
-import { DeleteError, FetchError, IInstalledPackageState } from "shared/types";
+import { DeleteError, FetchError, IInstalledPackageState, IStoreState } from "shared/types";
 import { PluginNames } from "shared/utils";
 import { getType } from "typesafe-actions";
 import AccessURLTable from "./AccessURLTable/AccessURLTable";
@@ -160,7 +160,7 @@ describe("AppView", () => {
             selected: undefined,
             isFetching: true,
           } as IInstalledPackageState,
-        }),
+        } as Partial<IStoreState>),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <AppView />
@@ -181,7 +181,7 @@ describe("AppView", () => {
             isFetching: false,
             error: new Error("foo not found"),
           } as IInstalledPackageState,
-        }),
+        } as Partial<IStoreState>),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <AppView />
@@ -199,7 +199,9 @@ describe("AppView", () => {
 
     await act(async () => {
       wrapper = mountWrapper(
-        getStore({ apps: { error: new FetchError("boom!") } as IInstalledPackageState }),
+        getStore({
+          apps: { error: new FetchError("boom!") } as IInstalledPackageState,
+        } as Partial<IStoreState>),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <AppView />
@@ -226,7 +228,7 @@ describe("AppView", () => {
               },
             ],
           } as IConfigState,
-        }),
+        } as Partial<IStoreState>),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <AppView />
@@ -252,7 +254,7 @@ describe("AppView", () => {
               },
             ],
           } as IConfigState,
-        }),
+        } as Partial<IStoreState>),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <AppView />
@@ -272,7 +274,7 @@ describe("AppView", () => {
             selected: { ...installedPackage },
             selectedDetails: { ...availablePackageDetail },
           } as IInstalledPackageState,
-        }),
+        } as Partial<IStoreState>),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <AppView />
@@ -297,7 +299,7 @@ describe("AppView", () => {
               } as InstalledPackageReference,
             },
           } as IInstalledPackageState,
-        }),
+        } as Partial<IStoreState>),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <AppView />
@@ -317,7 +319,7 @@ describe("AppView", () => {
       wrapper = mountWrapper(
         getStore({
           apps: { selected: { ...installedPackage } } as IInstalledPackageState,
-        }),
+        } as Partial<IStoreState>),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <AppView />
@@ -351,7 +353,9 @@ describe("AppView", () => {
       let wrapper: any;
       await act(async () => {
         wrapper = mountWrapper(
-          getStore({ apps: { selected: installedPackage } as IInstalledPackageState }),
+          getStore({
+            apps: { selected: installedPackage } as IInstalledPackageState,
+          } as Partial<IStoreState>),
           <MemoryRouter initialEntries={[routePathParam]}>
             <Route path={routePath}>
               <AppView />
@@ -383,7 +387,9 @@ describe("AppView", () => {
       let wrapper: any;
       await act(async () => {
         wrapper = mountWrapper(
-          getStore({ apps: { selected: installedPackage } as IInstalledPackageState }),
+          getStore({
+            apps: { selected: installedPackage } as IInstalledPackageState,
+          } as Partial<IStoreState>),
           <MemoryRouter initialEntries={[routePathParam]}>
             <Route path={routePath}>
               <AppView />
@@ -425,7 +431,7 @@ describe("AppView", () => {
           getStore({
             ...validState,
             apps: { ...validState.apps, error: new Error("Boom!") } as IInstalledPackageState,
-          }),
+          } as Partial<IStoreState>),
           <MemoryRouter initialEntries={[routePathParam]}>
             <Route path={routePath}>
               <AppView />
@@ -445,7 +451,7 @@ describe("AppView", () => {
           getStore({
             ...validState,
             apps: { ...validState.apps, error: new DeleteError("Boom!") } as IInstalledPackageState,
-          }),
+          } as Partial<IStoreState>),
           <MemoryRouter initialEntries={[routePathParam]}>
             <Route path={routePath}>
               <AppView />
@@ -469,7 +475,9 @@ describe("AppView", () => {
     let wrapper: any;
     await act(async () => {
       wrapper = mountWrapper(
-        getStore({ apps: { selected: installedPackage } as IInstalledPackageState }),
+        getStore({
+          apps: { selected: installedPackage } as IInstalledPackageState,
+        } as Partial<IStoreState>),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <AppView />
@@ -499,7 +507,9 @@ describe("AppView actions", () => {
         resourceRefs: apiResourceRefs,
       } as GetInstalledPackageResourceRefsResponse),
     );
-    const store = getStore({ apps: { selected: installedPackage } as IInstalledPackageState });
+    const store = getStore({
+      apps: { selected: installedPackage } as IInstalledPackageState,
+    } as Partial<IStoreState>);
 
     await act(async () => {
       mountWrapper(
@@ -555,7 +565,9 @@ describe("AppView actions", () => {
       } as GetInstalledPackageResourceRefsResponse),
     );
 
-    const store = getStore({ apps: { selected: installedPackage } as IInstalledPackageState });
+    const store = getStore({
+      apps: { selected: installedPackage } as IInstalledPackageState,
+    } as Partial<IStoreState>);
     let wrapper: any;
     await act(async () => {
       wrapper = mountWrapper(

--- a/dashboard/src/components/AppView/CustomAppView/CustomAppView.test.tsx
+++ b/dashboard/src/components/AppView/CustomAppView/CustomAppView.test.tsx
@@ -6,7 +6,8 @@ import {
   AvailablePackageDetail,
   ResourceRef,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
-import { getStore, mountWrapper } from "shared/specs/mountWrapper";
+import { getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
+import { IStoreState } from "shared/types";
 import CustomAppView from ".";
 import { CustomComponent } from "../../../RemoteComponent";
 import { IAppViewResourceRefs } from "../AppView";
@@ -96,8 +97,9 @@ it("should render the remote component with the default URL", () => {
 it("should render the remote component with the URL if set in the config", () => {
   const wrapper = mountWrapper(
     getStore({
+      ...initialState,
       config: { remoteComponentsUrl: "www.thiswebsite.com" },
-    }),
+    } as Partial<IStoreState>),
     <CustomAppView {...defaultProps} />,
   );
   expect(wrapper.find(CustomComponent).prop("url")).toBe("www.thiswebsite.com");

--- a/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
@@ -3,10 +3,10 @@
 
 import Table from "components/js/Table";
 import LoadingWrapper from "components/LoadingWrapper/LoadingWrapper";
-import { keyForResourceRef } from "shared/ResourceRef";
 import { ResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
-import { getStore, mountWrapper } from "shared/specs/mountWrapper";
-import { IResource } from "shared/types";
+import { keyForResourceRef } from "shared/ResourceRef";
+import { getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
+import { IResource, IStoreState } from "shared/types";
 import ResourceTable from "./ResourceTable";
 
 const defaultProps = {
@@ -37,6 +37,7 @@ const deployment = {
 
 it("renders a table with a resource", () => {
   const state = getStore({
+    ...initialState,
     kube: {
       items: {
         [sampleKey]: {
@@ -45,7 +46,7 @@ it("renders a table with a resource", () => {
         },
       },
     },
-  });
+  } as Partial<IStoreState>);
   const wrapper = mountWrapper(
     state,
     <ResourceTable {...defaultProps} resourceRefs={[sampleResourceRef]} />,
@@ -57,6 +58,7 @@ it("renders a table with a resource", () => {
 
 it("renders a table with a loading resource", () => {
   const state = getStore({
+    ...initialState,
     kube: {
       items: {
         [sampleKey]: {
@@ -64,7 +66,7 @@ it("renders a table with a loading resource", () => {
         },
       },
     },
-  });
+  } as Partial<IStoreState>);
   const wrapper = mountWrapper(
     state,
     <ResourceTable {...defaultProps} resourceRefs={[sampleResourceRef]} />,
@@ -78,6 +80,7 @@ it("renders a table with a loading resource", () => {
 
 it("renders a table with an error", () => {
   const state = getStore({
+    ...initialState,
     kube: {
       items: {
         [sampleKey]: {
@@ -86,7 +89,7 @@ it("renders a table with an error", () => {
         },
       },
     },
-  });
+  } as Partial<IStoreState>);
   const wrapper = mountWrapper(
     state,
     <ResourceTable {...defaultProps} resourceRefs={[sampleResourceRef]} />,
@@ -100,6 +103,7 @@ it("renders a table with an error", () => {
 
 it("do not fail if the resources are already populated but the refs not yet", () => {
   const state = getStore({
+    ...initialState,
     kube: {
       items: {
         [sampleKey]: {
@@ -108,7 +112,7 @@ it("do not fail if the resources are already populated but the refs not yet", ()
         },
       },
     },
-  });
+  } as Partial<IStoreState>);
   const wrapper = mountWrapper(state, <ResourceTable {...defaultProps} resourceRefs={[]} />);
   expect(wrapper.find(Table)).not.toExist();
 });

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -8,7 +8,10 @@ import InfoCard from "components/InfoCard/InfoCard";
 import Alert from "components/js/Alert";
 import LoadingWrapper from "components/LoadingWrapper";
 import { AvailablePackageSummary, Context } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
-import { PackageRepositorySummary } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
+import {
+  PackageRepositoryDetail,
+  PackageRepositorySummary,
+} from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
 import { createMemoryHistory } from "history";
 import React from "react";
@@ -91,7 +94,12 @@ const csv = {
 const defaultState = {
   packages: defaultPackageState,
   operators: { csvs: [] } as Partial<IOperatorsState>,
-  repos: { reposSummaries: [] } as Partial<IPackageRepositoryState>,
+  repos: {
+    reposSummaries: [],
+    isFetching: false,
+    repoDetail: {} as PackageRepositoryDetail,
+    errors: [],
+  } as IPackageRepositoryState,
   config: {
     kubeappsCluster: defaultProps.cluster,
     kubeappsNamespace: defaultProps.kubeappsNamespace,
@@ -182,8 +190,8 @@ it("should render a message if there are no elements in the catalog and the fetc
   const wrapper = mountWrapper(
     getStore({
       ...defaultState,
-      packages: { hasFinishedFetching: true } as IPackageState,
-    }),
+      packages: { hasFinishedFetching: true },
+    } as Partial<IStoreState>),
     <Catalog />,
   );
   wrapper.setProps({ searchFilter: "" });
@@ -194,7 +202,7 @@ it("should render a message if there are no elements in the catalog and the fetc
 
 it("should render a spinner if there are no elements but it's still fetching", () => {
   const wrapper = mountWrapper(
-    getStore({ ...defaultState, packages: { hasFinishedFetching: false } }),
+    getStore({ ...defaultState, packages: { hasFinishedFetching: false } } as Partial<IStoreState>),
     <Catalog />,
   );
   expect(wrapper.find(LoadingWrapper)).toExist();
@@ -202,7 +210,7 @@ it("should render a spinner if there are no elements but it's still fetching", (
 
 it("should not render a spinner if there are no elements and it finished fetching", () => {
   const wrapper = mountWrapper(
-    getStore({ ...defaultState, packages: { hasFinishedFetching: true } }),
+    getStore({ ...defaultState, packages: { hasFinishedFetching: true } } as Partial<IStoreState>),
     <Catalog />,
   );
   expect(wrapper.find(LoadingWrapper)).not.toExist();
@@ -210,7 +218,10 @@ it("should not render a spinner if there are no elements and it finished fetchin
 
 it("should render a spinner if there already pending elements", () => {
   const wrapper = mountWrapper(
-    getStore({ ...populatedState, packages: { hasFinishedFetching: false } }),
+    getStore({
+      ...populatedState,
+      packages: { hasFinishedFetching: false },
+    } as Partial<IStoreState>),
     <Catalog />,
   );
   expect(wrapper.find(LoadingWrapper)).toExist();
@@ -218,7 +229,10 @@ it("should render a spinner if there already pending elements", () => {
 
 it("should not render a message if only operators are selected", () => {
   const wrapper = mountWrapper(
-    getStore({ ...populatedState, packages: { hasFinishedFetching: true } }),
+    getStore({
+      ...populatedState,
+      packages: { hasFinishedFetching: true },
+    } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam + "?Operators=bar"]}>
       <Route path={routePath}>
         <Catalog />
@@ -230,7 +244,10 @@ it("should not render a message if only operators are selected", () => {
 
 it("should not render a message if there are no more elements", () => {
   const wrapper = mountWrapper(
-    getStore({ ...populatedState, packages: { hasFinishedFetching: true } }),
+    getStore({
+      ...populatedState,
+      packages: { hasFinishedFetching: true },
+    } as Partial<IStoreState>),
     <Catalog />,
   );
   const message = wrapper.find(".end-page-message");
@@ -239,7 +256,10 @@ it("should not render a message if there are no more elements", () => {
 
 it("should not render a message if there are no more elements but it's searching", () => {
   const wrapper = mountWrapper(
-    getStore({ ...populatedState, packages: { hasFinishedFetching: true } }),
+    getStore({
+      ...populatedState,
+      packages: { hasFinishedFetching: true },
+    } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam + "?Search=bar"]}>
       <Route path={routePath}>
         <Catalog />
@@ -252,7 +272,10 @@ it("should not render a message if there are no more elements but it's searching
 
 it("should render the scroll handler if not finished", () => {
   const wrapper = mountWrapper(
-    getStore({ ...populatedState, packages: { hasFinishedFetching: false } }),
+    getStore({
+      ...populatedState,
+      packages: { hasFinishedFetching: false },
+    } as Partial<IStoreState>),
     <Catalog />,
   );
   const scroll = wrapper.find(".scroll-handler");
@@ -262,7 +285,10 @@ it("should render the scroll handler if not finished", () => {
 
 it("should not render the scroll handler if finished", () => {
   const wrapper = mountWrapper(
-    getStore({ ...populatedState, packages: { hasFinishedFetching: true } }),
+    getStore({
+      ...populatedState,
+      packages: { hasFinishedFetching: true },
+    } as Partial<IStoreState>),
     <Catalog />,
   );
   const scroll = wrapper.find(".scroll-handler");
@@ -703,8 +729,8 @@ describe("filters by package repository", () => {
         ...populatedState,
         repos: {
           reposSummaries: [{ name: "foo" } as PackageRepositorySummary],
-        } as IPackageRepositoryState,
-      }),
+        },
+      } as Partial<IStoreState>),
       <MemoryRouter initialEntries={[routePathParam]}>
         <Route path={routePath}>
           <Catalog />
@@ -733,8 +759,8 @@ describe("filters by package repository", () => {
         ...populatedState,
         repos: {
           reposSummaries: [{ name: "foo" } as PackageRepositorySummary],
-        } as IPackageRepositoryState,
-      }),
+        },
+      } as Partial<IStoreState>),
       <MemoryRouter initialEntries={[`/c/${defaultProps.cluster}/ns/my-ns/catalog`]}>
         <Route path={routePath}>
           <Catalog />
@@ -761,8 +787,8 @@ describe("filters by package repository", () => {
     mountWrapper(
       getStore({
         ...populatedState,
-        repos: { repos: [{ name: "foo" } as PackageRepositorySummary] },
-      }),
+        repos: { ...populatedState.repos, repos: [{ name: "foo" } as PackageRepositorySummary] },
+      } as Partial<IStoreState>),
       <MemoryRouter
         initialEntries={[
           `/c/${defaultProps.cluster}/ns/${initialState.config.globalReposNamespace}/catalog`,
@@ -782,8 +808,8 @@ describe("filters by package repository", () => {
     mountWrapper(
       getStore({
         ...populatedState,
-        repos: { repos: [{ name: "foo" } as PackageRepositorySummary] },
-      }),
+        repos: { ...populatedState.repos, repos: [{ name: "foo" } as PackageRepositorySummary] },
+      } as Partial<IStoreState>),
       <MemoryRouter initialEntries={[`/c/other-cluster/ns/my-ns/catalog`]}>
         <Route path={routePath}>
           <Catalog />
@@ -831,7 +857,7 @@ describe("filters by operator provider", () => {
       getStore({
         ...populatedState,
         operators: { csvs: [csv, csv2] },
-      }),
+      } as Partial<IStoreState>),
       <MemoryRouter initialEntries={[routePathParam]}>
         <Route path={routePath}>
           <Catalog />
@@ -855,7 +881,7 @@ describe("filters by operator provider", () => {
       getStore({
         ...populatedState,
         operators: { csvs: [csv, csv2] },
-      }),
+      } as Partial<IStoreState>),
       <MemoryRouter initialEntries={[routePathParam]}>
         <Route path={routePath}>
           <Catalog />
@@ -879,7 +905,7 @@ describe("filters by operator provider", () => {
       getStore({
         ...populatedState,
         operators: { csvs: [csv, csv2] },
-      }),
+      } as Partial<IStoreState>),
       <MemoryRouter initialEntries={[routePathParam + "?Provider=you"]}>
         <Route path={routePath}>
           <Catalog />
@@ -973,7 +999,10 @@ describe("filters by category", () => {
       },
     } as any;
     const wrapper = mountWrapper(
-      getStore({ ...populatedState, operators: { csvs: [csv, csvWithCat] } }),
+      getStore({
+        ...populatedState,
+        operators: { csvs: [csv, csvWithCat] },
+      } as Partial<IStoreState>),
       <MemoryRouter initialEntries={[routePathParam + "?Category=E-Learning"]}>
         <Route path={routePath}>
           <Catalog />
@@ -994,7 +1023,10 @@ describe("filters by category", () => {
       },
     } as any;
     const wrapper = mountWrapper(
-      getStore({ ...populatedState, operators: { csvs: [csv, csvWithCat] } }),
+      getStore({
+        ...populatedState,
+        operators: { csvs: [csv, csvWithCat] },
+      } as Partial<IStoreState>),
       <MemoryRouter
         initialEntries={[routePathParam + "?Category=Developer%20Tools,Infrastructure"]}
       >

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
@@ -108,7 +108,7 @@ it("disables the submit button while loading", async () => {
       getStore({
         ...defaultState,
         repos: { ...defaultState.repos, isFetching: true } as IPackageRepositoryState,
-      }),
+      } as Partial<IStoreState>),
       <PkgRepoForm {...defaultProps} />,
     );
   });
@@ -155,7 +155,7 @@ it("shows an error creating a repo", async () => {
         repos: {
           errors: { create: new Error("boom!") },
         } as IPackageRepositoryState,
-      }),
+      } as Partial<IStoreState>),
       <PkgRepoForm {...defaultProps} />,
     );
   });
@@ -170,7 +170,7 @@ it("shows an error deleting a repo", async () => {
         repos: {
           errors: { delete: new Error("boom!") },
         } as IPackageRepositoryState,
-      }),
+      } as Partial<IStoreState>),
       <PkgRepoForm {...defaultProps} />,
     );
   });
@@ -185,7 +185,7 @@ it("shows an error fetching a repo", async () => {
         repos: {
           errors: { fetch: new Error("boom!") },
         } as IPackageRepositoryState,
-      }),
+      } as Partial<IStoreState>),
       <PkgRepoForm {...defaultProps} />,
     );
   });
@@ -200,7 +200,7 @@ it("shows an error updating a repo", async () => {
         repos: {
           errors: { update: new Error("boom!") },
         } as IPackageRepositoryState,
-      }),
+      } as Partial<IStoreState>),
       <PkgRepoForm {...defaultProps} />,
     );
   });
@@ -553,7 +553,7 @@ describe("when the repository info is already populated", () => {
         getStore({
           ...defaultState,
           repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-        }),
+        } as Partial<IStoreState>),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
     });
@@ -576,7 +576,7 @@ describe("when the repository info is already populated", () => {
         getStore({
           ...defaultState,
           repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-        }),
+        } as Partial<IStoreState>),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
     });
@@ -604,7 +604,7 @@ describe("when the repository info is already populated", () => {
         getStore({
           ...defaultState,
           repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-        }),
+        } as Partial<IStoreState>),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
     });
@@ -633,7 +633,7 @@ describe("when the repository info is already populated", () => {
         getStore({
           ...defaultState,
           repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-        }),
+        } as Partial<IStoreState>),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
     });
@@ -656,7 +656,7 @@ describe("when the repository info is already populated", () => {
         getStore({
           ...defaultState,
           repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-        }),
+        } as Partial<IStoreState>),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
     });
@@ -679,7 +679,7 @@ describe("when the repository info is already populated", () => {
         getStore({
           ...defaultState,
           repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-        }),
+        } as Partial<IStoreState>),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
     });
@@ -697,7 +697,7 @@ describe("when the repository info is already populated", () => {
         getStore({
           ...defaultState,
           repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-        }),
+        } as Partial<IStoreState>),
         <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
       );
     });
@@ -716,7 +716,7 @@ describe("when the repository info is already populated", () => {
           getStore({
             ...defaultState,
             repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-          }),
+          } as Partial<IStoreState>),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });
@@ -738,7 +738,7 @@ describe("when the repository info is already populated", () => {
           getStore({
             ...defaultState,
             repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-          }),
+          } as Partial<IStoreState>),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });
@@ -763,7 +763,7 @@ describe("when the repository info is already populated", () => {
           getStore({
             ...defaultState,
             repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-          }),
+          } as Partial<IStoreState>),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });
@@ -789,7 +789,7 @@ describe("when the repository info is already populated", () => {
           getStore({
             ...defaultState,
             repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-          }),
+          } as Partial<IStoreState>),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });
@@ -819,7 +819,7 @@ describe("when the repository info is already populated", () => {
           getStore({
             ...defaultState,
             repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-          }),
+          } as Partial<IStoreState>),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });
@@ -849,7 +849,7 @@ describe("when the repository info is already populated", () => {
           getStore({
             ...defaultState,
             repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-          }),
+          } as Partial<IStoreState>),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });
@@ -877,7 +877,7 @@ describe("when the repository info is already populated", () => {
           getStore({
             ...defaultState,
             repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-          }),
+          } as Partial<IStoreState>),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });
@@ -906,7 +906,7 @@ describe("when the repository info is already populated", () => {
           getStore({
             ...defaultState,
             repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
-          }),
+          } as Partial<IStoreState>),
           <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
         );
       });

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoList.test.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoList.test.tsx
@@ -4,18 +4,19 @@
 import actions from "actions";
 import Alert from "components/js/Alert";
 import Table from "components/js/Table";
+import TableRow from "components/js/Table/components/TableRow";
 import Tooltip from "components/js/Tooltip";
 import { PackageRepositorySummary } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
 import { act } from "react-dom/test-utils";
 import * as ReactRedux from "react-redux";
 import { Link } from "react-router-dom";
+import { IPackageRepositoryState } from "reducers/repos";
 import { Kube } from "shared/Kube";
 import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
+import { IStoreState } from "shared/types";
 import { PkgRepoControl } from "./PkgRepoControl";
 import { PkgRepoDisabledControl } from "./PkgRepoDisabledControl";
 import PkgRepoList from "./PkgRepoList";
-import TableRow from "components/js/Table/components/TableRow";
-import { IPackageRepositoryState } from "reducers/repos";
 
 const {
   clusters: { currentCluster, clusters },
@@ -60,7 +61,7 @@ it("fetches repos only from the globalReposNamespace", () => {
           },
         },
       },
-    }),
+    } as Partial<IStoreState>),
     <PkgRepoList />,
   );
   expect(actions.repos.fetchRepoSummaries).toHaveBeenCalledWith("");
@@ -97,7 +98,7 @@ it("shows a warning if the cluster is not the default one", () => {
           },
         },
       },
-    }),
+    } as Partial<IStoreState>),
     <PkgRepoList />,
   );
   expect(wrapper.find(Alert)).toIncludeText(
@@ -107,7 +108,9 @@ it("shows a warning if the cluster is not the default one", () => {
 
 it("shows an error fetching a repo", () => {
   const wrapper = mountWrapper(
-    getStore({ repos: { errors: { fetch: new Error("boom!") } } as IPackageRepositoryState }),
+    getStore({
+      repos: { errors: { fetch: new Error("boom!") } } as IPackageRepositoryState,
+    } as Partial<IStoreState>),
     <PkgRepoList />,
   );
   expect(wrapper.find(Alert)).toIncludeText("boom!");
@@ -115,7 +118,9 @@ it("shows an error fetching a repo", () => {
 
 it("shows an error deleting a repo", () => {
   const wrapper = mountWrapper(
-    getStore({ repos: { errors: { delete: new Error("boom!") } } as IPackageRepositoryState }),
+    getStore({
+      repos: { errors: { delete: new Error("boom!") } } as IPackageRepositoryState,
+    } as Partial<IStoreState>),
     <PkgRepoList />,
   );
   expect(wrapper.find(Alert)).toIncludeText("boom!");
@@ -159,7 +164,7 @@ describe("global and namespaced repositories", () => {
           ...initialState.clusters,
           clusters: {
             [currentCluster]: {
-              ...initialState.clusters.clusters[currentCluster],
+              ...initialState.clusters.clusters[initialState.clusters.currentCluster],
               currentNamespace: "other",
             },
           },
@@ -167,7 +172,7 @@ describe("global and namespaced repositories", () => {
         repos: {
           reposSummaries: [globalRepo],
         } as IPackageRepositoryState,
-      }),
+      } as Partial<IStoreState>),
       <PkgRepoList />,
     );
     expect(wrapper.find(Table)).toHaveLength(1);
@@ -195,7 +200,7 @@ describe("global and namespaced repositories", () => {
         repos: {
           reposSummaries: [globalRepo],
         } as IPackageRepositoryState,
-      }),
+      } as Partial<IStoreState>),
       <PkgRepoList />,
     );
 
@@ -228,7 +233,7 @@ describe("global and namespaced repositories", () => {
         repos: {
           reposSummaries: [globalRepo, namespacedRepo],
         } as IPackageRepositoryState,
-      }),
+      } as Partial<IStoreState>),
       <PkgRepoList />,
     );
     // A table per repository type
@@ -241,7 +246,7 @@ describe("global and namespaced repositories", () => {
         repos: {
           reposSummaries: [namespacedRepo],
         } as IPackageRepositoryState,
-      }),
+      } as Partial<IStoreState>),
       <PkgRepoList />,
     );
     expect(wrapper.find(Table).find(Link).prop("to")).toEqual(
@@ -255,7 +260,7 @@ describe("global and namespaced repositories", () => {
         repos: {
           reposSummaries: [namespacedRepo],
         } as IPackageRepositoryState,
-      }),
+      } as Partial<IStoreState>),
       <PkgRepoList />,
     );
     act(() => {
@@ -271,7 +276,7 @@ describe("global and namespaced repositories", () => {
         repos: {
           reposSummaries: [namespacedRepo],
         } as IPackageRepositoryState,
-      }),
+      } as Partial<IStoreState>),
       <PkgRepoList />,
     );
     act(() => {

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -76,7 +76,7 @@ it("fetches the available versions", () => {
   actions.availablepackages.fetchAndSelectAvailablePackageDetail = fetchAvailablePackageVersions;
 
   mountWrapper(
-    getStore({}),
+    getStore({} as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
         <DeploymentForm />
@@ -102,7 +102,7 @@ describe("renders an error", () => {
           selected: { ...defaultSelectedPkg },
         },
         apps: { error: new Error("wrong format!") },
-      }),
+      } as Partial<IStoreState>),
       <Router history={history}>
         <Route path={routePath}>
           <DeploymentForm />
@@ -121,7 +121,7 @@ describe("renders an error", () => {
       getStore({
         packages: { selected: { ...defaultSelectedPkg, error: new FetchError("not found") } },
         apps: { error: undefined },
-      }),
+      } as Partial<IStoreState>),
       <Router history={history}>
         <Route path={routePath}>
           <DeploymentForm />

--- a/dashboard/src/components/DeploymentFormBody/AdvancedDeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/AdvancedDeploymentForm.test.tsx
@@ -4,6 +4,7 @@
 import AceEditor from "react-ace";
 import { SupportedThemes } from "shared/Config";
 import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
+import { IStoreState } from "shared/types";
 import AdvancedDeploymentForm from "./AdvancedDeploymentForm";
 
 const defaultProps = {
@@ -25,7 +26,7 @@ it("sets light theme by default", () => {
 
 it("changes theme", () => {
   const wrapper = mountWrapper(
-    getStore({ config: { theme: SupportedThemes.dark } }),
+    getStore({ config: { theme: SupportedThemes.dark } } as Partial<IStoreState>),
     <AdvancedDeploymentForm {...defaultProps} />,
   );
   expect(wrapper.find(AceEditor).prop("theme")).toBe("solarized_dark");

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getStore, mountWrapper } from "shared/specs/mountWrapper";
-import { IBasicFormParam } from "shared/types";
+import { IBasicFormParam, IStoreState } from "shared/types";
 import { CustomComponent } from "../../../RemoteComponent";
 import CustomFormComponentLoader from "./CustomFormParam";
 
@@ -71,7 +71,7 @@ it("should render the remote component with the URL if set in the config", () =>
   const wrapper = mountWrapper(
     getStore({
       config: { remoteComponentsUrl: "www.thiswebsite.com" },
-    }),
+    } as Partial<IStoreState>),
     <CustomFormComponentLoader {...defaultProps} />,
   );
   expect(wrapper.find(CustomComponent).prop("url")).toBe("www.thiswebsite.com");

--- a/dashboard/src/components/DeploymentFormBody/Differential.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/Differential.test.tsx
@@ -4,6 +4,7 @@
 import ReactDiffViewer from "react-diff-viewer";
 import { SupportedThemes } from "shared/Config";
 import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
+import { IStoreState } from "shared/types";
 import Differential from "./Differential";
 
 it("should render a diff between two strings", () => {
@@ -37,7 +38,7 @@ it("sets light theme by default", () => {
 
 it("changes theme", () => {
   const wrapper = mountWrapper(
-    getStore({ config: { theme: SupportedThemes.dark } }),
+    getStore({ config: { theme: SupportedThemes.dark } } as Partial<IStoreState>),
     <Differential oldValues="foo" newValues="bar" emptyDiffElement={<span>empty</span>} />,
   );
   expect(wrapper.find(ReactDiffViewer).prop("useDarkTheme")).toBe(true);

--- a/dashboard/src/components/HeadManager/HeadManager.test.tsx
+++ b/dashboard/src/components/HeadManager/HeadManager.test.tsx
@@ -7,6 +7,7 @@ import { Helmet } from "react-helmet";
 import * as ReactRedux from "react-redux";
 import { SupportedThemes } from "shared/Config";
 import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
+import { IStoreState } from "shared/types";
 import HeadManager from "./HeadManager";
 
 let spyOnUseDispatch: jest.SpyInstance;
@@ -40,7 +41,7 @@ it("should use the light theme by default", () => {
 
 it("should use the dark theme", () => {
   mountWrapper(
-    getStore({ config: { theme: SupportedThemes.dark } }),
+    getStore({ config: { theme: SupportedThemes.dark } } as Partial<IStoreState>),
     <HeadManager>
       <></>
     </HeadManager>,

--- a/dashboard/src/components/Header/ContextSelector.test.tsx
+++ b/dashboard/src/components/Header/ContextSelector.test.tsx
@@ -13,6 +13,7 @@ import * as ReactRouter from "react-router";
 import { Router } from "react-router-dom";
 import { IClustersState } from "reducers/cluster";
 import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
+import { IStoreState } from "shared/types";
 import ContextSelector from "./ContextSelector";
 
 let spyOnUseDispatch: jest.SpyInstance;
@@ -97,14 +98,14 @@ it("shows the current cluster", () => {
       },
     },
   } as IClustersState;
-  const wrapper = mountWrapper(getStore({ clusters }), <ContextSelector />);
+  const wrapper = mountWrapper(getStore({ clusters } as Partial<IStoreState>), <ContextSelector />);
   expect(wrapper.find("select").at(0).prop("value")).toBe("bar");
 });
 
 it("shows the current namespace", () => {
   const clusters = cloneDeep(initialState.clusters);
   clusters.clusters[clusters.currentCluster].currentNamespace = "other";
-  const wrapper = mountWrapper(getStore({ clusters }), <ContextSelector />);
+  const wrapper = mountWrapper(getStore({ clusters } as Partial<IStoreState>), <ContextSelector />);
   expect(wrapper.find("select").at(1).prop("value")).toBe("other");
 });
 
@@ -141,7 +142,7 @@ it("submits the form to create a new namespace with custom labels", () => {
   config.createNamespaceLabels = {
     "managed-by": "kubeapps",
   };
-  const wrapper = mountWrapper(getStore({ config }), <ContextSelector />);
+  const wrapper = mountWrapper(getStore({ config } as Partial<IStoreState>), <ContextSelector />);
 
   const modalButton = wrapper.find(".flat-btn").first();
   act(() => {
@@ -169,7 +170,7 @@ it("shows an error creating a namespace", () => {
   const clusters = cloneDeep(initialState.clusters);
   clusters.clusters[clusters.currentCluster].error = { error: new Error("Boom"), action: "create" };
 
-  const wrapper = mountWrapper(getStore({ clusters }), <ContextSelector />);
+  const wrapper = mountWrapper(getStore({ clusters } as Partial<IStoreState>), <ContextSelector />);
 
   const modalButton = wrapper.find(".flat-btn").first();
   act(() => {
@@ -192,7 +193,7 @@ it("disables the create button if not allowed", () => {
       },
     },
   } as IClustersState;
-  const wrapper = mountWrapper(getStore({ clusters }), <ContextSelector />);
+  const wrapper = mountWrapper(getStore({ clusters } as Partial<IStoreState>), <ContextSelector />);
   expect(wrapper.find(".flat-btn").first()).toBeDisabled();
 });
 
@@ -207,7 +208,7 @@ it("disables the change context button if namespace is not loaded yet", () => {
       },
     },
   } as IClustersState;
-  const wrapper = mountWrapper(getStore({ clusters }), <ContextSelector />);
+  const wrapper = mountWrapper(getStore({ clusters } as Partial<IStoreState>), <ContextSelector />);
   expect(wrapper.find(CdsButton).filterWhere(b => b.text() === "Change Context")).toBeDisabled();
 });
 

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -4,7 +4,8 @@
 import actions from "actions";
 import * as ReactRedux from "react-redux";
 import { NavLink } from "react-router-dom";
-import { getStore, mountWrapper } from "shared/specs/mountWrapper";
+import { getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
+import { IStoreState } from "shared/types";
 import { app } from "shared/url";
 import Header from "./Header";
 
@@ -25,18 +26,22 @@ afterEach(() => {
 });
 
 const defaultState = {
+  ...initialState,
   clusters: {
+    ...initialState.clusters,
     currentCluster: "default",
     clusters: {
+      ...initialState.clusters.clusters,
       default: {
+        ...initialState.clusters.clusters[initialState.clusters.currentCluster],
         currentNamespace: "default",
         namespaces: ["default", "other"],
       },
     },
   },
-  auth: { authenticated: true },
-  config: { appVersion: "v2.0.0" },
-};
+  auth: { ...initialState.auth, authenticated: true },
+  config: { ...initialState.config, appVersion: "v2.0.0" },
+} as IStoreState;
 
 it("fetch namespaces and the ability to create them", () => {
   mountWrapper(getStore(defaultState), <Header />);
@@ -63,7 +68,7 @@ it("should skip the links if it's not authenticated", () => {
     getStore({
       ...defaultState,
       auth: { authenticated: false },
-    }),
+    } as Partial<IStoreState>),
     <Header />,
   );
   const items = wrapper.find(".nav-link");
@@ -75,15 +80,18 @@ it("should skip the links if the namespace info is not available", () => {
     getStore({
       ...defaultState,
       clusters: {
+        ...initialState.clusters,
         currentCluster: "default",
         clusters: {
+          ...initialState.clusters.clusters,
           default: {
+            ...initialState.clusters.clusters[initialState.clusters.currentCluster],
             currentNamespace: "",
             namespaces: [],
           },
         },
       },
-    }),
+    } as Partial<IStoreState>),
     <Header />,
   );
   const items = wrapper.find(".nav-link");

--- a/dashboard/src/components/Header/Menu.test.tsx
+++ b/dashboard/src/components/Header/Menu.test.tsx
@@ -94,7 +94,7 @@ describe("theme switcher toggle", () => {
 
   it("toggle checked if dark theme is configured", () => {
     const wrapper = mountWrapper(
-      getStore({ config: { theme: SupportedThemes.dark } }),
+      getStore({ config: { theme: SupportedThemes.dark } } as Partial<IStoreState>),
       <Menu {...defaultProps} />,
     );
     const toggle = wrapper.find("cds-toggle input");

--- a/dashboard/src/components/LoginForm/LoginForm.test.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.test.tsx
@@ -5,7 +5,9 @@ import LoadingWrapper from "components/LoadingWrapper";
 import { Location } from "history";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter, Redirect } from "react-router-dom";
+import { IConfigState } from "reducers/config";
 import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
+import { IStoreState } from "shared/types";
 import LoginForm from "./LoginForm";
 import OAuthLogin from "./OauthLogin";
 import TokenLogin from "./TokenLogin";
@@ -191,9 +193,12 @@ describe("oauth login form", () => {
       ...defaultStore,
       config: {
         authProxyEnabled: true,
-      },
+      } as IConfigState,
     };
-    const wrapper = mountWrapper(getStore({ ...state }), <LoginForm {...props} />);
+    const wrapper = mountWrapper(
+      getStore({ ...state } as Partial<IStoreState>),
+      <LoginForm {...props} />,
+    );
     expect(props.checkCookieAuthentication).toHaveBeenCalled();
     expect(wrapper.find(OAuthLogin)).toExist();
     expect(wrapper.find("a").findWhere(a => a.prop("href") === props.oauthLoginURI)).toExist();
@@ -204,7 +209,7 @@ describe("oauth login form", () => {
       ...defaultStore,
       config: {
         authProxyEnabled: true,
-      },
+      } as IConfigState,
     };
     const props2 = {
       ...props,
@@ -212,7 +217,10 @@ describe("oauth login form", () => {
         then: jest.fn(() => false),
       }),
     };
-    const wrapper = mountWrapper(getStore({ ...state }), <LoginForm {...props2} />);
+    const wrapper = mountWrapper(
+      getStore({ ...state } as Partial<IStoreState>),
+      <LoginForm {...props2} />,
+    );
     expect(wrapper.find(LoadingWrapper)).toExist();
     expect(wrapper.find(OAuthLogin)).not.toExist();
   });

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
@@ -16,7 +16,7 @@ import ApplicationStatusContainer from "containers/ApplicationStatusContainer";
 import { act } from "react-dom/test-utils";
 import * as ReactRedux from "react-redux";
 import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
-import { FetchError } from "shared/types";
+import { FetchError, IStoreState } from "shared/types";
 import OperatorInstance from "./OperatorInstance";
 
 const defaultProps = {
@@ -71,10 +71,12 @@ afterEach(() => {
 it("renders a fetch error", () => {
   const wrapper = mountWrapper(
     getStore({
+      ...initialState,
       operators: {
-        errors: { resource: { fetch: new FetchError("Boom!") } },
+        ...initialState.operators,
+        errors: { ...initialState.operators.errors, resource: { fetch: new FetchError("Boom!") } },
       },
-    }),
+    } as Partial<IStoreState>),
     <OperatorInstance {...defaultProps} />,
   );
   expect(wrapper.find(Alert)).toIncludeText("Boom!");
@@ -88,7 +90,7 @@ it("renders an update error", () => {
         csv: defaultCSV,
         errors: { resource: { update: new Error("Boom!") } },
       },
-    }),
+    } as Partial<IStoreState>),
     <OperatorInstance {...defaultProps} />,
   );
   expect(wrapper.find(Alert)).toIncludeText("Boom!");
@@ -101,7 +103,7 @@ it("renders an delete error", () => {
         csv: defaultCSV,
         errors: { resource: { update: new Error("Boom!") } },
       },
-    }),
+    } as Partial<IStoreState>),
     <OperatorInstance {...defaultProps} />,
   );
   expect(wrapper.find(Alert)).toIncludeText("Boom!");
@@ -129,7 +131,7 @@ it("retrieves CSV and resource when mounted", () => {
 
 it("renders a loading wrapper", () => {
   const wrapper = mountWrapper(
-    getStore({ operators: { isFetching: true } }),
+    getStore({ operators: { isFetching: true } } as Partial<IStoreState>),
     <OperatorInstance {...defaultProps} />,
   );
   expect(wrapper.find(LoadingWrapper)).toExist();
@@ -137,7 +139,7 @@ it("renders a loading wrapper", () => {
 
 it("renders all the subcomponents", () => {
   const wrapper = mountWrapper(
-    getStore({ operators: { csv: defaultCSV, resource } }),
+    getStore({ operators: { csv: defaultCSV, resource } } as Partial<IStoreState>),
     <OperatorInstance {...defaultProps} />,
   );
   expect(wrapper.find(ApplicationStatusContainer)).toExist();
@@ -152,7 +154,7 @@ it("skips AppNotes and AppValues if the resource doesn't have spec or status", (
   const wrapper = mountWrapper(
     getStore({
       operators: { csv: defaultCSV, resource: { ...resource, spec: undefined, status: undefined } },
-    }),
+    } as Partial<IStoreState>),
     <OperatorInstance {...defaultProps} />,
   );
   expect(wrapper.find(AppNotes)).not.toExist();
@@ -163,7 +165,7 @@ it("deletes the resource", async () => {
   const deleteResource = jest.fn().mockReturnValue(true);
   actions.operators.deleteResource = deleteResource;
   const wrapper = mountWrapper(
-    getStore({ operators: { csv: defaultCSV, resource } }),
+    getStore({ operators: { csv: defaultCSV, resource } } as Partial<IStoreState>),
     <OperatorInstance {...defaultProps} />,
   );
 
@@ -192,9 +194,13 @@ it("deletes the resource", async () => {
 it("updates the state with the CRD resources", () => {
   const wrapper = mountWrapper(
     getStore({
-      operators: { csv: defaultCSV, resource },
-      kube: { kinds: { Foo: { apiVersion: "apps/v1", plural: "foos", namespaced: true } } },
-    }),
+      ...initialState,
+      operators: { ...initialState.operators, csv: defaultCSV, resource },
+      kube: {
+        ...initialState.kube,
+        kinds: { Foo: { apiVersion: "apps/v1", plural: "foos", namespaced: true } },
+      },
+    } as Partial<IStoreState>),
     <OperatorInstance {...defaultProps} />,
   );
   expect(wrapper.find(ResourceTabs).prop("deployments")).toMatchObject([
@@ -232,9 +238,13 @@ it("updates the state with all the resources if the CRD doesn't define any", () 
   } as any;
   const wrapper = mountWrapper(
     getStore({
-      operators: { csv: csvWithoutResource, resource },
-      kube: { kinds: { Foo: { apiVersion: "apps/v1", plural: "foos", namespaced: true } } },
-    }),
+      ...initialState,
+      operators: { ...initialState.operators, csv: csvWithoutResource, resource },
+      kube: {
+        ...initialState.kube,
+        kinds: { Foo: { apiVersion: "apps/v1", plural: "foos", namespaced: true } },
+      },
+    } as Partial<IStoreState>),
     <OperatorInstance {...defaultProps} />,
   );
   const resources = wrapper.find(ResourceTabs).props();

--- a/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.test.tsx
+++ b/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.test.tsx
@@ -9,7 +9,7 @@ import OperatorHeader from "components/OperatorView/OperatorHeader";
 import { act } from "react-dom/test-utils";
 import * as ReactRedux from "react-redux";
 import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
-import { FetchError, IClusterServiceVersion } from "shared/types";
+import { FetchError, IClusterServiceVersion, IStoreState } from "shared/types";
 import OperatorInstanceForm, { IOperatorInstanceFormProps } from "./OperatorInstanceForm";
 
 const defaultProps: IOperatorInstanceFormProps = {
@@ -57,10 +57,12 @@ afterEach(() => {
 it("renders a fetch error", () => {
   const wrapper = mountWrapper(
     getStore({
+      ...initialState,
       operators: {
-        errors: { csv: { fetch: new FetchError("Boom!") } },
+        ...initialState.operators,
+        errors: { ...initialState.operators.errors, csv: { fetch: new FetchError("Boom!") } },
       },
-    }),
+    } as Partial<IStoreState>),
     <OperatorInstanceForm {...defaultProps} />,
   );
   expect(wrapper.find(Alert)).toIncludeText("Boom!");
@@ -74,7 +76,7 @@ it("renders a create error", () => {
         csv: defaultCSV,
         errors: { resource: { create: new Error("Boom!") } },
       },
-    }),
+    } as Partial<IStoreState>),
     <OperatorInstanceForm {...defaultProps} />,
   );
   expect(wrapper.find(Alert)).toIncludeText("Boom!");
@@ -93,7 +95,7 @@ it("retrieves CSV when mounted", () => {
 
 it("retrieves the example values and the target CRD from the given CSV", () => {
   const wrapper = mountWrapper(
-    getStore({ operators: { csv: defaultCSV } }),
+    getStore({ operators: { csv: defaultCSV } } as Partial<IStoreState>),
     <OperatorInstanceForm {...defaultProps} />,
   );
   expect(wrapper.find(OperatorInstanceFormBody).props()).toMatchObject({
@@ -107,7 +109,7 @@ it("defaults to empty defaultValues if the examples annotation is not found", ()
     metadata: {},
   } as IClusterServiceVersion;
   const wrapper = mountWrapper(
-    getStore({ operators: { csv } }),
+    getStore({ operators: { csv } } as Partial<IStoreState>),
     <OperatorInstanceForm {...defaultProps} />,
   );
   expect(wrapper.find(OperatorInstanceFormBody).props()).toMatchObject({
@@ -124,7 +126,7 @@ it("should submit the form", () => {
   const createResource = jest.fn();
   actions.operators.createResource = createResource;
   const wrapper = mountWrapper(
-    getStore({ operators: { csv: defaultCSV } }),
+    getStore({ operators: { csv: defaultCSV } } as Partial<IStoreState>),
     <OperatorInstanceForm {...defaultProps} />,
   );
 

--- a/dashboard/src/components/OperatorInstanceUpdateForm/OperatorInstanceUpdateForm.test.tsx
+++ b/dashboard/src/components/OperatorInstanceUpdateForm/OperatorInstanceUpdateForm.test.tsx
@@ -7,7 +7,7 @@ import OperatorInstanceFormBody from "components/OperatorInstanceFormBody/Operat
 import OperatorHeader from "components/OperatorView/OperatorHeader";
 import * as ReactRedux from "react-redux";
 import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
-import { FetchError } from "shared/types";
+import { FetchError, IStoreState } from "shared/types";
 import OperatorInstanceUpdateForm, {
   IOperatorInstanceUpgradeFormProps,
 } from "./OperatorInstanceUpdateForm";
@@ -91,7 +91,7 @@ it("set default and deployed values", () => {
         resource: defaultResource,
         csv: defaultCSV,
       },
-    }),
+    } as Partial<IStoreState>),
     <OperatorInstanceUpdateForm {...defaultProps} />,
   );
   expect(wrapper.find(OperatorInstanceFormBody).props()).toMatchObject({
@@ -108,12 +108,15 @@ it("renders an error if the resource is not populated", () => {
 it("renders only an error if the resource is not found", () => {
   const wrapper = mountWrapper(
     getStore({
+      ...initialState,
       operators: {
+        ...initialState.operators,
         errors: {
+          ...initialState.operators.errors,
           fetch: new FetchError("not found"),
         },
       },
-    }),
+    } as Partial<IStoreState>),
     <OperatorInstanceUpdateForm {...defaultProps} />,
   );
   expect(wrapper.find(Alert)).toIncludeText("not found");
@@ -129,7 +132,7 @@ it("should submit the form", () => {
         resource: defaultResource,
         csv: defaultCSV,
       },
-    }),
+    } as Partial<IStoreState>),
     <OperatorInstanceUpdateForm {...defaultProps} />,
   );
 

--- a/dashboard/src/components/OperatorList/OperatorList.test.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.test.tsx
@@ -8,7 +8,7 @@ import SearchFilter from "components/SearchFilter/SearchFilter";
 import { act } from "react-dom/test-utils";
 import * as ReactRedux from "react-redux";
 import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
-import { IPackageManifest } from "shared/types";
+import { IPackageManifest, IStoreState } from "shared/types";
 import InfoCard from "../InfoCard/InfoCard";
 import { AUTO_PILOT, BASIC_INSTALL } from "../OperatorView/OperatorCapabilityLevel";
 import OLMNotFound from "./OLMNotFound";
@@ -71,7 +71,10 @@ const sampleSubscription = {
 
 it("renders a LoadingWrapper if fetching", () => {
   const wrapper = mountWrapper(
-    getStore({ operators: { isFetcing: true } }),
+    getStore({
+      ...initialState,
+      operators: { ...initialState.operators, isFetcing: true },
+    } as Partial<IStoreState>),
     <OperatorList {...defaultProps} />,
   );
   expect(wrapper.find(LoadingWrapper)).toExist();
@@ -89,7 +92,7 @@ it("renders an error", () => {
   const wrapper = mountWrapper(
     getStore({
       operators: { isOLMInstalled: true, errors: { operator: { fetch: new Error("Forbidden!") } } },
-    }),
+    } as Partial<IStoreState>),
     <OperatorList {...defaultProps} />,
   );
   const error = wrapper.find(Alert).filterWhere(a => a.prop("theme") === "danger");
@@ -101,7 +104,7 @@ it("request operators if the OLM is installed", () => {
   const getOperators = jest.fn();
   actions.operators.getOperators = getOperators;
   const wrapper = mountWrapper(
-    getStore({ operators: { isOLMInstalled: true } }),
+    getStore({ operators: { isOLMInstalled: true } } as Partial<IStoreState>),
     <OperatorList {...defaultProps} />,
   );
   wrapper.setProps({ namespace: "other" });
@@ -110,7 +113,9 @@ it("request operators if the OLM is installed", () => {
 
 it("render the operator list", () => {
   const wrapper = mountWrapper(
-    getStore({ operators: { isOLMInstalled: true, operators: [sampleOperator] } }),
+    getStore({
+      operators: { isOLMInstalled: true, operators: [sampleOperator] },
+    } as Partial<IStoreState>),
     <OperatorList {...defaultProps} />,
   );
   expect(wrapper.find(OLMNotFound)).not.toExist();
@@ -125,7 +130,7 @@ it("render the operator list with installed operators", () => {
         operators: [sampleOperator],
         subscriptions: [sampleSubscription],
       },
-    }),
+    } as Partial<IStoreState>),
     <OperatorList {...defaultProps} />,
   );
   expect(wrapper.find(OLMNotFound)).not.toExist();
@@ -140,7 +145,9 @@ it("render the operator list with installed operators", () => {
 
 it("render the operator list without installed operators", () => {
   const wrapper = mountWrapper(
-    getStore({ operators: { isOLMInstalled: true, operators: [sampleOperator] } }),
+    getStore({
+      operators: { isOLMInstalled: true, operators: [sampleOperator] },
+    } as Partial<IStoreState>),
     <OperatorList {...defaultProps} />,
   );
   expect(wrapper.find(OLMNotFound)).not.toExist();
@@ -179,7 +186,7 @@ describe("filter operators", () => {
     const wrapper = mountWrapper(
       getStore({
         operators: { isOLMInstalled: true, operators: [sampleOperator, sampleOperator2] },
-      }),
+      } as Partial<IStoreState>),
       <OperatorList {...defaultProps} />,
     );
     expect(wrapper.find(InfoCard).length).toBe(2);
@@ -196,7 +203,7 @@ describe("filter operators", () => {
     const wrapper = mountWrapper(
       getStore({
         operators: { isOLMInstalled: true, operators: [sampleOperator, sampleOperator2] },
-      }),
+      } as Partial<IStoreState>),
       <OperatorList {...defaultProps} filter={{ [filterNames.SEARCH]: "foo" }} />,
     );
     const operator = wrapper.find(InfoCard);
@@ -208,7 +215,7 @@ describe("filter operators", () => {
     const wrapper = mountWrapper(
       getStore({
         operators: { isOLMInstalled: true, operators: [sampleOperator, sampleOperator2] },
-      }),
+      } as Partial<IStoreState>),
       <OperatorList {...defaultProps} filter={{ [filterNames.PROVIDER]: "kubeapps__%20inc" }} />,
     );
     expect(wrapper.find(".label-info").text()).toBe("Provider: kubeapps,%20inc ");
@@ -218,7 +225,7 @@ describe("filter operators", () => {
     const wrapper = mountWrapper(
       getStore({
         operators: { isOLMInstalled: true, operators: [sampleOperator, sampleOperator2] },
-      }),
+      } as Partial<IStoreState>),
       <OperatorList {...defaultProps} filter={{ [filterNames.SEARCH]: "nope" }} />,
     );
     expect(wrapper.find(InfoCard)).not.toExist();
@@ -229,7 +236,7 @@ describe("filter operators", () => {
     const wrapper = mountWrapper(
       getStore({
         operators: { isOLMInstalled: true, operators: [sampleOperator, sampleOperator2] },
-      }),
+      } as Partial<IStoreState>),
       <OperatorList {...defaultProps} filter={{ [filterNames.CATEGORY]: "security" }} />,
     );
     const operator = wrapper.find(InfoCard);
@@ -241,7 +248,7 @@ describe("filter operators", () => {
     const wrapper = mountWrapper(
       getStore({
         operators: { isOLMInstalled: true, operators: [sampleOperator, sampleOperator2] },
-      }),
+      } as Partial<IStoreState>),
       <OperatorList {...defaultProps} filter={{ [filterNames.CAPABILITY]: BASIC_INSTALL }} />,
     );
     const operator = wrapper.find(InfoCard);

--- a/dashboard/src/components/OperatorNew/OperatorNew.test.tsx
+++ b/dashboard/src/components/OperatorNew/OperatorNew.test.tsx
@@ -6,6 +6,7 @@ import actions from "actions";
 import Alert from "components/js/Alert";
 import * as ReactRedux from "react-redux";
 import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
+import { IStoreState } from "shared/types";
 import OperatorNew from "./OperatorNew";
 
 const defaultProps = {
@@ -79,7 +80,7 @@ it("calls getOperator when mounting the component", () => {
 
 it("parses the default channel when receiving the operator", () => {
   const wrapper = mountWrapper(
-    getStore({ operators: { operator: defaultOperator } }),
+    getStore({ operators: { operator: defaultOperator } } as Partial<IStoreState>),
     <OperatorNew {...defaultProps} />,
   );
   const input = wrapper.find("#operator-channel-beta");
@@ -89,7 +90,9 @@ it("parses the default channel when receiving the operator", () => {
 
 it("renders a fetch error if present", () => {
   const wrapper = mountWrapper(
-    getStore({ operators: { errors: { operator: { fetch: new Error("Boom") } } } }),
+    getStore({
+      operators: { errors: { operator: { fetch: new Error("Boom") } } },
+    } as Partial<IStoreState>),
     <OperatorNew {...defaultProps} />,
   );
   expect(wrapper.find(Alert)).toIncludeText("Boom");
@@ -97,7 +100,9 @@ it("renders a fetch error if present", () => {
 
 it("renders a create error if present", () => {
   const wrapper = mountWrapper(
-    getStore({ operators: { errors: { operator: { create: new Error("Boom") } } } }),
+    getStore({
+      operators: { errors: { operator: { create: new Error("Boom") } } },
+    } as Partial<IStoreState>),
     <OperatorNew {...defaultProps} />,
   );
   expect(wrapper.find(Alert)).toIncludeText("Boom");
@@ -105,12 +110,17 @@ it("renders a create error if present", () => {
 
 it("shows an error if the operator doesn't have any channel defined", () => {
   const operator = {
+    ...initialState.operators.operator,
     status: {
+      ...initialState.operators.operator?.status,
       channels: [],
     },
   };
   const wrapper = mountWrapper(
-    getStore({ operators: { operator } }),
+    getStore({
+      ...initialState,
+      operators: { ...initialState.operators, operator },
+    } as Partial<IStoreState>),
     <OperatorNew {...defaultProps} />,
   );
   expect(wrapper.find(Alert)).toIncludeText(
@@ -120,7 +130,7 @@ it("shows an error if the operator doesn't have any channel defined", () => {
 
 it("disables the submit button if the operators ns is selected", () => {
   const wrapper = mountWrapper(
-    getStore({ operators: { operator: defaultOperator } }),
+    getStore({ operators: { operator: defaultOperator } } as Partial<IStoreState>),
     <OperatorNew {...defaultProps} namespace="operators" />,
   );
   expect(wrapper.find(CdsButton)).toBeDisabled();
@@ -132,7 +142,7 @@ it("disables the submit button if the operators ns is selected", () => {
 it("deploys an operator", async () => {
   const createOperator = jest.fn().mockReturnValue(true);
   actions.operators.createOperator = createOperator;
-  const store = getStore({ operators: { operator: defaultOperator } });
+  const store = getStore({ operators: { operator: defaultOperator } } as Partial<IStoreState>);
 
   const wrapper = mountWrapper(store, <OperatorNew {...defaultProps} />);
   const onSubmit = wrapper.find("form").prop("onSubmit") as () => Promise<void>;

--- a/dashboard/src/components/OperatorSummary/OperatorSummary.test.tsx
+++ b/dashboard/src/components/OperatorSummary/OperatorSummary.test.tsx
@@ -5,6 +5,7 @@ import Alert from "components/js/Alert";
 import LoadingWrapper from "components/LoadingWrapper/LoadingWrapper";
 import { cloneDeep } from "lodash";
 import { getStore, mountWrapper } from "shared/specs/mountWrapper";
+import { IStoreState } from "shared/types";
 import OperatorSummary from "./OperatorSummary";
 
 const defaultOperator = {
@@ -39,7 +40,10 @@ const defaultOperator = {
 } as any;
 
 it("shows a loading wrapper", () => {
-  const wrapper = mountWrapper(getStore({ operators: { isFetching: true } }), <OperatorSummary />);
+  const wrapper = mountWrapper(
+    getStore({ operators: { isFetching: true } } as Partial<IStoreState>),
+    <OperatorSummary />,
+  );
   expect(wrapper.find(LoadingWrapper)).toExist();
 });
 
@@ -47,7 +51,7 @@ it("shows an alert if the operator doesn't have a channel", () => {
   const operatorWithoutChannel = cloneDeep(defaultOperator);
   operatorWithoutChannel.status.channels = [];
   const wrapper = mountWrapper(
-    getStore({ operators: { operator: operatorWithoutChannel } }),
+    getStore({ operators: { operator: operatorWithoutChannel } } as Partial<IStoreState>),
     <OperatorSummary />,
   );
   expect(wrapper.find(Alert)).toExist();
@@ -57,7 +61,7 @@ it("doesn't fail with missing info", () => {
   const operatorWithoutAnnotations = cloneDeep(defaultOperator);
   delete operatorWithoutAnnotations.status.channels[0].currentCSVDesc.annotations;
   const wrapper = mountWrapper(
-    getStore({ operators: { operator: operatorWithoutAnnotations } }),
+    getStore({ operators: { operator: operatorWithoutAnnotations } } as Partial<IStoreState>),
     <OperatorSummary />,
   );
   expect(wrapper.find(".left-menu")).toExist();
@@ -65,7 +69,7 @@ it("doesn't fail with missing info", () => {
 
 it("shows all the operator info", () => {
   const wrapper = mountWrapper(
-    getStore({ operators: { operator: defaultOperator } }),
+    getStore({ operators: { operator: defaultOperator } } as Partial<IStoreState>),
     <OperatorSummary />,
   );
   expect(wrapper.find(".left-menu-subsection")).toHaveLength(5);

--- a/dashboard/src/components/OperatorView/OperatorView.test.tsx
+++ b/dashboard/src/components/OperatorView/OperatorView.test.tsx
@@ -6,6 +6,7 @@ import actions from "actions";
 import Alert from "components/js/Alert";
 import * as ReactRedux from "react-redux";
 import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
+import { IStoreState } from "shared/types";
 import OperatorDescription from "./OperatorDescription";
 import OperatorView from "./OperatorView";
 
@@ -78,7 +79,7 @@ it("tries to get the CSV for the current operator", () => {
   const getCSV = jest.fn();
   actions.operators.getCSV = getCSV;
   mountWrapper(
-    getStore({ operators: { operator: defaultOperator } }),
+    getStore({ operators: { operator: defaultOperator } } as Partial<IStoreState>),
     <OperatorView {...defaultProps} />,
   );
 
@@ -91,7 +92,9 @@ it("tries to get the CSV for the current operator", () => {
 
 it("shows an error if it exists", () => {
   const wrapper = mountWrapper(
-    getStore({ operators: { errors: { operator: { fetch: new Error("boom") } } } }),
+    getStore({
+      operators: { errors: { operator: { fetch: new Error("boom") } } },
+    } as Partial<IStoreState>),
     <OperatorView {...defaultProps} />,
   );
   expect(wrapper.find(Alert)).toIncludeText("boom");
@@ -99,12 +102,17 @@ it("shows an error if it exists", () => {
 
 it("shows an error if the operator doesn't have any channel defined", () => {
   const operator = {
+    ...initialState.operators.operator,
     status: {
+      ...initialState.operators.operator?.status,
       channels: [],
     },
   };
   const wrapper = mountWrapper(
-    getStore({ operators: { operator } }),
+    getStore({
+      ...initialState,
+      operators: { ...initialState.operators, operator },
+    } as Partial<IStoreState>),
     <OperatorView {...defaultProps} />,
   );
   expect(wrapper.find(Alert)).toIncludeText(
@@ -121,7 +129,7 @@ it("selects the default channel", () => {
     },
   };
   const wrapper = mountWrapper(
-    getStore({ operators: { operator } }),
+    getStore({ operators: { operator } } as Partial<IStoreState>),
     <OperatorView {...defaultProps} />,
   );
   expect(wrapper.find(OperatorDescription).prop("description")).toEqual(
@@ -136,7 +144,7 @@ it("disables the Header deploy button if the subscription already exists", () =>
         operator: defaultOperator,
         subscriptions: [{ spec: { name: defaultOperator.metadata.name } }],
       },
-    }),
+    } as Partial<IStoreState>),
     <OperatorView {...defaultProps} />,
   );
   wrapper.find(CdsButton).forEach(button => expect(button).toBeDisabled());

--- a/dashboard/src/components/SelectRepoForm/SelectRepoForm.test.tsx
+++ b/dashboard/src/components/SelectRepoForm/SelectRepoForm.test.tsx
@@ -10,6 +10,7 @@ import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
 import * as ReactRedux from "react-redux";
 import { IPackageRepositoryState } from "reducers/repos";
 import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
+import { IStoreState } from "shared/types";
 import SelectRepoForm from "./SelectRepoForm";
 
 const defaultContext = {
@@ -63,7 +64,7 @@ it("should fetch repositories", () => {
 it("should render a loading page if fetching", () => {
   expect(
     mountWrapper(
-      getStore({ repos: { isFetching: true } }),
+      getStore({ repos: { isFetching: true } } as Partial<IStoreState>),
       <SelectRepoForm {...defaultContext} />,
     ).find("LoadingWrapper"),
   ).toExist();
@@ -71,7 +72,7 @@ it("should render a loading page if fetching", () => {
 
 it("render an error if failed to request repos", () => {
   const wrapper = mountWrapper(
-    getStore({ repos: { errors: { fetch: new Error("boom") } } }),
+    getStore({ repos: { errors: { fetch: new Error("boom") } } } as Partial<IStoreState>),
     <SelectRepoForm {...defaultContext} />,
   );
   expect(wrapper.find(Alert)).toIncludeText("boom");
@@ -97,7 +98,9 @@ it("should select a repo", () => {
 
   const props = { ...defaultContext, app: installedPackageDetail };
   const wrapper = mountWrapper(
-    getStore({ repos: { reposSummaries: [repo] } as IPackageRepositoryState }),
+    getStore({
+      repos: { reposSummaries: [repo] } as IPackageRepositoryState,
+    } as Partial<IStoreState>),
     <SelectRepoForm {...props} />,
   );
   wrapper.find("select").simulate("change", { target: { value: "default/bitnami" } });

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import actions from "actions";
-import { cloneDeep } from "lodash";
 import DeploymentFormBody from "components/DeploymentFormBody/DeploymentFormBody";
 import Alert from "components/js/Alert";
 import LoadingWrapper from "components/LoadingWrapper/LoadingWrapper";
-import PackageVersionSelector from "components/PackageHeader/PackageVersionSelector";
 import PackageHeader from "components/PackageHeader/PackageHeader";
+import PackageVersionSelector from "components/PackageHeader/PackageVersionSelector";
 import {
   AvailablePackageDetail,
   AvailablePackageReference,
@@ -20,6 +19,7 @@ import {
   VersionReference,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
+import { cloneDeep } from "lodash";
 import { act } from "react-dom/test-utils";
 import * as ReactRedux from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
@@ -30,6 +30,7 @@ import {
   FetchError,
   IInstalledPackageState,
   IPackageState,
+  IStoreState,
 } from "shared/types";
 import * as url from "shared/url";
 import UpgradeForm from "./UpgradeForm";
@@ -121,11 +122,11 @@ describe("it behaves like a loading component", () => {
       ...defaultStore,
       apps: {
         isFetching: true,
-      } as IPackageState,
+      } as IInstalledPackageState,
     };
     expect(
       mountWrapper(
-        getStore({ ...state }),
+        getStore({ ...state } as Partial<IStoreState>),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <UpgradeForm />,
@@ -144,7 +145,7 @@ describe("it behaves like a loading component", () => {
     };
     expect(
       mountWrapper(
-        getStore({ ...state }),
+        getStore({ ...state } as Partial<IStoreState>),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <UpgradeForm />,
@@ -164,7 +165,7 @@ describe("it behaves like a loading component", () => {
     };
     expect(
       mountWrapper(
-        getStore({ ...state }),
+        getStore({ ...state } as Partial<IStoreState>),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <UpgradeForm />,
@@ -186,7 +187,7 @@ describe("it behaves like a loading component", () => {
 
     expect(
       mountWrapper(
-        getStore({ ...state }),
+        getStore({ ...state } as Partial<IStoreState>),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <UpgradeForm />,
@@ -210,7 +211,7 @@ it("fetches the available versions", () => {
     } as IInstalledPackageState,
   };
   mountWrapper(
-    getStore({ ...state }),
+    getStore({ ...state } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
         <UpgradeForm />,
@@ -240,7 +241,7 @@ it("hides the PackageVersionSelector in the PackageHeader", () => {
     } as IPackageState,
   };
   const wrapper = mountWrapper(
-    getStore({ ...state }),
+    getStore({ ...state } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
         <UpgradeForm />,
@@ -266,7 +267,7 @@ it("does not fetch the current package version if there is already one in the st
     } as IPackageState,
   };
   mountWrapper(
-    getStore({ ...state }),
+    getStore({ ...state } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
         <UpgradeForm />,
@@ -300,7 +301,7 @@ describe("renders an error", () => {
     };
 
     const wrapper = mountWrapper(
-      getStore({ ...state }),
+      getStore({ ...state } as Partial<IStoreState>),
       <MemoryRouter initialEntries={[routePathParam]}>
         <Route path={routePath}>
           <UpgradeForm />,
@@ -328,7 +329,7 @@ it("empty values applied is allowed", () => {
   };
 
   const wrapper = mountWrapper(
-    getStore({ ...state }),
+    getStore({ ...state } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
         <UpgradeForm />,
@@ -355,7 +356,7 @@ it("defaults the upgrade version to the current version", () => {
   };
 
   const wrapper = mountWrapper(
-    getStore({ ...state }),
+    getStore({ ...state } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
         <UpgradeForm />,
@@ -388,7 +389,7 @@ it("uses the selected version passed in the component's props", () => {
   };
 
   mountWrapper(
-    getStore({ ...state }),
+    getStore({ ...state } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam + "/1.5.0"]}>
       <Route path={routePath + "/:version"}>
         <UpgradeForm version={"1.5.0"} />,
@@ -422,7 +423,7 @@ it("forwards the appValues when modified", () => {
     } as IPackageState,
   };
   const wrapper = mountWrapper(
-    getStore({ ...state }),
+    getStore({ ...state } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
         <UpgradeForm />,
@@ -461,9 +462,7 @@ it("triggers an upgrade when submitting the form", async () => {
   };
 
   const wrapper = mountWrapper(
-    getStore({
-      ...state,
-    }),
+    getStore({ ...state } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
         <UpgradeForm />,
@@ -516,9 +515,7 @@ describe("when receiving new props", () => {
     };
 
     const wrapper = mountWrapper(
-      getStore({
-        ...state,
-      }),
+      getStore({ ...state } as Partial<IStoreState>),
       <MemoryRouter initialEntries={[routePathParam]}>
         <Route path={routePath}>
           <UpgradeForm />,
@@ -547,9 +544,7 @@ describe("when receiving new props", () => {
       } as IPackageState,
     };
     const wrapper = mountWrapper(
-      getStore({
-        ...state,
-      }),
+      getStore({ ...state } as Partial<IStoreState>),
       <MemoryRouter initialEntries={[routePathParam]}>
         <Route path={routePath}>
           <UpgradeForm />,
@@ -574,9 +569,7 @@ describe("when receiving new props", () => {
       } as IPackageState,
     };
     const wrapper = mountWrapper(
-      getStore({
-        ...state,
-      }),
+      getStore({ ...state }),
       <MemoryRouter initialEntries={[routePathParam]}>
         <Route path={routePath}>
           <UpgradeForm />,
@@ -698,9 +691,7 @@ describe("when receiving new props", () => {
       };
 
       const wrapper = mountWrapper(
-        getStore({
-          ...newState,
-        }),
+        getStore({ ...newState }),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <UpgradeForm />,
@@ -730,9 +721,7 @@ it("shows, by default, the default values of the deployed package plus any modif
     } as IPackageState,
   };
   const wrapper = mountWrapper(
-    getStore({
-      ...state,
-    }),
+    getStore({ ...state } as Partial<IStoreState>),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
         <UpgradeForm />,

--- a/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
+++ b/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
@@ -7,7 +7,7 @@ import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { keyForResourceRef } from "shared/ResourceRef";
 import { ResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
-import { IKubeItem, IKubeState, IResource } from "shared/types";
+import { IKubeItem, IKubeState, IResource, IStoreState } from "shared/types";
 import AccessURLTableContainer from ".";
 import AccessURLTable from "../../components/AppView/AccessURLTable";
 
@@ -19,7 +19,7 @@ const makeStore = (resources: { [s: string]: IKubeItem<IResource> }) => {
     kinds: initialKinds,
     subscriptions: {},
   };
-  return mockStore({ kube: state, config: { featureFlags: {} } });
+  return mockStore({ kube: state, config: { featureFlags: {} } } as Partial<IStoreState>);
 };
 
 describe("AccessURLTableContainer", () => {

--- a/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
+++ b/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { shallow } from "enzyme";
+import { ResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { initialKinds } from "reducers/kube";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { keyForResourceRef } from "shared/ResourceRef";
-import { IKubeItem, IKubeState, IResource } from "shared/types";
+import { IKubeItem, IKubeState, IResource, IStoreState } from "shared/types";
 import ApplicationStatusContainer from ".";
 import ApplicationStatus from "../../components/ApplicationStatus";
-import { ResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 
 const mockStore = configureMockStore([thunk]);
 
@@ -19,7 +19,7 @@ const makeStore = (resources: { [s: string]: IKubeItem<IResource> }) => {
     kinds: initialKinds,
     subscriptions: {},
   };
-  return mockStore({ kube: state, config: { featureFlags: {} } });
+  return mockStore({ kube: state, config: { featureFlags: {} } } as Partial<IStoreState>);
 };
 
 describe("ApplicationStatusContainer", () => {

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
@@ -9,6 +9,7 @@ import { IConfigState } from "reducers/config";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { SupportedThemes } from "shared/Config";
+import { IStoreState } from "shared/types";
 import LoginForm from "./LoginFormContainer";
 
 const mockStore = configureMockStore([thunk]);
@@ -58,7 +59,7 @@ const makeStore = (
       },
     },
   };
-  return mockStore({ auth, config, clusters });
+  return mockStore({ auth, config, clusters } as Partial<IStoreState>);
 };
 
 const emptyLocation: Location = {

--- a/dashboard/src/shared/AxiosInstance.test.ts
+++ b/dashboard/src/shared/AxiosInstance.test.ts
@@ -7,10 +7,12 @@ import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { addAuthHeaders, addErrorHandling, axios } from "shared/AxiosInstance";
 import { Auth } from "./Auth";
+import { initialState } from "./specs/mountWrapper";
 import {
   ConflictError,
   ForbiddenError,
   InternalServerError,
+  IStoreState,
   NotFoundError,
   UnauthorizedError,
   UnprocessableEntity,
@@ -33,9 +35,10 @@ describe("createAxiosInterceptorWithAuth", () => {
 
     store = mockStore({
       auth: {
+        ...initialState.auth,
         state,
       },
-    });
+    } as Partial<IStoreState>);
 
     Auth.validateToken = jest.fn();
     Auth.setAuthToken = jest.fn();


### PR DESCRIPTION
### Description of the change

This PR simply adds types to the state variables used along the UI test suite. Sometimes, we add some properties (or we miss others) that don't really belong to the state type definition. Without a type declaration, we don't get any warning in the IDE. This PR is to fix this. 

### Benefits

Type-related warnings when adding wrong fields to the state vars used in the tests

### Possible drawbacks

N/A

### Applicable issues

- slightly related #5121 

### Additional information

N/A