### PR TITLE
Fix for CI: adding chart museum ingress

### DIFF
--- a/script/chart-museum.sh
+++ b/script/chart-museum.sh
@@ -89,7 +89,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/connection-proxy-header: keep-alive
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/rewrite-target: /\$2
   name: chartmuseum
 spec:
   rules:
@@ -101,7 +101,7 @@ spec:
             name: chartmuseum
             port:
               number: 8080
-        path: /chart-museum(/|$)(.*)
+        path: /chart-museum(/|\$)(.*)
         pathType: Prefix
 EOF
 

--- a/script/chart-museum.sh
+++ b/script/chart-museum.sh
@@ -61,7 +61,6 @@ pushChartToChartMuseum() {
   local CHART_FILE=$3
 
   echo ">> Pushing chart '${CHART_FILE}' (${CHART_NAME} v${CHART_VERSION}) to chart museum at ${CHARTMUSEUM_HOSTNAME} and IP ${CHARTMUSEUM_IP}"
-  echo "$(curl -Lk -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" -H "Host: ${CHARTMUSEUM_HOSTNAME}" http://${CHARTMUSEUM_IP}/api/charts/${CHART_NAME}/${CHART_VERSION} | jq)"
   CHART_EXISTS=$(curl -Lk -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" -H "Host: ${CHARTMUSEUM_HOSTNAME}" http://${CHARTMUSEUM_IP}/api/charts/${CHART_NAME}/${CHART_VERSION} | jq -r 'any([ .error] ; . > 0)')
   if [ "$CHART_EXISTS" == "true" ]; then
     echo ">> Chart ${CHART_NAME} v${CHART_VERSION} already exists: deleting"

--- a/script/chart-museum.sh
+++ b/script/chart-museum.sh
@@ -33,7 +33,7 @@ pullBitnamiChart() {
 
   CHART_FILE="${CHART_NAME}-${CHART_VERSION}.tgz"
   CHART_URL="https://charts.bitnami.com/bitnami/${CHART_FILE}"
-  echo ">> Adding ${CHART_NAME}-${CHART_VERSION} to ChartMuseum from URL $CHART_URL"
+  echo ">> Storing locally ${CHART_NAME}-${CHART_VERSION} chart from URL $CHART_URL"
   curl -LO "${CHART_URL}"
 }
 
@@ -61,7 +61,8 @@ pushChartToChartMuseum() {
   local CHART_FILE=$3
 
   echo ">> Pushing chart '${CHART_FILE}' (${CHART_NAME} v${CHART_VERSION}) to chart museum at ${CHARTMUSEUM_HOSTNAME} and IP ${CHARTMUSEUM_IP}"
-  CHART_EXISTS=$(curl -Lk -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" -H "Host: ${CHARTMUSEUM_HOSTNAME}" -X GET http://${CHARTMUSEUM_IP}/api/charts/${CHART_NAME}/${CHART_VERSION} | jq -r 'any([ .error] ; . > 0)')
+  echo "$(curl -Lk -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" -H "Host: ${CHARTMUSEUM_HOSTNAME}" http://${CHARTMUSEUM_IP}/api/charts/${CHART_NAME}/${CHART_VERSION} | jq)"
+  CHART_EXISTS=$(curl -Lk -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" -H "Host: ${CHARTMUSEUM_HOSTNAME}" http://${CHARTMUSEUM_IP}/api/charts/${CHART_NAME}/${CHART_VERSION} | jq -r 'any([ .error] ; . > 0)')
   if [ "$CHART_EXISTS" == "true" ]; then
     echo ">> Chart ${CHART_NAME} v${CHART_VERSION} already exists: deleting"
     curl -Lk -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" -H "Host: ${CHARTMUSEUM_HOSTNAME}" -X DELETE http://${CHARTMUSEUM_IP}/api/charts/${CHART_NAME}/${CHART_VERSION}
@@ -108,6 +109,7 @@ spec:
         path: /
         pathType: ImplementationSpecific
 EOF
+  sleep 20
 
   echo "Chart museum v${CHARTMUSEUM_VERSION} installed in namespace ${CHARTMUSEUM_NS}"
   echo "Credentials: ${CHARTMUSEUM_USER} / ${CHARTMUSEUM_PWD}"

--- a/script/chart-museum.sh
+++ b/script/chart-museum.sh
@@ -3,8 +3,6 @@
 # Copyright 2022 the Kubeapps contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null && pwd)"
-CONTROL_PLANE_CONTAINER=${CONTROL_PLANE_CONTAINER:-"kubeapps-ci-control-plane"}
 CHARTMUSEUM_USER=${CHARTMUSEUM_USER:-"admin"}
 CHARTMUSEUM_PWD=${CHARTMUSEUM_PWD:-"password"}
 CHARTMUSEUM_NS=${CHARTMUSEUM_NS:-"chart-museum"}

--- a/script/chart-museum.sh
+++ b/script/chart-museum.sh
@@ -3,11 +3,13 @@
 # Copyright 2022 the Kubeapps contributors.
 # SPDX-License-Identifier: Apache-2.0
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null && pwd)"
+CONTROL_PLANE_CONTAINER=${CONTROL_PLANE_CONTAINER:-"kubeapps-ci-control-plane"}
 CHARTMUSEUM_USER=${CHARTMUSEUM_USER:-"admin"}
 CHARTMUSEUM_PWD=${CHARTMUSEUM_PWD:-"password"}
 CHARTMUSEUM_NS=${CHARTMUSEUM_NS:-"chart-museum"}
 CHARTMUSEUM_VERSION=${CHARTMUSEUM_VERSION:-"3.9.0"}
-CHARTMUSEUM_HOSTNAME=${CHARTMUSEUM_HOSTNAME:-"localhost"}
+CHARTMUSEUM_HOSTNAME=${CHARTMUSEUM_HOSTNAME:-"chart-museum"}
 
 # Pull a Bitnami chart to a local TGZ file
 # Arguments:
@@ -57,16 +59,15 @@ pushChartToChartMuseum() {
   local CHART_VERSION=$2
   local CHART_FILE=$3
 
-  echo "Pushing chart ${CHART_NAME} v${CHART_VERSION} to chart museum"
-  CHART_EXISTS=$(curl -k -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" -X GET http://${CHARTMUSEUM_HOSTNAME}/chart-museum/api/charts/${CHART_NAME}/${CHART_VERSION} | jq -r 'any([ .error] ; . > 0)')
-  echo "Chart exists? $CHART_EXISTS"
+  echo ">> Pushing chart '${CHART_FILE}' (${CHART_NAME} v${CHART_VERSION}) to chart museum at ${CHARTMUSEUM_HOSTNAME}"
+  CHART_EXISTS=$(curl -Lk -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" -X GET http://${CHARTMUSEUM_HOSTNAME}/api/charts/${CHART_NAME}/${CHART_VERSION} | jq -r 'any([ .error] ; . > 0)')
   if [ "$CHART_EXISTS" == "true" ]; then
-    echo ">> CHART EXISTS: deleting"
-    curl -k -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" -X DELETE http://${CHARTMUSEUM_HOSTNAME}/chart-museum/api/charts/${CHART_NAME}/${CHART_VERSION}
+    echo ">> Chart ${CHART_NAME} v${CHART_VERSION} already exists: deleting"
+    curl -Lk -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" -X DELETE http://${CHARTMUSEUM_HOSTNAME}/api/charts/${CHART_NAME}/${CHART_VERSION}
   fi
   
   echo ">> Uploading chart from file ${CHART_FILE}"
-  curl -k -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" --data-binary "@${CHART_FILE}" http://${CHARTMUSEUM_HOSTNAME}/chart-museum/api/charts  
+  curl -Lk -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" --data-binary "@${CHART_FILE}" http://${CHARTMUSEUM_HOSTNAME}/api/charts  
 }
 
 # Install ChartsMuseum
@@ -88,7 +89,8 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/connection-proxy-header: keep-alive
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-    nginx.ingress.kubernetes.io/rewrite-target: /\$2
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
+    nginx.ingress.kubernetes.io/proxy-buffers: "4.0"
   name: chartmuseum
 spec:
   ingressClassName: nginx
@@ -101,16 +103,19 @@ spec:
             name: chartmuseum
             port:
               number: 8080
-        path: /chart-museum(/|\$)(.*)
-        pathType: Prefix
+        path: /
+        pathType: ImplementationSpecific
 EOF
+
+  # Add Ingress IP to hosts file
+  sudo echo "${DEX_IP}  ${CHARTMUSEUM_HOSTNAME}" >> /etc/hosts
 
   echo "Chart museum v${CHARTMUSEUM_VERSION} installed in namespace ${CHARTMUSEUM_NS}"
   echo "Credentials: ${CHARTMUSEUM_USER} / ${CHARTMUSEUM_PWD}"
   echo "Cluster internal URL: "
   echo "    http://chartmuseum.${CHARTMUSEUM_NS}.svc.cluster.local:8080/"
   echo "URL through ingress: "
-  echo "    http://${CHARTMUSEUM_HOSTNAME}/chart-museum"
+  echo "    http://${CHARTMUSEUM_HOSTNAME}/"
 }
 
 # Uninstall ChartsMuseum

--- a/script/chart-museum.sh
+++ b/script/chart-museum.sh
@@ -57,15 +57,15 @@ pushChartToChartMuseum() {
   local CHART_FILE=$3
 
   echo "Pushing chart ${CHART_NAME} v${CHART_VERSION} to chart museum"
-  CHART_EXISTS=$(curl -L -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" -X GET http://localhost/chart-museum/api/charts/${CHART_NAME}/${CHART_VERSION} | jq -r 'any([ .error] ; . > 0)')
+  CHART_EXISTS=$(curl -k -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" -X GET http://localhost/chart-museum/api/charts/${CHART_NAME}/${CHART_VERSION} | jq -r 'any([ .error] ; . > 0)')
   echo "Chart exists? $CHART_EXISTS"
   if [ "$CHART_EXISTS" == "true" ]; then
     echo ">> CHART EXISTS: deleting"
-    curl -L -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" -X DELETE http://localhost/chart-museum/api/charts/${CHART_NAME}/${CHART_VERSION}
+    curl -k -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" -X DELETE http://localhost/chart-museum/api/charts/${CHART_NAME}/${CHART_VERSION}
   fi
   
   echo ">> Uploading chart from file ${CHART_FILE}"
-  curl -L -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" --data-binary "@${CHART_FILE}" http://localhost/chart-museum/api/charts  
+  curl -k -u "${CHARTMUSEUM_USER}:${CHARTMUSEUM_PWD}" --data-binary "@${CHART_FILE}" http://localhost/chart-museum/api/charts  
   
   rm ${CHART_FILE}
 }

--- a/script/chart-museum.sh
+++ b/script/chart-museum.sh
@@ -74,7 +74,6 @@ pushChartToChartMuseum() {
 # Install ChartsMuseum
 installChartMuseum() {
   echo "Installing ChartMuseum ${CHARTMUSEUM_VERSION}..."
-  echo "https://github.com/chartmuseum/charts/releases/download/chartmuseum-${CHARTMUSEUM_VERSION}/chartmuseum-${CHARTMUSEUM_VERSION}.tgz"
   helm install chartmuseum --namespace ${CHARTMUSEUM_NS} --create-namespace "https://github.com/chartmuseum/charts/releases/download/chartmuseum-${CHARTMUSEUM_VERSION}/chartmuseum-${CHARTMUSEUM_VERSION}.tgz" \
     --set env.open.DISABLE_API=false \
     --set persistence.enabled=true \

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -137,15 +137,11 @@ installOLM() {
 # Arguments:
 #   $1: chart
 #   $2: version
-#   $3: chartmuseum username
-#   $4: chartmuseum password
 # Returns: None
 #########################
 pushChart() {
   local chart=$1
   local version=$2
-  local user=$3
-  local password=$4
   prefix="kubeapps-"
   description="foo ${chart} chart for CI"
 
@@ -164,6 +160,7 @@ pushChart() {
   sed -i "0,/^\([[:space:]]*description: *\).*/s//\1${description}/" ./${chart}-${version}/${chart}/Chart.yaml
   helm package ./${chart}-${version}/${chart} -d .
 
+  sleep 10
   pushChartToChartMuseum "${chart}" "${version}" "${prefix}${chart}-${version}.tgz"
 }
 
@@ -320,8 +317,8 @@ fi
 
 # Install ChartMuseum
 installChartMuseum "${CHARTMUSEUM_VERSION}"
-pushChart apache 8.6.2 admin password
-pushChart apache 8.6.3 admin password
+pushChart apache 8.6.2
+pushChart apache 8.6.3
 
 # Install Kubeapps
 installOrUpgradeKubeapps "${ROOT_DIR}/chart/kubeapps"

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -160,7 +160,6 @@ pushChart() {
   sed -i "0,/^\([[:space:]]*description: *\).*/s//\1${description}/" ./${chart}-${version}/${chart}/Chart.yaml
   helm package ./${chart}-${version}/${chart} -d .
 
-  sleep 10
   pushChartToChartMuseum "${chart}" "${version}" "${prefix}${chart}-${version}.tgz"
 }
 


### PR DESCRIPTION
### Description of the change

CI E2E runs are constantly failing due to problems with the `port-forward` done in the chart-museum part.
Whenever a chart is needed to be pushed to chart-museum, there is a port-forward done to the service.

That solution is weak and error prone, this PR removes that and adds an ingress setup for Chart museum so that there is no port-forward used anymore.
Ingress is only used from the scripts to push charts. From the E2E tests, the same internal service locator is used (`http://chartmuseum.${CHARTMUSEUM_NS}.svc.cluster.local:8080/`).

### Benefits

It should bring more reliability.

### Possible drawbacks

N/A

### Applicable issues

N/A
