### PR TITLE
CI - wait until "operators" appears before typing

### DIFF
--- a/integration/tests/operators/06-operator-deployment.spec.js
+++ b/integration/tests/operators/06-operator-deployment.spec.js
@@ -14,6 +14,7 @@ test("Deploys an Operator", async ({ page }) => {
 
   // Go to operators page
   await page.goto(utils.getUrl("/#/c/default/ns/kubeapps/operators"));
+  await page.waitForSelector('h1:has-text("Operators")');
   await page.waitForFunction('document.querySelector("cds-progress-circle") === null');
 
   // Select operator to deploy


### PR DESCRIPTION
### Description of the change

I've noticed a random failure in the operator-relate CI test: it starts typing before the view is fully rendered. See below:

![image](https://user-images.githubusercontent.com/11535726/186121467-729079e9-db9a-4fa4-b508-c5186b6a4cbf.png)


This PR is just to add a wait for the proper selector to become visible before starting typing.

### Benefits

More CI reliability.

### Possible drawbacks

N/A

### Applicable issues

- related #5227 

### Additional information

N/A
