### PR TITLE
Changes to support OCI with flux in the UI

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -329,7 +329,7 @@ describe("fetchRepoSummaries", () => {
       },
       {
         type: getType(repoActions.requestRepoSummaries),
-        payload: globalReposNamespace,
+        payload: "",
       },
       {
         type: getType(repoActions.receiveRepoSummaries),
@@ -367,7 +367,7 @@ describe("fetchRepoSummaries", () => {
       },
       {
         type: getType(repoActions.requestRepoSummaries),
-        payload: globalReposNamespace,
+        payload: "",
       },
       {
         type: getType(repoActions.receiveRepoSummaries),

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -23,7 +23,9 @@ import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { PackageRepositoriesService } from "shared/PackageRepositoriesService";
 import PackagesService from "shared/PackagesService";
-import { IPkgRepoFormData, NotFoundError, RepositoryStorageTypes } from "shared/types";
+import { initialState } from "shared/specs/mountWrapper";
+import { IPkgRepoFormData, IStoreState, NotFoundError, RepositoryStorageTypes } from "shared/types";
+import { PluginNames } from "shared/utils";
 import { getType } from "typesafe-actions";
 import actions from ".";
 import { convertPkgRepoDetailToSummary } from "./repos";
@@ -32,7 +34,10 @@ const { repos: repoActions } = actions;
 const mockStore = configureMockStore([thunk]);
 
 let store: any;
-const plugin = { name: "my.plugin", version: "0.0.1" } as Plugin;
+const plugin = { name: PluginNames.PACKAGES_HELM, version: "0.0.1" } as Plugin;
+const fluxPlugin = { name: PluginNames.PACKAGES_FLUX, version: "v1beta1" } as Plugin;
+const carvelPlugin = { name: PluginNames.PACKAGES_KAPP, version: "v1beta1" } as Plugin;
+
 const packageRepoRef = {
   identifier: "repo-abc",
   context: { cluster: "default", namespace: "default" },
@@ -64,19 +69,29 @@ const packageRepositoryDetail = {
 
 const kubeappsNamespace = "kubeapps-namespace";
 const globalReposNamespace = "kubeapps-repos-global";
+const carvelGlobalNamespace = "carvel-repos-global";
 
 beforeEach(() => {
   store = mockStore({
-    config: { kubeappsNamespace, globalReposNamespace },
+    config: {
+      ...initialState.config,
+      kubeappsNamespace,
+      globalReposNamespace,
+      carvelGlobalNamespace,
+    },
     clusters: {
+      ...initialState.clusters,
       currentCluster: "default",
       clusters: {
+        ...initialState.clusters.clusters,
         default: {
+          ...initialState.clusters.clusters[initialState.clusters.currentCluster],
           currentNamespace: kubeappsNamespace,
         },
       },
     },
-  });
+  } as Partial<IStoreState>);
+
   PackageRepositoriesService.getPackageRepositorySummaries = jest
     .fn()
     .mockImplementationOnce(() => {
@@ -488,6 +503,42 @@ describe("addRepo", () => {
     it("returns true (addRepoCMDAuth)", async () => {
       const res = await store.dispatch(addRepoCMDAuth);
       expect(res).toBe(true);
+    });
+
+    it("sets flux repos as global", async () => {
+      await store.dispatch(
+        repoActions.addRepo("my-namespace", {
+          ...pkgRepoFormData,
+          plugin: fluxPlugin as Plugin,
+        }),
+      );
+      expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
+        "default",
+        "my-namespace",
+        {
+          ...pkgRepoFormData,
+          plugin: fluxPlugin,
+        },
+        false,
+      );
+    });
+
+    it("sets carvel repos as global if using the carvelGlobalNamespace", async () => {
+      await store.dispatch(
+        repoActions.addRepo(carvelGlobalNamespace, {
+          ...pkgRepoFormData,
+          plugin: carvelPlugin as Plugin,
+        }),
+      );
+      expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
+        "default",
+        carvelGlobalNamespace,
+        {
+          ...pkgRepoFormData,
+          plugin: carvelPlugin,
+        },
+        false,
+      );
     });
   });
 

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -139,12 +139,7 @@ export const addRepo = (
     } = getState();
     try {
       dispatch(addOrUpdateRepo());
-      // TODO(agamez): improve the global/namespaced repos UX
-      // to avoid hacks like this (flux repos are always global)
-      // https://github.com/vmware-tanzu/kubeapps/issues/2995
-      const namespaceScoped =
-        !isGlobalNamespace(namespace, request.plugin?.name, config) &&
-        request.plugin?.name !== PluginNames.PACKAGES_FLUX;
+      const namespaceScoped = !isGlobalNamespace(namespace, request.plugin?.name, config);
       const addPackageRepositoryResponse = await PackageRepositoriesService.addPackageRepository(
         currentCluster,
         namespace,

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -69,7 +69,7 @@ export const fetchRepoSummaries = (
   return async (dispatch, getState) => {
     const {
       clusters: { currentCluster },
-      config: { globalReposNamespace },
+      config: { globalReposNamespace, carvelGlobalNamespace },
     } = getState();
     try {
       dispatch(requestRepoSummaries(namespace));
@@ -77,12 +77,14 @@ export const fetchRepoSummaries = (
         cluster: currentCluster,
         namespace: namespace,
       });
-      if (!listGlobal || namespace === globalReposNamespace) {
+      if (!listGlobal || [globalReposNamespace, carvelGlobalNamespace].includes(namespace)) {
         dispatch(receiveRepoSummaries(repos.packageRepositorySummaries));
       } else {
         // Global repos need to be added
+        // instead of passing each global repo's namespace, we defer the decision to the backend using ns=""
+        // however, this can cause issues when using unprivileged users, see #5215
         let totalRepos = repos.packageRepositorySummaries;
-        dispatch(requestRepoSummaries(globalReposNamespace));
+        dispatch(requestRepoSummaries(""));
         const globalRepos = await PackageRepositoriesService.getPackageRepositorySummaries({
           cluster: currentCluster,
           namespace: "",

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -15,7 +15,7 @@ import { ThunkAction } from "redux-thunk";
 import { PackageRepositoriesService } from "shared/PackageRepositoriesService";
 import PackagesService from "shared/PackagesService";
 import { IPkgRepoFormData, IStoreState, NotFoundError } from "shared/types";
-import { isGlobalNamespace } from "shared/utils";
+import { isGlobalNamespace, PluginNames } from "shared/utils";
 import { ActionType, deprecated } from "typesafe-actions";
 
 const { createAction } = deprecated;
@@ -139,7 +139,12 @@ export const addRepo = (
     } = getState();
     try {
       dispatch(addOrUpdateRepo());
-      const namespaceScoped = !isGlobalNamespace(namespace, request.plugin?.name, config);
+      // TODO(agamez): improve the global/namespaced repos UX
+      // to avoid hacks like this (flux repos are always global)
+      // https://github.com/vmware-tanzu/kubeapps/issues/2995
+      const namespaceScoped =
+        !isGlobalNamespace(namespace, request.plugin?.name, config) &&
+        request.plugin?.name !== PluginNames.PACKAGES_FLUX;
       const addPackageRepositoryResponse = await PackageRepositoriesService.addPackageRepository(
         currentCluster,
         namespace,

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -15,7 +15,7 @@ import { ThunkAction } from "redux-thunk";
 import { PackageRepositoriesService } from "shared/PackageRepositoriesService";
 import PackagesService from "shared/PackagesService";
 import { IPkgRepoFormData, IStoreState, NotFoundError } from "shared/types";
-import { isGlobalNamespace, PluginNames } from "shared/utils";
+import { isGlobalNamespace } from "shared/utils";
 import { ActionType, deprecated } from "typesafe-actions";
 
 const { createAction } = deprecated;

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -88,7 +88,13 @@ export default function Catalog() {
     },
     operators,
     repos: { reposSummaries: repos },
-    config: { appVersion, kubeappsCluster, globalReposNamespace, featureFlags },
+    config: {
+      appVersion,
+      kubeappsCluster,
+      globalReposNamespace,
+      carvelGlobalNamespace,
+      featureFlags,
+    },
   } = useSelector((state: IStoreState) => state);
   const { cluster, namespace } = ReactRouter.useParams() as IRouteParams;
   const location = ReactRouter.useLocation();
@@ -240,7 +246,11 @@ export default function Catalog() {
   // We do not currently support package repositories on additional clusters.
   const supportedCluster = cluster === kubeappsCluster;
   useEffect(() => {
-    if (!namespace || !supportedCluster || namespace === globalReposNamespace) {
+    if (
+      !namespace ||
+      !supportedCluster ||
+      [globalReposNamespace, carvelGlobalNamespace].includes(namespace)
+    ) {
       // All Namespaces. Global namespace or other cluster, show global repos only
       dispatch(actions.repos.fetchRepoSummaries(""));
       return () => {};
@@ -248,7 +258,7 @@ export default function Catalog() {
     // In other case, fetch global and namespace repos
     dispatch(actions.repos.fetchRepoSummaries(namespace, true));
     return () => {};
-  }, [dispatch, supportedCluster, namespace, globalReposNamespace]);
+  }, [dispatch, supportedCluster, namespace, globalReposNamespace, carvelGlobalNamespace]);
 
   useEffect(() => {
     // Ignore operators if specified

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
@@ -717,8 +717,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                             id="kubeapps-repo-type-oci"
                             type="radio"
                             name="type"
-                            // TODO(agamez): workaround until Flux plugin also supports OCI artifacts
-                            disabled={plugin?.name === PluginNames.PACKAGES_FLUX || !!repo?.type}
+                            disabled={!!repo?.type}
                             value={RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI || ""}
                             checked={type === RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI}
                             onChange={handleTypeRadioButtonChange}
@@ -1664,35 +1663,34 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
             id="panel-filtering"
             expanded={accordion[2]}
             hidden={
-              type !== RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI &&
+              type !== RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI ||
               plugin?.name !== PluginNames.PACKAGES_HELM
             }
           >
             <CdsAccordionHeader onClick={() => toggleAccordion(2)}>Filtering</CdsAccordionHeader>
             <CdsAccordionContent>
               <CdsFormGroup layout="vertical">
-                {type === RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI && (
-                  <CdsTextarea>
-                    <label htmlFor="kubeapps-oci-repositories">
-                      List of Repositories (required)
-                    </label>
-                    <CdsControlMessage>
-                      Include a list of comma-separated OCI repositories that will be available in
-                      Kubeapps.
-                    </CdsControlMessage>
-                    <textarea
-                      id="kubeapps-oci-repositories"
-                      className="cds-textarea-fix"
-                      placeholder={"nginx, jenkins"}
-                      value={ociRepositories || ""}
-                      onChange={handleOCIRepositoriesChange}
-                      required={type === RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI}
-                    />
-                  </CdsTextarea>
-                )}
-                {/* TODO(agamez): workaround until Flux plugin also supports OCI artifacts */}
                 {plugin?.name === PluginNames.PACKAGES_HELM && (
                   <>
+                    {type === RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI && (
+                      <CdsTextarea>
+                        <label htmlFor="kubeapps-oci-repositories">
+                          List of Repositories (required)
+                        </label>
+                        <CdsControlMessage>
+                          Include a list of comma-separated OCI repositories that will be available
+                          in Kubeapps.
+                        </CdsControlMessage>
+                        <textarea
+                          id="kubeapps-oci-repositories"
+                          className="cds-textarea-fix"
+                          placeholder={"nginx, jenkins"}
+                          value={ociRepositories || ""}
+                          onChange={handleOCIRepositoriesChange}
+                          required={type === RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI}
+                        />
+                      </CdsTextarea>
+                    )}
                     <CdsTextarea>
                       <label htmlFor="kubeapps-repo-filter-repositories">
                         Filter Applications (optional)

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
@@ -278,10 +278,10 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
       ? ociRepositories?.split(",").map(r => r.trim())
       : [];
 
-    // If the scheme is not specified, assume HTTPS. This is common for OCI registries
-    // unless using the kapp plugin, which explicitly should not include https:// protocol prefix
+    // In the Helm plugin, if the scheme is not specified, assume HTTPS (also for OCI registries)
+    // Other plugins don't allow passing a scheme (eg. carvel) and others require a different one (eg. flux: oci://)
     let finalURL = url;
-    if (plugin?.name !== PluginNames.PACKAGES_KAPP && !url?.startsWith("http")) {
+    if (plugin?.name === PluginNames.PACKAGES_HELM && !url?.startsWith("http")) {
       finalURL = `https://${url}`;
     }
 

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
@@ -150,7 +150,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
   const [filterRegex, setFilterRegex] = useState(false);
 
   // -- Advanced  variables --
-  const [interval, setInterval] = useState(initialInterval);
+  const [syncInterval, setSyncInterval] = useState(initialInterval);
   const [performValidation, setPerformValidation] = useState(true);
   const [customCA, setCustomCA] = useState("");
   const [skipTLS, setSkipTLS] = useState(!!repo?.tlsConfig?.insecureSkipVerify);
@@ -186,7 +186,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
       setDescription(repo.description);
       setSkipTLS(!!repo.tlsConfig?.insecureSkipVerify);
       setPassCredentials(!!repo.auth?.passCredentials);
-      setInterval(repo.interval);
+      setSyncInterval(repo.interval);
       setCustomCA(repo.tlsConfig?.certAuthority || "");
       setAuthCustomHeader(repo.auth?.header || "");
       setBearerToken(repo.auth?.header || "");
@@ -329,7 +329,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
         password: !isUserManagedSecret ? secretPassword : "",
         server: !isUserManagedSecret ? secretServer : "",
       } as DockerCredentials,
-      interval,
+      interval: syncInterval,
       name,
       passCredentials,
       plugin,
@@ -378,7 +378,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
     setDescription(e.target.value);
   };
   const handleIntervalChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInterval(e.target.value);
+    setSyncInterval(e.target.value);
   };
   const handlePerformValidationChange = (_e: React.ChangeEvent<HTMLInputElement>) => {
     setPerformValidation(!performValidation);
@@ -435,15 +435,17 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
         setType(RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_HELM);
         // helm plugin doesn't allow interval
         // eslint-disable-next-line no-implied-eval
-        setInterval("");
+        setSyncInterval("");
         break;
       case PluginNames.PACKAGES_FLUX:
         setType(RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_HELM);
         setInterval(interval || initialInterval);
+        setSyncInterval(syncInterval || initialInterval);
         break;
       case PluginNames.PACKAGES_KAPP:
         setType(RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_CARVEL_IMGPKGBUNDLE);
         setInterval(interval || initialInterval);
+        setSyncInterval(syncInterval || initialInterval);
         break;
     }
   };
@@ -1741,7 +1743,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                       id="kubeapps-repo-interval"
                       type="text"
                       placeholder={initialInterval}
-                      value={interval || ""}
+                      value={syncInterval || ""}
                       onChange={handleIntervalChange}
                     />
                     <CdsControlMessage>

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
@@ -431,20 +431,26 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
     setPlugin(getPluginByName(e.target.value));
     // set some default values based on the selected plugin
     switch (getPluginByName(e.target.value)?.name) {
-      case PluginNames.PACKAGES_HELM:
-        setType(RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_HELM);
+      case PluginNames.PACKAGES_HELM: {
+        if (!type) {
+          setType(RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_HELM);
+        }
         // helm plugin doesn't allow interval
         // eslint-disable-next-line no-implied-eval
         setSyncInterval("");
         break;
-      case PluginNames.PACKAGES_FLUX:
-        setType(RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_HELM);
-        setInterval(interval || initialInterval);
+      }
+      case PluginNames.PACKAGES_FLUX: {
+        if (!type) {
+          setType(RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_HELM);
+        }
         setSyncInterval(syncInterval || initialInterval);
         break;
+      }
       case PluginNames.PACKAGES_KAPP:
-        setType(RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_CARVEL_IMGPKGBUNDLE);
-        setInterval(interval || initialInterval);
+        if (!type) {
+          setType(RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_CARVEL_IMGPKGBUNDLE);
+        }
         setSyncInterval(syncInterval || initialInterval);
         break;
     }

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoList.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoList.tsx
@@ -49,7 +49,11 @@ function PkgRepoList() {
   // so calling several times to refetchRepos would run the code inside, even
   // if the dependencies do not change.
   const refetchRepos: () => void = useCallback(() => {
-    if (!namespace || !supportedCluster || namespace === globalReposNamespace) {
+    if (
+      !namespace ||
+      !supportedCluster ||
+      [globalReposNamespace, carvelGlobalNamespace].includes(namespace)
+    ) {
       // All Namespaces. Global namespace or other cluster, show global repos only
       dispatch(actions.repos.fetchRepoSummaries(""));
       return () => {};
@@ -57,7 +61,7 @@ function PkgRepoList() {
     // In other case, fetch global and namespace repos
     dispatch(actions.repos.fetchRepoSummaries(namespace, true));
     return () => {};
-  }, [dispatch, supportedCluster, namespace, globalReposNamespace]);
+  }, [dispatch, supportedCluster, namespace, globalReposNamespace, carvelGlobalNamespace]);
 
   useEffect(() => {
     refetchRepos();
@@ -232,7 +236,7 @@ function PkgRepoList() {
                       Repository" button to create one.
                     </p>
                   )}
-                  {namespace !== globalReposNamespace && (
+                  {![globalReposNamespace, carvelGlobalNamespace].includes(namespace) && (
                     <>
                       <h3>Namespaced Repositories: {namespace}</h3>
                       <p>

--- a/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
+++ b/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
@@ -31,7 +31,7 @@ function SelectRepoForm({ cluster, namespace, app }: ISelectRepoFormProps) {
     packages: {
       selected: { error: packageError },
     },
-    config: { kubeappsNamespace, kubeappsCluster, globalReposNamespace },
+    config: { kubeappsNamespace, kubeappsCluster, globalReposNamespace, carvelGlobalNamespace },
   } = useSelector((state: IStoreState) => state);
 
   const [userRepoName, setUserRepoName] = useState(repo?.name ?? "");
@@ -41,7 +41,11 @@ function SelectRepoForm({ cluster, namespace, app }: ISelectRepoFormProps) {
   // We do not currently support package repositories on additional clusters.
   const supportedCluster = cluster === kubeappsCluster;
   useEffect(() => {
-    if (!namespace || !supportedCluster || namespace === globalReposNamespace) {
+    if (
+      !namespace ||
+      !supportedCluster ||
+      [globalReposNamespace, carvelGlobalNamespace].includes(namespace)
+    ) {
       // All Namespaces. Global namespace or other cluster, show global repos only
       dispatch(actions.repos.fetchRepoSummaries(""));
       return () => {};
@@ -49,7 +53,14 @@ function SelectRepoForm({ cluster, namespace, app }: ISelectRepoFormProps) {
     // In other case, fetch global and namespace repos
     dispatch(actions.repos.fetchRepoSummaries(namespace, true));
     return () => {};
-  }, [dispatch, namespace, kubeappsNamespace, globalReposNamespace, supportedCluster]);
+  }, [
+    dispatch,
+    namespace,
+    kubeappsNamespace,
+    globalReposNamespace,
+    carvelGlobalNamespace,
+    supportedCluster,
+  ]);
 
   const handleRepoNameChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (e.target.value) {

--- a/dashboard/src/shared/utils.test.ts
+++ b/dashboard/src/shared/utils.test.ts
@@ -193,8 +193,8 @@ it("isGlobalNamespace", () => {
   } as IConfig;
   expect(isGlobalNamespace("helm-global", PluginNames.PACKAGES_HELM, kubeappsConfig)).toBe(true);
   expect(isGlobalNamespace("helm-global", PluginNames.PACKAGES_KAPP, kubeappsConfig)).toBe(false);
-  expect(isGlobalNamespace("helm-global", PluginNames.PACKAGES_FLUX, kubeappsConfig)).toBe(false);
+  expect(isGlobalNamespace("helm-global", PluginNames.PACKAGES_FLUX, kubeappsConfig)).toBe(true);
   expect(isGlobalNamespace("carvel-global", PluginNames.PACKAGES_HELM, kubeappsConfig)).toBe(false);
   expect(isGlobalNamespace("carvel-global", PluginNames.PACKAGES_KAPP, kubeappsConfig)).toBe(true);
-  expect(isGlobalNamespace("carvel-global", PluginNames.PACKAGES_FLUX, kubeappsConfig)).toBe(false);
+  expect(isGlobalNamespace("carvel-global", PluginNames.PACKAGES_FLUX, kubeappsConfig)).toBe(true);
 });

--- a/dashboard/src/shared/utils.ts
+++ b/dashboard/src/shared/utils.ts
@@ -228,8 +228,10 @@ export function isGlobalNamespace(namespace: string, pluginName: string, kubeapp
       return namespace === kubeappsConfig.globalReposNamespace;
     case PluginNames.PACKAGES_KAPP:
       return namespace === kubeappsConfig.carvelGlobalNamespace;
+    // Currently, Flux doesn't namespaced repos, so it will always be global
+    case PluginNames.PACKAGES_FLUX:
+      return true;
     default:
-      // Currently, Flux doesn't support global namespaces
       return false;
   }
 }


### PR DESCRIPTION
### Description of the change

Since the OCI support in Flux was something in progress, we didn't allow adding OCI repos in the past release. As we are implementing this support, the UI should also support it.

In this PR I'm also squeezing a fix for a regression we've had: Flux repos couldn't be created as they need to be global. This was broken in the https://github.com/vmware-tanzu/kubeapps/pull/5203 hotfix.

Besides, this PR fixes several minor problems, namely:

- Rename to `setInterval` to `setSyncInterval` since there is a js function called setInterval and the IDE was triggering some warnings.
- Avoid re-auto-selecting storage type if the user already has selected one.
- Avoid overriding the scheme (`https://`, `oci://`, etc) with the default one except for the helm plugin. It was causing some issues with the Flux OCI repos.

### Benefits

See above.

### Possible drawbacks

N/A

### Applicable issues

- related #5007 

### Additional information

I haven't been able to fetch packages from an OCI repo yet IRL, but the repo CR is being properly created and used, according to the logs.
