### PR TITLE
Remove unused `testImage` from chart

### DIFF
--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -422,18 +422,12 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 
 ### Other Parameters
 
-| Name                      | Description                                                                                           | Value                  |
-| ------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------- |
-| `allowNamespaceDiscovery` | Allow users to discover available namespaces (only the ones they have access)                         | `true`                 |
-| `clusters`                | List of clusters that Kubeapps can target for deployments                                             | `[]`                   |
-| `featureFlags.operators`  | Enable ingress record generation for Kubeapps                                                         | `false`                |
-| `rbac.create`             | Specifies whether RBAC resources should be created                                                    | `true`                 |
-| `testImage.registry`      | NGINX image registry                                                                                  | `docker.io`            |
-| `testImage.repository`    | NGINX image repository                                                                                | `bitnami/nginx`        |
-| `testImage.tag`           | NGINX image tag (immutable tags are recommended)                                                      | `1.23.1-debian-11-r15` |
-| `testImage.digest`        | NGINX image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
-| `testImage.pullPolicy`    | NGINX image pull policy                                                                               | `IfNotPresent`         |
-| `testImage.pullSecrets`   | NGINX image pull secrets                                                                              | `[]`                   |
+| Name                      | Description                                                                   | Value   |
+| ------------------------- | ----------------------------------------------------------------------------- | ------- |
+| `allowNamespaceDiscovery` | Allow users to discover available namespaces (only the ones they have access) | `true`  |
+| `clusters`                | List of clusters that Kubeapps can target for deployments                     | `[]`    |
+| `featureFlags.operators`  | Enable ingress record generation for Kubeapps                                 | `false` |
+| `rbac.create`             | Specifies whether RBAC resources should be created                            | `true`  |
 
 
 ### Database Parameters

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -4,7 +4,7 @@
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "kubeapps.imagePullSecrets" -}}
-{{ include "common.images.pullSecrets" (dict "images" (list .Values.frontend.image .Values.dashboard.image .Values.apprepository.image .Values.apprepository.syncImage .Values.authProxy.image .Values.pinnipedProxy.image .Values.kubeappsapis.image .Values.testImage) "global" .Values.global) }}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.frontend.image .Values.dashboard.image .Values.apprepository.image .Values.apprepository.syncImage .Values.authProxy.image .Values.pinnipedProxy.image .Values.kubeappsapis.image) "global" .Values.global) }}
 {{- end -}}
 
 {{/*

--- a/chart/kubeapps/templates/frontend/deployment.yaml
+++ b/chart/kubeapps/templates/frontend/deployment.yaml
@@ -173,6 +173,8 @@ spec:
             - --skip-auth-regex=^\/custom_locale\.json$
             - --skip-auth-regex=^\/favicon.*\.png$
             - --skip-auth-regex=^\/favicon.*\.ico$
+            - --skip-auth-regex=^\/android-chrome-192x192\.png$
+            - --skip-auth-regex=^\/android-chrome-512x512\.png$
             - --skip-auth-regex=^\/static\/
             - --skip-auth-regex=^\/apis/core/plugins/v1alpha1/configured-plugins$
             - --skip-auth-regex=^\/apis/kubeappsapis.core.plugins.v1alpha1.PluginsService/GetConfiguredPlugins$

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1427,34 +1427,6 @@ rbac:
   ## @param rbac.create Specifies whether RBAC resources should be created
   ##
   create: true
-## Image used for the tests
-## Bitnami NGINX image
-## ref: https://hub.docker.com/r/bitnami/nginx/tags/
-## @param testImage.registry NGINX image registry
-## @param testImage.repository NGINX image repository
-## @param testImage.tag NGINX image tag (immutable tags are recommended)
-## @param testImage.digest NGINX image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
-## @param testImage.pullPolicy NGINX image pull policy
-## @param testImage.pullSecrets NGINX image pull secrets
-##
-testImage:
-  registry: docker.io
-  repository: bitnami/nginx
-  tag: 1.23.1-debian-11-r15
-  digest: ""
-  ## Specify a imagePullPolicy
-  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-  ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-  ##
-  pullPolicy: IfNotPresent
-  ## Optionally specify an array of imagePullSecrets.
-  ## Secrets must be manually created in the namespace.
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-  ## e.g:
-  ## pullSecrets:
-  ##   - myRegistryKeySecretName
-  ##
-  pullSecrets: []
 
 ## @section Database Parameters
 


### PR DESCRIPTION
### Description of the change

We noticed we had an unused `.testImage` in our chart. It was being used by a former `helm test` command we used to have.
Today, it is no longer used and can be safely deleted.

### Benefits

No old code in the chart.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

Also squeezing a couple of auth-proxy bypasses for the favicon files.
