### PR TITLE
Remove io/ioutils imports

### DIFF
--- a/cmd/asset-syncer/server/utils.go
+++ b/cmd/asset-syncer/server/utils.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"image"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -439,7 +438,7 @@ func extractFilesFromBuffer(buf *bytes.Buffer) (*artifactFiles, error) {
 			filename := strings.ToLower(path.Base(compressedFileName))
 			if importantFiles[filename] {
 				// Read content
-				data, err := ioutil.ReadAll(tarReader)
+				data, err := io.ReadAll(tarReader)
 				if err != nil {
 					return nil, err
 				}

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"image"
 	"image/color"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -34,7 +33,7 @@ import (
 	log "k8s.io/klog/v2"
 )
 
-var validRepoIndexYAMLBytes, _ = ioutil.ReadFile("testdata/valid-index.yaml")
+var validRepoIndexYAMLBytes, _ = os.ReadFile("testdata/valid-index.yaml")
 var validRepoIndexYAML = string(validRepoIndexYAMLBytes)
 
 type badHTTPClient struct {
@@ -337,7 +336,7 @@ func Test_chartTarballURL(t *testing.T) {
 
 func Test_initNetClient(t *testing.T) {
 	// Test env
-	otherDir, err := ioutil.TempDir("", "ca-registry")
+	otherDir, err := os.TempDir("", "ca-registry")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,7 +362,7 @@ b90fhqZZ3FqZD7W1qJGKvz/8geqi0noip+uq/dokK1jarRkOVEJP+EvXkHo0tIuc
 h251U/Daz6NiQBM9AxyAw6EHm8XAZBvCuebfzyrT
 -----END CERTIFICATE-----`
 	otherCA := path.Join(otherDir, "ca.crt")
-	err = ioutil.WriteFile(otherCA, []byte(caCert), 0644)
+	err = os.WriteFile(otherCA, []byte(caCert), 0644)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1394,7 +1393,7 @@ func TestUnescapeChartsData(t *testing.T) {
 func TestHelmRepoAppliesUnescape(t *testing.T) {
 	repo := &models.RepoInternal{Name: "test", Namespace: "repo-namespace", URL: "http://testrepo.com"}
 	expectedRepo := &models.Repo{Name: repo.Name, Namespace: repo.Namespace, URL: repo.URL}
-	repoIndexYAMLBytes, _ := ioutil.ReadFile("testdata/helm-index-spaces.yaml")
+	repoIndexYAMLBytes, _ := os.ReadFile("testdata/helm-index-spaces.yaml")
 	repoIndexYAML := string(repoIndexYAMLBytes)
 	expectedCharts := []models.Chart{
 		{

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -336,7 +336,7 @@ func Test_chartTarballURL(t *testing.T) {
 
 func Test_initNetClient(t *testing.T) {
 	// Test env
-	otherDir, err := os.TempDir("", "ca-registry")
+	otherDir, err := os.MkdirTemp("", "ca-registry")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -287,7 +286,7 @@ func createConfigGetter(serveOpts core.ServeOptions, clustersConfig kube.Cluster
 		// if using the local kubeconfig, read it from the KUBECONFIG path and
 		// create the restConfig
 		log.Warningf("Using the local kubeconfig configuration (in KUBECONFIG='%s' envar) since you passed --unsafe-local-dev-kubeconfig=true", os.Getenv("KUBECONFIG"))
-		kubeconfigBytes, err := ioutil.ReadFile(os.Getenv("KUBECONFIG"))
+		kubeconfigBytes, err := os.ReadFile(os.Getenv("KUBECONFIG"))
 		if err != nil {
 			return nil, fmt.Errorf("unable to read the file in KUBECONFIG envar: %w", err)
 		}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"strings"
 
@@ -343,7 +343,7 @@ func downloadHttpChartFn(options *common.HttpClientOptions) func(chartID, chartU
 			return nil, err
 		}
 
-		chartTgz, err := ioutil.ReadAll(reader)
+		chartTgz, err := io.ReadAll(reader)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart_test.go
@@ -820,7 +820,7 @@ func TestChartCacheResyncNotIdle(t *testing.T) {
 
 		const NUM_CHARTS = 20
 		// create a YAML index file that contains this many unique packages
-		tmpFile, err := os.TempFile(os.MkdirTemp(), "*.yaml")
+		tmpFile, err := os.CreateTemp(os.TempDir(), "*.yaml")
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart_test.go
@@ -820,7 +820,7 @@ func TestChartCacheResyncNotIdle(t *testing.T) {
 
 		const NUM_CHARTS = 20
 		// create a YAML index file that contains this many unique packages
-		tmpFile, err := os.TempFile(os.TempDir(), "*.yaml")
+		tmpFile, err := os.TempFile(os.MkdirTemp(), "*.yaml")
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart_test.go
@@ -6,7 +6,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -120,7 +119,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 			}
 
 			for _, s := range redis_charts_spec {
-				tarGzBytes, err := ioutil.ReadFile(s.tgzFile)
+				tarGzBytes, err := os.ReadFile(s.tgzFile)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
@@ -251,7 +250,7 @@ func TestTransientHttpFailuresAreRetriedForChartCache(t *testing.T) {
 		charts := []testSpecChartWithUrl{}
 
 		for _, s := range redis_charts_spec {
-			tarGzBytes, err := ioutil.ReadFile(s.tgzFile)
+			tarGzBytes, err := os.ReadFile(s.tgzFile)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
@@ -442,7 +441,7 @@ func TestNonExistingRepoOrInvalidPkgVersionGetAvailablePackageDetail(t *testing.
 			replaceUrls := make(map[string]string)
 			charts := []testSpecChartWithUrl{}
 			for _, s := range redis_charts_spec {
-				tarGzBytes, err := ioutil.ReadFile(s.tgzFile)
+				tarGzBytes, err := os.ReadFile(s.tgzFile)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
@@ -629,7 +628,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 			replaceUrls := make(map[string]string)
 			charts := []testSpecChartWithUrl{}
 			for _, s := range redis_charts_spec {
-				tarGzBytes, err := ioutil.ReadFile(s.tgzFile)
+				tarGzBytes, err := os.ReadFile(s.tgzFile)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
@@ -804,7 +803,7 @@ func TestChartCacheResyncNotIdle(t *testing.T) {
 		}
 
 		// what I need is a single repo with a whole bunch of unique charts (packages)
-		tarGzBytes, err := ioutil.ReadFile(testTgz("redis-14.4.0.tgz"))
+		tarGzBytes, err := os.ReadFile(testTgz("redis-14.4.0.tgz"))
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -821,13 +820,13 @@ func TestChartCacheResyncNotIdle(t *testing.T) {
 
 		const NUM_CHARTS = 20
 		// create a YAML index file that contains this many unique packages
-		tmpFile, err := ioutil.TempFile(os.TempDir(), "*.yaml")
+		tmpFile, err := os.TempFile(os.TempDir(), "*.yaml")
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
 		defer os.Remove(tmpFile.Name())
 
-		templateYAMLBytes, err := ioutil.ReadFile(testYaml("single-package-template.yaml"))
+		templateYAMLBytes, err := os.ReadFile(testYaml("single-package-template.yaml"))
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -972,12 +971,12 @@ func TestChartWithRelativeURL(t *testing.T) {
 	repoName := "testRepo"
 	repoNamespace := "default"
 
-	tarGzBytes, err := ioutil.ReadFile(testTgz("airflow-1.0.0.tgz"))
+	tarGzBytes, err := os.ReadFile(testTgz("airflow-1.0.0.tgz"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	indexYAMLBytes, err := ioutil.ReadFile(testYaml("chart-with-relative-url.yaml"))
+	indexYAMLBytes, err := os.ReadFile(testYaml("chart-with-relative-url.yaml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common/utils.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common/utils.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -87,9 +86,7 @@ func init() {
 	}
 }
 
-//
 // miscellaneous utility funcs
-//
 func NewDefaultPluginConfig() *FluxPluginConfig {
 	// If no config is provided, we default to the existing values for backwards
 	// compatibility.
@@ -281,7 +278,6 @@ func HelmGetterOptionsFromSecret(secret apiv1.Secret) ([]getter.Option, error) {
 	}
 }
 
-//
 // Secrets with no username AND password are ignored, if only one is defined it
 // returns an error.
 func basicAuthFromSecret(secret apiv1.Secret, options *HttpClientOptions) error {
@@ -454,7 +450,7 @@ func ParsePluginConfig(pluginConfigPath string) (*FluxPluginConfig, error) {
 	var config internalFluxPluginConfig
 
 	// #nosec G304
-	pluginConfig, err := ioutil.ReadFile(pluginConfigPath)
+	pluginConfig, err := os.ReadFile(pluginConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open plugin config at %q: %w", pluginConfigPath, err)
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/global_vars_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/global_vars_test.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"time"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
@@ -3610,7 +3610,7 @@ var (
 	}
 
 	newFakeRemoteOciRegistryData_1 = func() (*fakeRemoteOciRegistryData, error) {
-		chartBytes, err := ioutil.ReadFile(testTgz("podinfo-6.1.5.tgz"))
+		chartBytes, err := os.ReadFile(testTgz("podinfo-6.1.5.tgz"))
 		if err != nil {
 			return nil, err
 		}
@@ -3721,15 +3721,15 @@ var (
 	}
 
 	newFakeRemoteOciRegistryData_2 = func() (*fakeRemoteOciRegistryData, error) {
-		chartBytes1, err := ioutil.ReadFile(testTgz("podinfo-6.1.5.tgz"))
+		chartBytes1, err := os.ReadFile(testTgz("podinfo-6.1.5.tgz"))
 		if err != nil {
 			return nil, err
 		}
-		chartBytes2, err := ioutil.ReadFile(testTgz("podinfo-6.0.0.tgz"))
+		chartBytes2, err := os.ReadFile(testTgz("podinfo-6.0.0.tgz"))
 		if err != nil {
 			return nil, err
 		}
-		chartBytes3, err := ioutil.ReadFile(testTgz("podinfo-6.0.3.tgz"))
+		chartBytes3, err := os.ReadFile(testTgz("podinfo-6.0.3.tgz"))
 		if err != nil {
 			return nil, err
 		}
@@ -3759,11 +3759,11 @@ var (
 	}
 
 	newFakeRemoteOciRegistryData_3 = func() (*fakeRemoteOciRegistryData, error) {
-		chartBytes1, err := ioutil.ReadFile(testTgz("podinfo-6.1.5.tgz"))
+		chartBytes1, err := os.ReadFile(testTgz("podinfo-6.1.5.tgz"))
 		if err != nil {
 			return nil, err
 		}
-		chartBytes2, err := ioutil.ReadFile(testTgz("airflow-6.7.1.tgz"))
+		chartBytes2, err := os.ReadFile(testTgz("airflow-6.7.1.tgz"))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_test.go
@@ -5,9 +5,9 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -1124,7 +1124,7 @@ func newChartsAndReleases(t *testing.T, existingK8sObjs []testSpecGetInstalledPa
 	releases = []helmv2.HelmRelease{}
 
 	for _, existing := range existingK8sObjs {
-		tarGzBytes, err := ioutil.ReadFile(existing.chartTarGz)
+		tarGzBytes, err := os.ReadFile(existing.chartTarGz)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo_test.go
@@ -6,9 +6,9 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -569,12 +569,12 @@ func TestGetAvailablePackageSummariesWithPagination(t *testing.T) {
 
 func TestGetAvailablePackageSummaryAfterRepoIndexUpdate(t *testing.T) {
 	t.Run("test get available package summaries after repo index is updated", func(t *testing.T) {
-		indexYamlBeforeUpdateBytes, err := ioutil.ReadFile(testYaml("index-before-update.yaml"))
+		indexYamlBeforeUpdateBytes, err := os.ReadFile(testYaml("index-before-update.yaml"))
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
 
-		indexYamlAfterUpdateBytes, err := ioutil.ReadFile(testYaml("index-after-update.yaml"))
+		indexYamlAfterUpdateBytes, err := os.ReadFile(testYaml("index-after-update.yaml"))
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -711,7 +711,7 @@ func TestGetAvailablePackageSummaryAfterFluxHelmRepoDelete(t *testing.T) {
 		replaceUrls := make(map[string]string)
 		charts := []testSpecChartWithUrl{}
 		for _, s := range valid_index_charts_spec {
-			tarGzBytes, err := ioutil.ReadFile(s.tgzFile)
+			tarGzBytes, err := os.ReadFile(s.tgzFile)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
@@ -1788,7 +1788,7 @@ func TestGetOciPackageRepositoryDetail(t *testing.T) {
 
 func TestGetPackageRepositorySummaries(t *testing.T) {
 	// some prep
-	indexYAMLBytes, err := ioutil.ReadFile(testYaml("valid-index.yaml"))
+	indexYAMLBytes, err := os.ReadFile(testYaml("valid-index.yaml"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2542,7 +2542,7 @@ func redisKeyForRepoNamespacedName(name types.NamespacedName) (string, error) {
 }
 
 func newHttpRepoAndServeIndex(repoIndex, repoName, repoNamespace string, replaceUrls map[string]string, secretRef string) (*httptest.Server, *sourcev1.HelmRepository, error) {
-	indexYAMLBytes, err := ioutil.ReadFile(repoIndex)
+	indexYAMLBytes, err := os.ReadFile(repoIndex)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server_test.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -190,9 +190,7 @@ func TestGetAvailablePackagesStatus(t *testing.T) {
 	}
 }
 
-//
 // utilities
-//
 type testSpecChartWithUrl struct {
 	chartID       string
 	chartRevision string
@@ -276,7 +274,7 @@ func newHelmActionConfig(t *testing.T, namespace string, rels []helmReleaseStub)
 
 	actionConfig := &action.Configuration{
 		Releases:     storage.Init(memDriver),
-		KubeClient:   &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: ioutil.Discard}},
+		KubeClient:   &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard}},
 		Capabilities: chartutil.DefaultCapabilities,
 		Log: func(format string, v ...interface{}) {
 			t.Helper()

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/test_util_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/test_util_test.go
@@ -10,8 +10,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"testing"
 
@@ -159,11 +159,11 @@ func compareJSONStrings(t *testing.T, expectedJSONString, actualJSONString strin
 // generate-cert.sh script in testdata directory is used to generate these files
 func getCertsForTesting(t *testing.T) (ca, pub, priv []byte) {
 	var err error
-	if ca, err = ioutil.ReadFile(testCert("ca.pem")); err != nil {
+	if ca, err = os.ReadFile(testCert("ca.pem")); err != nil {
 		t.Fatalf("%+v", err)
-	} else if pub, err = ioutil.ReadFile(testCert("server.pem")); err != nil {
+	} else if pub, err = os.ReadFile(testCert("server.pem")); err != nil {
 		t.Fatalf("%+v", err)
-	} else if priv, err = ioutil.ReadFile(testCert("server-key.pem")); err != nil {
+	} else if priv, err = os.ReadFile(testCert("server-key.pem")); err != nil {
 		t.Fatalf("%+v", err)
 	}
 	return ca, pub, priv

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/common/plugin.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/common/plugin.go
@@ -6,7 +6,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/pkgutils"
 )
@@ -55,7 +55,7 @@ func ParsePluginConfig(pluginConfigPath string) (*HelmPluginConfig, error) {
 	var config helmConfig
 
 	// #nosec G304
-	pluginConfig, err := ioutil.ReadFile(pluginConfigPath)
+	pluginConfig, err := os.ReadFile(pluginConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open plugin config at %q: %w", pluginConfigPath, err)
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
@@ -6,9 +6,9 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -797,7 +797,7 @@ func TestAddPackageRepository(t *testing.T) {
 
 func TestGetPackageRepositorySummaries(t *testing.T) {
 	// some prep
-	indexYAMLBytes, err := ioutil.ReadFile(testYaml("valid-index.yaml"))
+	indexYAMLBytes, err := os.ReadFile(testYaml("valid-index.yaml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"regexp"
@@ -1998,7 +1998,7 @@ func newActionConfigFixture(t *testing.T, namespace string, rels []releaseStub, 
 	memDriver := driver.NewMemory()
 
 	if kubeClient == nil {
-		kubeClient = &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: ioutil.Discard}}
+		kubeClient = &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard}}
 	}
 
 	actionConfig := &action.Configuration{

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/test_util_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/test_util_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"testing"

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/test_util_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/test_util_test.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 
 	appRepov1 "github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
@@ -169,7 +169,7 @@ func (f *fakeHTTPClient) Do(h *http.Request) (*http.Response, error) {
 }
 
 func httpResponse(statusCode int, body string) *http.Response {
-	return &http.Response{StatusCode: statusCode, Body: ioutil.NopCloser(bytes.NewReader([]byte(body)))}
+	return &http.Response{StatusCode: statusCode, Body: io.NopCloser(bytes.NewReader([]byte(body)))}
 }
 
 func testCert(name string) string {
@@ -183,11 +183,11 @@ func testYaml(name string) string {
 // generate-cert.sh script in testdata directory is used to generate these files
 func getCertsForTesting(t *testing.T) (ca, pub, priv []byte) {
 	var err error
-	if ca, err = ioutil.ReadFile(testCert("ca.pem")); err != nil {
+	if ca, err = os.ReadFile(testCert("ca.pem")); err != nil {
 		t.Fatalf("%+v", err)
-	} else if pub, err = ioutil.ReadFile(testCert("server.pem")); err != nil {
+	} else if pub, err = os.ReadFile(testCert("server.pem")); err != nil {
 		t.Fatalf("%+v", err)
-	} else if priv, err = ioutil.ReadFile(testCert("server-key.pem")); err != nil {
+	} else if priv, err = os.ReadFile(testCert("server-key.pem")); err != nil {
 		t.Fatalf("%+v", err)
 	}
 	return ca, pub, priv

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/cppforlife/go-cli-ui/ui"
 	ctlapp "github.com/k14s/kapp/pkg/kapp/app"
@@ -68,7 +68,7 @@ func parsePluginConfig(pluginConfigPath string) (*kappControllerPluginParsedConf
 
 	// load the configuration file and unmarshall the values
 	// #nosec G304
-	pluginConfigFile, err := ioutil.ReadFile(pluginConfigPath)
+	pluginConfigFile, err := os.ReadFile(pluginConfigPath)
 	if err != nil {
 		return config, fmt.Errorf("unable to open plugin config at %q: %w", pluginConfigPath, err)
 	}

--- a/cmd/kubeapps-apis/plugins/pkg/agent/agent_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/agent/agent_test.go
@@ -4,7 +4,7 @@
 package agent
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -27,7 +27,7 @@ func newActionConfigFixture(t *testing.T) *action.Configuration {
 
 	return &action.Configuration{
 		Releases:     storage.Init(driver.NewMemory()),
-		KubeClient:   &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: ioutil.Discard}},
+		KubeClient:   &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard}},
 		Capabilities: chartutil.DefaultCapabilities,
 		Log: func(format string, v ...interface{}) {
 			t.Helper()

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -126,7 +125,7 @@ func readResponseBody(res *http.Response) ([]byte, error) {
 		return nil, fmt.Errorf("chart download request failed")
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -9,16 +9,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"path"
-	"strings"
-	"testing"
-	"time"
-
 	"github.com/google/go-cmp/cmp"
-
 	"github.com/stretchr/testify/assert"
 	appRepov1 "github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	helmfake "github.com/vmware-tanzu/kubeapps/pkg/helm/fake"
@@ -31,6 +22,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
 )
 
 func Test_resolveChartURL(t *testing.T) {
@@ -450,7 +447,7 @@ func (f *fakeHTTPClient) Do(h *http.Request) (*http.Response, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewReader(body))}, nil
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(body))}, nil
 	}
 	for _, chartURL := range f.chartURLs {
 		if h.URL.String() == chartURL {
@@ -928,7 +925,7 @@ func TestOCIClient(t *testing.T) {
 
 	t.Run("GetChart - Returns a chart", func(t *testing.T) {
 		cli := NewOCIClient("foo")
-		data, err := ioutil.ReadFile("./testdata/nginx-5.1.1-apiVersionV2.tgz")
+		data, err := os.ReadFile("./testdata/nginx-5.1.1-apiVersionV2.tgz")
 		assert.NoError(t, err)
 		cli.(*OCIRepoClient).puller = &helmfake.OCIPuller{
 			ExpectedName: "foo/bar/nginx:5.1.1",
@@ -944,7 +941,7 @@ func TestOCIClient(t *testing.T) {
 
 	t.Run("GetChart - Returns a chart with multiple slashes", func(t *testing.T) {
 		cli := NewOCIClient("foo")
-		data, err := ioutil.ReadFile("./testdata/nginx-5.1.1-apiVersionV2.tgz")
+		data, err := os.ReadFile("./testdata/nginx-5.1.1-apiVersionV2.tgz")
 		assert.NoError(t, err)
 		cli.(*OCIRepoClient).puller = &helmfake.OCIPuller{
 			ExpectedName: "foo/bar/bar/nginx:5.1.1",

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -9,6 +9,14 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	appRepov1 "github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
@@ -22,12 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
-	"net/http"
-	"os"
-	"path"
-	"strings"
-	"testing"
-	"time"
 )
 
 func Test_resolveChartURL(t *testing.T) {

--- a/pkg/helm/index_test.go
+++ b/pkg/helm/index_test.go
@@ -4,14 +4,14 @@
 package helm
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware-tanzu/kubeapps/pkg/chart/models"
 )
 
-var validRepoIndexYAMLBytes, _ = ioutil.ReadFile("testdata/valid-index.yaml")
+var validRepoIndexYAMLBytes, _ = os.ReadFile("testdata/valid-index.yaml")
 var validRepoIndexYAML = string(validRepoIndexYAMLBytes)
 
 func Test_parseRepoIndex(t *testing.T) {

--- a/pkg/http-client/httpclient.go
+++ b/pkg/http-client/httpclient.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -25,7 +24,7 @@ type Client interface {
 
 // ClientWithDefaults implements Client interface
 // and includes an override of the Do method which injects the following supported defaults:
-//  - headers: e.g. User-Agent and Authorization (when present)
+//   - headers: e.g. User-Agent and Authorization (when present)
 type ClientWithDefaults struct {
 	Client         Client
 	DefaultHeaders http.Header
@@ -43,8 +42,8 @@ func (c *ClientWithDefaults) Do(req *http.Request) (*http.Response, error) {
 }
 
 // creates a new instance of http Client, with following default configuration:
-//		- timeout
-//		- proxy from environment
+//   - timeout
+//   - proxy from environment
 func New() *http.Client {
 	return &http.Client{
 		Timeout: time.Second * defaultTimeoutSeconds,
@@ -60,7 +59,7 @@ func NewWithCertFile(certFile string, skipTLS bool) (*http.Client, error) {
 	// If additionalCA exists, load it
 	if _, err := os.Stat(certFile); !os.IsNotExist(err) {
 		// #nosec G304
-		certs, err := ioutil.ReadFile(certFile)
+		certs, err := os.ReadFile(certFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to append %s to RootCAs: %v", certFile, err)
 		}
@@ -175,7 +174,7 @@ func Get(url string, cli Client, headers map[string]string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }
 
 // performs an HTTP GET request using provided client, URL and request headers.
@@ -202,7 +201,7 @@ func GetStream(url string, cli Client, reqHeaders map[string]string) (io.ReadClo
 
 	if res.StatusCode != http.StatusOK {
 		errorMsg := fmt.Sprintf("GET request to [%s] failed due to status [%d]", url, res.StatusCode)
-		errPayload, err := ioutil.ReadAll(res.Body)
+		errPayload, err := io.ReadAll(res.Body)
 		if err == nil && len(errPayload) > 0 {
 			errorMsg += ": " + string(errPayload)
 		}

--- a/pkg/http-client/httpclient_test.go
+++ b/pkg/http-client/httpclient_test.go
@@ -7,14 +7,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	errors "errors"
-	"io/ioutil"
+	"github.com/google/go-cmp/cmp"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 const pemCert = `
@@ -139,7 +136,7 @@ func TestSetClientTls(t *testing.T) {
 			t.Fatalf("expected OK, got: %d", resp.StatusCode)
 		}
 
-		payload, err := ioutil.ReadAll(resp.Body)
+		payload, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		} else if got, want := payload, expectedPayload; !cmp.Equal(got, want) {

--- a/pkg/http-client/httpclient_test.go
+++ b/pkg/http-client/httpclient_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	errors "errors"
+	"io"
 	"github.com/google/go-cmp/cmp"
 	"net/http"
 	"net/http/httptest"

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -8,11 +8,18 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
 	"github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	apprepoclientset "github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
 	v1alpha1typed "github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned/typed/apprepository/v1alpha1"
 	httpclient "github.com/vmware-tanzu/kubeapps/pkg/http-client"
-	"io"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,12 +30,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	log "k8s.io/klog/v2"
-	"net/http"
-	"net/url"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
 )
 
 const OCIImageManifestMediaType = "application/vnd.oci.image.manifest.v1+json"
@@ -160,7 +161,7 @@ func NewClusterConfig(inClusterConfig *rest.Config, userToken string, cluster st
 }
 
 func ParseClusterConfig(configPath, caFilesPrefix string, pinnipedProxyURL, PinnipedProxyCACert string) (ClustersConfig, func(), error) {
-	caFilesDir, err := os.TempDir(caFilesPrefix, "")
+	caFilesDir, err := os.MkdirTemp(caFilesPrefix, "")
 	if err != nil {
 		return ClustersConfig{}, func() {}, err
 	}

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -13,7 +13,6 @@ import (
 	v1alpha1typed "github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned/typed/apprepository/v1alpha1"
 	httpclient "github.com/vmware-tanzu/kubeapps/pkg/http-client"
 	"io"
-	"io/ioutil"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -161,7 +160,7 @@ func NewClusterConfig(inClusterConfig *rest.Config, userToken string, cluster st
 }
 
 func ParseClusterConfig(configPath, caFilesPrefix string, pinnipedProxyURL, PinnipedProxyCACert string) (ClustersConfig, func(), error) {
-	caFilesDir, err := ioutil.TempDir(caFilesPrefix, "")
+	caFilesDir, err := os.TempDir(caFilesPrefix, "")
 	if err != nil {
 		return ClustersConfig{}, func() {}, err
 	}
@@ -170,7 +169,7 @@ func ParseClusterConfig(configPath, caFilesPrefix string, pinnipedProxyURL, Pinn
 	}
 
 	// #nosec G304
-	content, err := ioutil.ReadFile(configPath)
+	content, err := os.ReadFile(configPath)
 	if err != nil {
 		return ClustersConfig{}, deferFn, err
 	}
@@ -209,7 +208,7 @@ func ParseClusterConfig(configPath, caFilesPrefix string, pinnipedProxyURL, Pinn
 			c.CAFile = filepath.Join(caFilesDir, c.Name)
 			// #nosec G306
 			// TODO(agamez): check if we can set perms to 0600 instead of 0644.
-			err = ioutil.WriteFile(c.CAFile, decodedCAData, 0644)
+			err = os.WriteFile(c.CAFile, decodedCAData, 0644)
 			if err != nil {
 				return ClustersConfig{}, deferFn, err
 			}
@@ -764,9 +763,9 @@ func getOCIAppRepositoryTag(cli httpclient.Client, repoURL string, repoName stri
 	var body []byte
 	var repoTagsData repoTagsList
 
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
-		log.Errorf("ioutil.ReadAll : unable to get: %v", err)
+		log.Errorf("io.ReadAll : unable to get: %v", err)
 		return "", err
 	}
 
@@ -818,7 +817,7 @@ func getOCIAppRepositoryMediaType(cli httpclient.Client, repoURL string, repoNam
 
 	var mediaData repoManifest
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -881,7 +880,7 @@ func (r HelmNonOCIValidator) Validate(cli httpclient.Client) (*ValidationRespons
 	}
 	response := &ValidationResponse{Code: res.StatusCode, Message: "OK"}
 	if response.Code != 200 {
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to parse validation response. Got: %w", err)
 		}

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -1857,7 +1857,7 @@ func TestParseClusterConfig(t *testing.T) {
 }
 
 func createConfigFile(t *testing.T, content string) string {
-	tmpfile, err := os.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -309,7 +309,7 @@ func TestAppRepositoryCreate(t *testing.T) {
 				clientset:         cs,
 			}
 
-			apprepo, err := handler.CreateAppRepository(ioutil.NopCloser(strings.NewReader(tc.requestData)), tc.requestNamespace)
+			apprepo, err := handler.CreateAppRepository(io.NopCloser(strings.NewReader(tc.requestData)), tc.requestNamespace)
 			checkErr(t, err, tc.expectedError)
 
 			if apprepo != nil {
@@ -469,7 +469,7 @@ func TestAppRepositoryUpdate(t *testing.T) {
 				clientset:         cs,
 			}
 
-			apprepo, err := handler.UpdateAppRepository(ioutil.NopCloser(strings.NewReader(tc.requestData)), tc.requestNamespace)
+			apprepo, err := handler.UpdateAppRepository(io.NopCloser(strings.NewReader(tc.requestData)), tc.requestNamespace)
 			checkErr(t, err, tc.expectedError)
 
 			if apprepo != nil {
@@ -994,18 +994,18 @@ func TestNonOCIValidate(t *testing.T) {
 		{
 			name:             "it returns 200 OK validation response if there is no error and the external response is 200",
 			httpValidator:    HelmNonOCIValidator{Req: validRequest},
-			fakeRepoResponse: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewReader([]byte("OK")))},
+			fakeRepoResponse: &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader([]byte("OK")))},
 			expectedResponse: &ValidationResponse{Code: 200, Message: "OK"},
 		},
 		{
 			name:             "it does not include the body of the upstream response when validation succeeds",
 			httpValidator:    HelmNonOCIValidator{Req: validRequest},
-			fakeRepoResponse: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewReader([]byte("10 Mb of data")))},
+			fakeRepoResponse: &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader([]byte("10 Mb of data")))},
 			expectedResponse: &ValidationResponse{Code: 200, Message: "OK"},
 		},
 		{
 			name:             "it returns an error from the response with the body text if validation fails",
-			fakeRepoResponse: &http.Response{StatusCode: 401, Body: ioutil.NopCloser(bytes.NewReader([]byte("It failed because of X and Y")))},
+			fakeRepoResponse: &http.Response{StatusCode: 401, Body: io.NopCloser(bytes.NewReader([]byte("It failed because of X and Y")))},
 			expectedResponse: &ValidationResponse{Code: 401, Message: "It failed because of X and Y"},
 			httpValidator:    HelmNonOCIValidator{Req: validRequest},
 		},
@@ -1406,7 +1406,7 @@ func TestValidateAppRepository(t *testing.T) {
 			}
 
 			handler := userHandler{kubeappsNamespace: kubeappsNamespace}
-			response, err := handler.ValidateAppRepository(ioutil.NopCloser(bytes.NewReader(appRepoJson)), tc.requestNamespace)
+			response, err := handler.ValidateAppRepository(io.NopCloser(bytes.NewReader(appRepoJson)), tc.requestNamespace)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
@@ -1843,7 +1843,7 @@ func TestParseClusterConfig(t *testing.T) {
 
 			for clusterName, clusterConfig := range tc.expectedConfig.Clusters {
 				if clusterConfig.CertificateAuthorityDataDecoded != "" {
-					fileCAData, err := ioutil.ReadFile(config.Clusters[clusterName].CAFile)
+					fileCAData, err := os.ReadFile(config.Clusters[clusterName].CAFile)
 					if err != nil {
 						t.Fatalf("error opening %s: %+v", config.Clusters[clusterName].CAFile, err)
 					}
@@ -1857,7 +1857,7 @@ func TestParseClusterConfig(t *testing.T) {
 }
 
 func createConfigFile(t *testing.T, content string) string {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.TempFile("", "")
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}


### PR DESCRIPTION
### Description of the change

The latest golangci-lint version warned us about a deprecation in go: the `io/ioutils`  modules have been moved to `io` and `os` packages. This PR is removing this dependency in favor of each `io` and `os` functions.

### Benefits

No deprecated code in our codebase.

### Possible drawbacks

N/A (some fn signatures might have changed, I'll perform the requires changes as well)

### Applicable issues

-  related https://github.com/vmware-tanzu/kubeapps/pull/5290 (in fact, this PR has to be merged first, otherwise the linter will fail)

### Additional information
N/A
