### PR TITLE
Fix for E2E Carvel test 04 selectOption

### DIFF
--- a/integration/tests/carvel/04-default-deployment.spec.js
+++ b/integration/tests/carvel/04-default-deployment.spec.js
@@ -24,7 +24,8 @@ test("Deploys package with default values in main cluster", async ({ page }) => 
 
   // Deploy package
   await page.waitForSelector('select[name="package-versions"]');
-  await page.selectOption('select[name="package-versions"]', "2.0.0");
+  const versionSelector = await page.$('select[name="package-versions"]')
+  await versionSelector?.selectOption("2.0.0")
   const releaseNameLocator = page.locator("#releaseName");
   await releaseNameLocator.waitFor();
   await expect(releaseNameLocator).toHaveText("");


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

Trivial PR trying to fix the error appearing with E2E test 04 for Carvel.
It is the typical error on E2E CI that fails from time to time, but I noticed that the frequency has been increasing lately.

### Benefits

CI pipelines should pass successfully more often.

### Possible drawbacks

That this PR does not really fix the issue.

### Applicable issues

- fixes #5267 
