### PR TITLE
New K8s clients provider for Helm plugin

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_resources.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_resources.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (s *Server) getPkgRepositoryResource(ctx context.Context, cluster, namespace string) (dynamic.ResourceInterface, error) {
-	_, dynClient, err := s.GetClients(ctx, cluster)
+	dynClient, err := s.clientGetter.Dynamic(ctx, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (s *Server) getPkgRepository(ctx context.Context, cluster, namespace, ident
 	}
 
 	// Auth and TLS
-	typedClient, _, err := s.GetClients(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, cluster)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/pkg/clientgetter/clients_provider.go
+++ b/cmd/kubeapps-apis/plugins/pkg/clientgetter/clients_provider.go
@@ -1,0 +1,159 @@
+// Copyright 2022 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+package clientgetter
+
+import (
+	"context"
+	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/core"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	apiext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type TypedClientFunc func() (kubernetes.Interface, error)
+type DynamicClientFunc func() (dynamic.Interface, error)
+type ApiExtFunc func() (apiext.Interface, error)
+
+// ControllerRuntimeFunc returns an instance of https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/client#Client
+// that also supports Watch operations
+type ControllerRuntimeFunc func() (client.WithWatch, error)
+
+// ClientGetter holds the functions that will actually return the client independently
+type ClientGetter struct {
+	Typed             TypedClientFunc
+	Dynamic           DynamicClientFunc
+	ControllerRuntime ControllerRuntimeFunc
+	ApiExt            ApiExtFunc
+}
+
+// GetClientsFunc is a function that provides a ClientGetter per cluster
+type GetClientsFunc func(ctx context.Context, cluster string) (*ClientGetter, error)
+
+type ClientProviderInterface interface {
+	Typed(ctx context.Context, cluster string) (kubernetes.Interface, error)
+	Dynamic(ctx context.Context, cluster string) (dynamic.Interface, error)
+	ControllerRuntime(ctx context.Context, cluster string) (client.WithWatch, error)
+	ApiExt(ctx context.Context, cluster string) (apiext.Interface, error)
+	GetClients(ctx context.Context, cluster string) (*ClientGetter, error)
+}
+
+// ClientProvider provides a real implementation of the ClientProviderInterface interface
+type ClientProvider struct {
+	ClientsFunc GetClientsFunc
+}
+
+func (cp ClientProvider) Typed(ctx context.Context, cluster string) (kubernetes.Interface, error) {
+	clientGetter, err := cp.GetClients(ctx, cluster)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "unable to build clients due to: %v", err)
+	}
+	return clientGetter.Typed()
+}
+
+func (cp ClientProvider) Dynamic(ctx context.Context, cluster string) (dynamic.Interface, error) {
+	clientGetter, err := cp.GetClients(ctx, cluster)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "unable to build clients due to: %v", err)
+	}
+	return clientGetter.Dynamic()
+}
+
+func (cp ClientProvider) ControllerRuntime(ctx context.Context, cluster string) (client.WithWatch, error) {
+	clientGetter, err := cp.GetClients(ctx, cluster)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "unable to build clients due to: %v", err)
+	}
+	return clientGetter.ControllerRuntime()
+}
+
+func (cp ClientProvider) ApiExt(ctx context.Context, cluster string) (apiext.Interface, error) {
+	clientGetter, err := cp.GetClients(ctx, cluster)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "unable to build clients due to: %v", err)
+	}
+	return clientGetter.ApiExt()
+}
+
+func (cp ClientProvider) GetClients(ctx context.Context, cluster string) (*ClientGetter, error) {
+	if cp.ClientsFunc == nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "clients provider function is not set")
+	}
+	return cp.ClientsFunc(ctx, cluster)
+}
+
+// buildClientsProviderFunction Creates the default function for obtaining a ClientGetter
+func buildClientsProviderFunction(configGetter core.KubernetesConfigGetter, options Options) (GetClientsFunc, error) {
+	return func(ctx context.Context, cluster string) (*ClientGetter, error) {
+		if configGetter == nil {
+			return nil, status.Errorf(codes.Internal, "configGetter arg required")
+		}
+		config, err := configGetter(ctx, cluster)
+		if err != nil {
+			code := codes.FailedPrecondition
+			if status.Code(err) == codes.Unauthenticated {
+				// want to make sure we return same status in this case
+				code = codes.Unauthenticated
+			}
+			return nil, status.Errorf(code, "unable to get in cluster config due to: %v", err)
+		}
+
+		var typedClientFunc TypedClientFunc = func() (kubernetes.Interface, error) {
+			typedClient, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return nil, status.Errorf(codes.FailedPrecondition, "unable to get typed client due to: %v", err)
+			}
+			return typedClient, nil
+		}
+
+		var dynamicClientFunc DynamicClientFunc = func() (dynamic.Interface, error) {
+			dynamicClient, err := dynamic.NewForConfig(config)
+			if err != nil {
+				return nil, status.Errorf(codes.FailedPrecondition, "unable to get dynamic client due to: %v", err)
+			}
+			return dynamicClient, nil
+		}
+
+		var controllerRuntimeClientFunc ControllerRuntimeFunc = func() (client.WithWatch, error) {
+			ctrlOpts := client.Options{}
+			if options.Scheme != nil {
+				ctrlOpts.Scheme = options.Scheme
+			}
+			if options.Mapper != nil {
+				ctrlOpts.Mapper = options.Mapper
+			}
+
+			ctrlClient, err := client.NewWithWatch(config, ctrlOpts)
+			if err != nil {
+				return nil, status.Errorf(codes.FailedPrecondition, "unable to get controller runtime client due to: %v", err)
+			}
+			return ctrlClient, nil
+		}
+
+		var apiExtClientFunc ApiExtFunc = func() (apiext.Interface, error) {
+			apiExtensions, err := apiext.NewForConfig(config)
+			if err != nil {
+				return nil, status.Errorf(codes.FailedPrecondition, "unable to get api extensions client due to: %v", err)
+			}
+			return apiExtensions, nil
+		}
+		return &ClientGetter{typedClientFunc, dynamicClientFunc, controllerRuntimeClientFunc, apiExtClientFunc}, nil
+	}, nil
+}
+
+func NewClientProvider(configGetter core.KubernetesConfigGetter, options Options) (ClientProviderInterface, error) {
+	clientsGetFunc, err := buildClientsProviderFunction(configGetter, options)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "unable to get client provider functions due to: %v", err)
+	}
+	return &ClientProvider{ClientsFunc: clientsGetFunc}, nil
+}
+
+func NewFixedClientProvider(clientsGetter *ClientGetter) ClientProviderInterface {
+	return &ClientProvider{ClientsFunc: func(ctx context.Context, cluster string) (*ClientGetter, error) {
+		return clientsGetter, nil
+	}}
+}

