### PR TITLE
Fix olm test case

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ parameters:
     default: "v3.9.2"
   OLM_VERSION:
     type: "string"
-    default: "v0.21.2"
+    default: "v0.22.0"
   CHARTMUSEUM_VERSION:
     type: "string"
     default: "3.9.0"

--- a/integration/tests/operators/06-operator-deployment.spec.js
+++ b/integration/tests/operators/06-operator-deployment.spec.js
@@ -19,7 +19,7 @@ test("Deploys an Operator", async ({ page }) => {
   // Select operator to deploy
   await page.locator("input#search").fill("prometheus");
   await page.waitForTimeout(3000);
-  await page.click('a:has-text("prometheus")');
+  await page.click('a:has-text("Manage the full lifecycle of configuring and managing Prometheus")');
   await page.click('cds-button:has-text("Deploy") >> nth=0');
   await page.click('cds-button:has-text("Deploy")');
 

--- a/integration/tests/operators/06-operator-deployment.spec.js
+++ b/integration/tests/operators/06-operator-deployment.spec.js
@@ -14,12 +14,15 @@ test("Deploys an Operator", async ({ page }) => {
 
   // Go to operators page
   await page.goto(utils.getUrl("/#/c/default/ns/kubeapps/operators"));
-  await page.waitForTimeout(10000);
+  await page.waitForFunction('document.querySelector("cds-progress-circle") === null');
 
   // Select operator to deploy
   await page.locator("input#search").fill("prometheus");
   await page.waitForTimeout(3000);
-  await page.click('a:has-text("Manage the full lifecycle of configuring and managing Prometheus")');
+  // using locator with "has" instead of "hasText" to search by this exact name (and exclude others like "Red Hat, Inc.")
+  await page.locator("cds-checkbox", { has: page.locator('text="Red Hat"') }).click();
+
+  await page.click('a:has-text("prometheus")');
   await page.click('cds-button:has-text("Deploy") >> nth=0');
   await page.click('cds-button:has-text("Deploy")');
 


### PR DESCRIPTION
### Description of the change

It seems a new operator has been added and we are installing this new one instead of the expected one. See screenshot:
![image](https://user-images.githubusercontent.com/11535726/185908284-96efe7fc-71bb-4fe3-95b0-856a5d9749e3.png).

The new operator is indeed failing, therefore, the test case is failing too.

```
 install failed: deployment ack-prometheusservice-controller not ready before timeout: deployment "ack-prometheusservice-controller" exceeded its progress deadline
```

We need to make the selector more specific so that we really select the one we are expecting.

### Benefits

CI will pass again.

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #5225 

### Additional information

N/A
