### PR TITLE
Changed order of installing ChartMuseum in E2E tests

### DIFF
--- a/script/chart-museum.sh
+++ b/script/chart-museum.sh
@@ -86,6 +86,7 @@ installChartMuseum() {
     --set persistence.enabled=true \
     --set env.secret.BASIC_AUTH_USER=$CHARTMUSEUM_USER \
     --set env.secret.BASIC_AUTH_PASS=$CHARTMUSEUM_PWD
+  info "Waiting for ChartMuseum to be ready..."
   kubectl rollout status -w deployment/chartmuseum --namespace=${CHARTMUSEUM_NS}
 
   echo "Chart museum v${CHARTMUSEUM_VERSION} installed in namespace ${CHARTMUSEUM_NS}"

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -302,12 +302,15 @@ if [[ -n "${TEST_UPGRADE:-}" ]]; then
   k8s_wait_for_deployment kubeapps kubeapps-ci
 fi
 
-installOrUpgradeKubeapps "${ROOT_DIR}/chart/kubeapps"
-info "Waiting for Kubeapps components to be ready (local chart)..."
-k8s_wait_for_deployment kubeapps kubeapps-ci
+# Install ChartMuseum
 installChartMuseum "${CHARTMUSEUM_VERSION}"
 pushChart apache 8.6.2 admin password
 pushChart apache 8.6.3 admin password
+
+# Install Kubeapps
+installOrUpgradeKubeapps "${ROOT_DIR}/chart/kubeapps"
+info "Waiting for Kubeapps components to be ready (local chart)..."
+k8s_wait_for_deployment kubeapps kubeapps-ci
 
 # Setting up local Docker registry if not in GKE
 if [[ -z "${GKE_BRANCH-}" ]]; then


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

This PR changes the E2E execution logic to install first chart museum and then Kubeapps. Before, Kubeapps was being installed before. It could be rare, but in some situations, ChartMuseum could not be ready for Kubeapps.

After the refactoring done in #5143 it has been easier to implement this change, for example the namespace was already the right one, `chart-museum`.

### Benefits

Right installation order of E2E elements.

### Possible drawbacks

N/A

### Applicable issues

- fixes #4430