--- a/cmd/kubeapps-apis/plugins/pkg/clientgetter/clients_provider_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/clientgetter/clients_provider_test.go
@@ -1,0 +1,102 @@
+// Copyright 2022 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+package clientgetter
+
+import (
+	"context"
+	"fmt"
+	apiext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	apiextfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	typfake "k8s.io/client-go/kubernetes/fake"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetClientProvider(t *testing.T) {
+
+	clientGetter := &ClientProvider{ClientsFunc: func(ctx context.Context, cluster string) (*ClientGetter, error) {
+		return &ClientGetter{
+			Typed: func() (kubernetes.Interface, error) { return typfake.NewSimpleClientset(), nil },
+			Dynamic: func() (dynamic.Interface, error) {
+				return dynfake.NewSimpleDynamicClientWithCustomListKinds(
+					runtime.NewScheme(),
+					map[schema.GroupVersionResource]string{
+						{Group: "foo", Version: "bar", Resource: "baz"}: "PackageList",
+					},
+				), nil
+			},
+			ApiExt: func() (apiext.Interface, error) {
+				return apiextfake.NewSimpleClientset(), nil
+			},
+			ControllerRuntime: func() (ctrlclient.WithWatch, error) {
+				return ctrlfake.NewClientBuilder().Build(), nil
+			},
+		}, nil
+
+	}}
+
+	badClientGetter := &ClientProvider{ClientsFunc: func(ctx context.Context, cluster string) (*ClientGetter, error) {
+		return nil, fmt.Errorf("Bang!")
+	}}
+
+	testCases := []struct {
+		name         string
+		clientGetter ClientProviderInterface
+		statusCode   codes.Code
+	}{
+		{
+			name:         "it returns failed-precondition when configGetter itself errors",
+			statusCode:   codes.Unknown,
+			clientGetter: badClientGetter,
+		},
+		{
+			name:         "it returns client without error when configured correctly",
+			statusCode:   codes.OK,
+			clientGetter: clientGetter,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// If there is no error, the client should be a dynamic.Interface implementation.
+			if tc.statusCode == codes.OK {
+				dynamicClient, err := tc.clientGetter.Dynamic(context.Background(), "")
+				if err != nil {
+					t.Fatal(err)
+				} else if dynamicClient == nil {
+					t.Errorf("got: nil, want: dynamic.Interface")
+				}
+
+				typedClient, err := tc.clientGetter.Typed(context.Background(), "")
+				if err != nil {
+					t.Fatal(err)
+				} else if typedClient == nil {
+					t.Errorf("got: nil, want: kubernetes.Interface")
+				}
+
+				apiExClient, err := tc.clientGetter.ApiExt(context.Background(), "")
+				if err != nil {
+					t.Fatal(err)
+				} else if apiExClient == nil {
+					t.Errorf("got: nil, want: clientset.Interface")
+				}
+
+				ctrlClient, err := tc.clientGetter.ControllerRuntime(context.Background(), "")
+				if err != nil {
+					t.Fatal(err)
+				} else if ctrlClient == nil {
+					t.Errorf("got: nil, want: client.WithWatch")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

This PR adds a new logic for obtaining the clients for K8s APIs. It resides in the `/pkg` package, but it is only applied to the Helm plugin by now.
It should speed up the response times for Helm plugin: a lot when using Pinniped, not so much without Pinniped.

Problem solved here was found to be the root cause for #4919.

In the business logic of Helm plugin (at least), usually only one type of client is required per scenario (e.g. the typed client when retrieving available packages summary).
When using the old client getter, all types of clients were being retrieved due to [the invocation of `clientGetterHelper`](https://github.com/vmware-tanzu/kubeapps/blob/cf858134a3b67e9f6ee2c53ce7b5071407b3ff7a/cmd/kubeapps-apis/plugins/pkg/clientgetter/clientgetter.go#L228), even if only one was needed.

It turns out that when creating the dynamic client, many requests are done at the same time to the K8s APIs to get the resources, which probably is triggering the throttling mechanism. There is no throttling when `pinniped-proxy` is not in the picture, but when it is, all requests go through it, with throttling. List of URLs invoked:

```
/api/v1?timeout=32s
/apis?timeout=32s
/apis/admissionregistration.k8s.io/v1?timeout=32s
/apis/apiextensions.k8s.io/v1?timeout=32s
/apis/apiregistration.k8s.io/v1?timeout=32s
/apis/apps/v1?timeout=32s
/apis/authentication.concierge.pinniped.dev/v1alpha
/apis/authentication.k8s.io/v1?timeout=32s
/apis/authorization.k8s.io/v1?timeout=32s
/apis/autoscaling/v1?timeout=32s
/apis/autoscaling/v2?timeout=32s
/apis/autoscaling/v2beta2?timeout=32s
/apis/batch/v1?timeout=32s
/apis/certificates.k8s.io/v1?timeout=32s
/apis/config.concierge.pinniped.dev/v1alpha1?timeou
/apis/coordination.k8s.io/v1?timeout=32s
/apis/discovery.k8s.io/v1?timeout=32s
/apis/events.k8s.io/v1?timeout=32s
/apis/flowcontrol.apiserver.k8s.io/v1beta1?timeout=
/apis/flowcontrol.apiserver.k8s.io/v1beta2?timeout=
/apis/identity.concierge.pinniped.dev/v1alpha1?time
/apis/kubeapps.com/v1alpha1/apprepositories
/apis/login.concierge.pinniped.dev/v1alpha1?timeout
/apis/networking.k8s.io/v1?timeout=32s
/apis/node.k8s.io/v1?timeout=32s
/apis/policy/v1?timeout=32s
/apis/rbac.authorization.k8s.io/v1?timeout=32s
/apis/scheduling.k8s.io/v1?timeout=32s
/apis/storage.k8s.io/v1?timeout=32s
/apis/storage.k8s.io/v1beta1?timeout=32s
```

When creating all clients, even if only one was needed, the mentioned URLs are retrieved more than once, accumulating delays.

With this PR, the new clients provider allows to independently create the client according to the needs. All clients can still be retrieved together with `ClientProviderInterface.GetClients`, but there are dedicated methods for each type.
Difference with previous implementation is that [the function building the clients](https://github.com/vmware-tanzu/kubeapps/blob/4919-catalog-request-delayed/cmd/kubeapps-apis/plugins/pkg/clientgetter/clients_provider.go#L89) does not return the instances, but returns functions for each one to be invoked if needed.

### Benefits

Response time in many calls is improved from 5-9 seconds down to <1s when using Pinniped and Helm plugin.

### Possible drawbacks

N/A

### Applicable issues

- fixes #4919


