### PR TITLE
Add explicit scope to the new repo form

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -172,6 +172,8 @@ const pkgRepoFormData = {
     cert: "",
     key: "",
   },
+  namespace: "my-namespace",
+  isNamespaceScoped: true,
 } as IPkgRepoFormData;
 
 const actionTestCases: ITestCase[] = [
@@ -416,30 +418,25 @@ describe("fetchRepoSummaries", () => {
 });
 
 describe("addRepo", () => {
-  const addRepoCMD = repoActions.addRepo("my-namespace", pkgRepoFormData);
+  const addRepoCMD = repoActions.addRepo(pkgRepoFormData);
 
   context("when authHeader provided", () => {
-    const addRepoCMDAuth = repoActions.addRepo("my-namespace", {
+    const addRepoCMDAuth = repoActions.addRepo({
       ...pkgRepoFormData,
       authHeader: "Bearer: abc",
     });
 
     it("calls PackageRepositoriesService create including a auth struct (authHeader)", async () => {
       await store.dispatch(addRepoCMDAuth);
-      expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
-        "default",
-        "my-namespace",
-        {
-          ...pkgRepoFormData,
-          authHeader: "Bearer: abc",
-        },
-        true,
-      );
+      expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith("default", {
+        ...pkgRepoFormData,
+        authHeader: "Bearer: abc",
+      });
     });
 
     it("calls PackageRepositoriesService create including ociRepositories", async () => {
       await store.dispatch(
-        repoActions.addRepo("my-namespace", {
+        repoActions.addRepo({
           ...pkgRepoFormData,
           type: RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI,
           customDetail: {
@@ -448,34 +445,23 @@ describe("addRepo", () => {
           },
         }),
       );
-      expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
-        "default",
-        "my-namespace",
-        {
-          ...pkgRepoFormData,
-          type: RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI,
-          customDetail: {
-            ...pkgRepoFormData.customDetail,
-            ociRepositories: ["apache", "jenkins"],
-          },
+      expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith("default", {
+        ...pkgRepoFormData,
+
+        type: RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI,
+        customDetail: {
+          ...pkgRepoFormData.customDetail,
+          ociRepositories: ["apache", "jenkins"],
         },
-        true,
-      );
+      });
     });
 
     it("calls PackageRepositoriesService create skipping TLS verification", async () => {
-      await store.dispatch(
-        repoActions.addRepo("my-namespace", { ...pkgRepoFormData, skipTLS: true }),
-      );
-      expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
-        "default",
-        "my-namespace",
-        {
-          ...pkgRepoFormData,
-          skipTLS: true,
-        },
-        true,
-      );
+      await store.dispatch(repoActions.addRepo({ ...pkgRepoFormData, skipTLS: true }));
+      expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith("default", {
+        ...pkgRepoFormData,
+        skipTLS: true,
+      });
     });
 
     it("returns true", async () => {
@@ -485,22 +471,17 @@ describe("addRepo", () => {
   });
 
   context("when a customCA is provided", () => {
-    const addRepoCMDAuth = repoActions.addRepo("my-namespace", {
+    const addRepoCMDAuth = repoActions.addRepo({
       ...pkgRepoFormData,
       customCA: "This is a cert!",
     });
 
     it("calls PackageRepositoriesService create including a auth struct (custom CA)", async () => {
       await store.dispatch(addRepoCMDAuth);
-      expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
-        "default",
-        "my-namespace",
-        {
-          ...pkgRepoFormData,
-          customCA: "This is a cert!",
-        },
-        true,
-      );
+      expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith("default", {
+        ...pkgRepoFormData,
+        customCA: "This is a cert!",
+      });
     });
 
     it("returns true (addRepoCMDAuth)", async () => {
@@ -510,38 +491,36 @@ describe("addRepo", () => {
 
     it("sets flux repos as global", async () => {
       await store.dispatch(
-        repoActions.addRepo("my-namespace", {
+        repoActions.addRepo({
           ...pkgRepoFormData,
+          namespace: "my-namespace",
+          isNamespaceScoped: false,
           plugin: fluxPlugin as Plugin,
         }),
       );
-      expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
-        "default",
-        "my-namespace",
-        {
-          ...pkgRepoFormData,
-          plugin: fluxPlugin,
-        },
-        false,
-      );
+      expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith("default", {
+        ...pkgRepoFormData,
+        namespace: "my-namespace",
+        isNamespaceScoped: false,
+        plugin: fluxPlugin,
+      });
     });
 
     it("sets carvel repos as global if using the carvelGlobalNamespace", async () => {
       await store.dispatch(
-        repoActions.addRepo(carvelGlobalNamespace, {
+        repoActions.addRepo({
           ...pkgRepoFormData,
+          namespace: carvelGlobalNamespace,
+          isNamespaceScoped: false,
           plugin: carvelPlugin as Plugin,
         }),
       );
-      expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
-        "default",
-        carvelGlobalNamespace,
-        {
-          ...pkgRepoFormData,
-          plugin: carvelPlugin,
-        },
-        false,
-      );
+      expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith("default", {
+        ...pkgRepoFormData,
+        namespace: carvelGlobalNamespace,
+        isNamespaceScoped: false,
+        plugin: carvelPlugin,
+      });
     });
   });
 
@@ -550,9 +529,7 @@ describe("addRepo", () => {
       await store.dispatch(addRepoCMD);
       expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
         "default",
-        "my-namespace",
         pkgRepoFormData,
-        true,
       );
     });
 
@@ -607,7 +584,7 @@ describe("addRepo", () => {
 
   it("includes registry secrets if given", async () => {
     await store.dispatch(
-      repoActions.addRepo("my-namespace", {
+      repoActions.addRepo({
         ...pkgRepoFormData,
         customDetail: {
           ...pkgRepoFormData.customDetail,
@@ -619,39 +596,29 @@ describe("addRepo", () => {
       }),
     );
 
-    expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
-      "default",
-      "my-namespace",
-      {
-        ...pkgRepoFormData,
-        customDetail: {
-          ...pkgRepoFormData.customDetail,
-          imagesPullSecret: {
-            secretRef: "repo-1",
-            credentials: { server: "", username: "", password: "", email: "" },
-          },
+    expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith("default", {
+      ...pkgRepoFormData,
+      customDetail: {
+        ...pkgRepoFormData.customDetail,
+        imagesPullSecret: {
+          secretRef: "repo-1",
+          credentials: { server: "", username: "", password: "", email: "" },
         },
       },
-      true,
-    );
+    });
   });
 
   it("calls PackageRepositoriesService create with description", async () => {
     await store.dispatch(
-      repoActions.addRepo("my-namespace", {
+      repoActions.addRepo({
         ...pkgRepoFormData,
         description: "This is a weird description 123!@#$%^&&*()_+-=<>?/.,;:'\"",
       }),
     );
-    expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith(
-      "default",
-      "my-namespace",
-      {
-        ...pkgRepoFormData,
-        description: "This is a weird description 123!@#$%^&&*()_+-=<>?/.,;:'\"",
-      },
-      true,
-    );
+    expect(PackageRepositoriesService.addPackageRepository).toHaveBeenCalledWith("default", {
+      ...pkgRepoFormData,
+      description: "This is a weird description 123!@#$%^&&*()_+-=<>?/.,;:'\"",
+    });
   });
 });
 
@@ -681,21 +648,17 @@ describe("updateRepo", () => {
     ];
 
     await store.dispatch(
-      repoActions.updateRepo("my-namespace", {
+      repoActions.updateRepo({
         ...pkgRepoFormData,
         authHeader: "foo",
       }),
     );
 
     expect(store.getActions()).toEqual(expectedActions);
-    expect(PackageRepositoriesService.updatePackageRepository).toHaveBeenCalledWith(
-      "default",
-      "my-namespace",
-      {
-        ...pkgRepoFormData,
-        authHeader: "foo",
-      },
-    );
+    expect(PackageRepositoriesService.updatePackageRepository).toHaveBeenCalledWith("default", {
+      ...pkgRepoFormData,
+      authHeader: "foo",
+    });
   });
 
   it("updates a repo with an customCA", async () => {
@@ -724,17 +687,16 @@ describe("updateRepo", () => {
     ];
 
     await store.dispatch(
-      repoActions.updateRepo("my-namespace", { ...pkgRepoFormData, customCA: "This is a cert!" }),
-    );
-    expect(store.getActions()).toEqual(expectedActions);
-    expect(PackageRepositoriesService.updatePackageRepository).toHaveBeenCalledWith(
-      "default",
-      "my-namespace",
-      {
+      repoActions.updateRepo({
         ...pkgRepoFormData,
         customCA: "This is a cert!",
-      },
+      }),
     );
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(PackageRepositoriesService.updatePackageRepository).toHaveBeenCalledWith("default", {
+      ...pkgRepoFormData,
+      customCA: "This is a cert!",
+    });
   });
 
   it("returns an error if failed", async () => {
@@ -751,7 +713,7 @@ describe("updateRepo", () => {
       },
     ];
 
-    await store.dispatch(repoActions.updateRepo("my-namespace", pkgRepoFormData));
+    await store.dispatch(repoActions.updateRepo(pkgRepoFormData));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -760,21 +722,17 @@ describe("updateRepo", () => {
       packageRepoRef: packageRepositoryDetail.packageRepoRef,
     } as UpdatePackageRepositoryResponse);
     await store.dispatch(
-      repoActions.updateRepo("my-namespace", {
+      repoActions.updateRepo({
         ...pkgRepoFormData,
         type: RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI,
         customDetail: { ...pkgRepoFormData.customDetail, ociRepositories: ["apache", "jenkins"] },
       }),
     );
-    expect(PackageRepositoriesService.updatePackageRepository).toHaveBeenCalledWith(
-      "default",
-      "my-namespace",
-      {
-        ...pkgRepoFormData,
-        type: RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI,
-        customDetail: { ...pkgRepoFormData.customDetail, ociRepositories: ["apache", "jenkins"] },
-      },
-    );
+    expect(PackageRepositoriesService.updatePackageRepository).toHaveBeenCalledWith("default", {
+      ...pkgRepoFormData,
+      type: RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI,
+      customDetail: { ...pkgRepoFormData.customDetail, ociRepositories: ["apache", "jenkins"] },
+    });
   });
 
   it("updates a repo with description", async () => {
@@ -782,19 +740,15 @@ describe("updateRepo", () => {
       packageRepoRef: packageRepositoryDetail.packageRepoRef,
     } as UpdatePackageRepositoryResponse);
     await store.dispatch(
-      repoActions.updateRepo("my-namespace", {
+      repoActions.updateRepo({
         ...pkgRepoFormData,
         description: "updated description",
       }),
     );
-    expect(PackageRepositoriesService.updatePackageRepository).toHaveBeenCalledWith(
-      "default",
-      "my-namespace",
-      {
-        ...pkgRepoFormData,
-        description: "updated description",
-      },
-    );
+    expect(PackageRepositoriesService.updatePackageRepository).toHaveBeenCalledWith("default", {
+      ...pkgRepoFormData,
+      description: "updated description",
+    });
   });
 });
 

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -15,7 +15,6 @@ import { ThunkAction } from "redux-thunk";
 import { PackageRepositoriesService } from "shared/PackageRepositoriesService";
 import PackagesService from "shared/PackagesService";
 import { IPkgRepoFormData, IStoreState, NotFoundError } from "shared/types";
-import { isGlobalNamespace } from "shared/utils";
 import { ActionType, deprecated } from "typesafe-actions";
 
 const { createAction } = deprecated;
@@ -131,22 +130,17 @@ export const fetchRepoDetail = (
 };
 
 export const addRepo = (
-  namespace: string,
   request: IPkgRepoFormData,
 ): ThunkAction<Promise<boolean>, IStoreState, null, PkgReposAction> => {
   return async (dispatch, getState) => {
     const {
       clusters: { currentCluster },
-      config,
     } = getState();
     try {
       dispatch(addOrUpdateRepo());
-      const namespaceScoped = !isGlobalNamespace(namespace, request.plugin?.name, config);
       const addPackageRepositoryResponse = await PackageRepositoriesService.addPackageRepository(
         currentCluster,
-        namespace,
         request,
-        namespaceScoped,
       );
       // Ensure the repo have been created
       if (!addPackageRepositoryResponse?.packageRepoRef) {
@@ -186,7 +180,6 @@ export const addRepo = (
 };
 
 export const updateRepo = (
-  namespace: string,
   request: IPkgRepoFormData,
 ): ThunkAction<Promise<boolean>, IStoreState, null, PkgReposAction> => {
   return async (dispatch, getState) => {
@@ -196,11 +189,7 @@ export const updateRepo = (
     try {
       dispatch(addOrUpdateRepo());
       const updatePackageRepositoryResponse =
-        await PackageRepositoriesService.updatePackageRepository(
-          currentCluster,
-          namespace,
-          request,
-        );
+        await PackageRepositoriesService.updatePackageRepository(currentCluster, request);
 
       // Ensure the repo have been updated
       if (!updatePackageRepositoryResponse?.packageRepoRef) {

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoButton.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoButton.tsx
@@ -44,9 +44,9 @@ export function PkgRepoAddButton({
   const onSubmit = (request: IPkgRepoFormData) => {
     // decide whether to create or update the repository
     if (packageRepoRef) {
-      return dispatch(actions.repos.updateRepo(namespace, request));
+      return dispatch(actions.repos.updateRepo(request));
     } else {
-      return dispatch(actions.repos.addRepo(namespace, request));
+      return dispatch(actions.repos.addRepo(request));
     }
   };
 

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
@@ -84,6 +84,8 @@ const pkgRepoFormData = {
     cert: "",
     key: "",
   },
+  namespace: "default",
+  isNamespaceScoped: true,
 } as IPkgRepoFormData;
 
 let spyOnUseDispatch: jest.SpyInstance;

--- a/dashboard/src/shared/PackageRepositoriesService.test.ts
+++ b/dashboard/src/shared/PackageRepositoriesService.test.ts
@@ -91,6 +91,8 @@ const pkgRepoFormData = {
     cert: "",
     key: "",
   },
+  namespace,
+  isNamespaceScoped: true,
 } as IPkgRepoFormData;
 
 const packageRepoRef = {
@@ -161,9 +163,7 @@ describe("RepositoriesService", () => {
 
     const addPackageRepositoryResponse = await PackageRepositoriesService.addPackageRepository(
       cluster,
-      namespace,
-      pkgRepoFormData,
-      false,
+      { ...pkgRepoFormData, namespace, isNamespaceScoped: false },
     );
     expect(addPackageRepositoryResponse).toStrictEqual({
       packageRepoRef: {
@@ -197,7 +197,7 @@ describe("RepositoriesService", () => {
     setMockCoreClient("UpdatePackageRepository", mockUpdatePackageRepository);
 
     const updatePackageRepositoryResponse =
-      await PackageRepositoriesService.updatePackageRepository(cluster, namespace, pkgRepoFormData);
+      await PackageRepositoriesService.updatePackageRepository(cluster, pkgRepoFormData);
     expect(updatePackageRepositoryResponse).toStrictEqual({
       packageRepoRef: {
         identifier: pkgRepoFormData.name,

--- a/dashboard/src/shared/PackageRepositoriesService.ts
+++ b/dashboard/src/shared/PackageRepositoriesService.ts
@@ -47,35 +47,22 @@ export class PackageRepositoriesService {
     return await this.coreRepositoriesClient().GetPackageRepositoryDetail({ packageRepoRef });
   }
 
-  public static async addPackageRepository(
-    cluster: string,
-    namespace: string,
-    request: IPkgRepoFormData,
-    namespaceScoped: boolean,
-  ) {
+  public static async addPackageRepository(cluster: string, request: IPkgRepoFormData) {
     const addPackageRepositoryRequest = PackageRepositoriesService.buildAddOrUpdateRequest(
       false,
       cluster,
-      namespace,
       request,
-      namespaceScoped,
       PackageRepositoriesService.buildEncodedCustomDetail(request),
     );
 
     return await this.coreRepositoriesClient().AddPackageRepository(addPackageRepositoryRequest);
   }
 
-  public static async updatePackageRepository(
-    cluster: string,
-    namespace: string,
-    request: IPkgRepoFormData,
-  ) {
+  public static async updatePackageRepository(cluster: string, request: IPkgRepoFormData) {
     const updatePackageRepositoryRequest = PackageRepositoriesService.buildAddOrUpdateRequest(
       true,
       cluster,
-      namespace,
       request,
-      undefined,
       PackageRepositoriesService.buildEncodedCustomDetail(request),
     );
 
@@ -95,16 +82,14 @@ export class PackageRepositoriesService {
   private static buildAddOrUpdateRequest(
     isUpdate: boolean,
     cluster: string,
-    namespace: string,
     request: IPkgRepoFormData,
-    namespaceScoped?: boolean,
     pluginCustomDetail?: any,
   ) {
     const addPackageRepositoryRequest = {
-      context: { cluster, namespace },
+      context: { cluster, namespace: request.namespace },
       name: request.name,
       description: request.description,
-      namespaceScoped: namespaceScoped,
+      namespaceScoped: request.isNamespaceScoped,
       type: request.type,
       url: request.url,
       interval: request.interval,

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -448,4 +448,6 @@ export interface IPkgRepoFormData {
   customDetail?: Partial<
     HelmPackageRepositoryCustomDetail | KappControllerPackageRepositoryCustomDetail
   >;
+  namespace: string;
+  isNamespaceScoped: boolean;
 }

--- a/dashboard/src/shared/utils.ts
+++ b/dashboard/src/shared/utils.ts
@@ -235,3 +235,21 @@ export function isGlobalNamespace(namespace: string, pluginName: string, kubeapp
       return false;
   }
 }
+
+export function getGlobalNamespaceOrNamespace(
+  namespace: string,
+  pluginName: string,
+  kubeappsConfig: IConfig,
+) {
+  switch (pluginName) {
+    case PluginNames.PACKAGES_HELM:
+      return kubeappsConfig.globalReposNamespace;
+    case PluginNames.PACKAGES_KAPP:
+      return kubeappsConfig.carvelGlobalNamespace;
+    // Currently, Flux doesn't namespaced repos, so the given ns will be indeed global
+    case PluginNames.PACKAGES_FLUX:
+      return namespace;
+    default:
+      return "unknown";
+  }
+}


### PR DESCRIPTION
### Description of the change

Adding an explicit scope for selecting whether the repo should be namespace or global + some info messages to the user.


### Benefits

Adding a global repo will no longer require switching the context, which wasn't something trivial to figure out as a user.

### Possible drawbacks

N/A

### Applicable issues

- fixes #2995 

### Additional information

![reposWithScope](https://user-images.githubusercontent.com/11535726/187260510-d252f9a2-2848-4b35-8a41-fce43b13ef87.gif)


Squeezing two changes:
- Disable the description field if using carvel repos (as it currently errors if any is passed)
- Fix some <label> tags to comply with a11y recommendations.
