### PR TITLE
Add timestamp to Pinniped proxy logs

### DIFF
--- a/cmd/pinniped-proxy/src/main.rs
+++ b/cmd/pinniped-proxy/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2022 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::io::Write;
+use chrono::Local;
 use std::convert::Infallible;
 use std::fs;
 
@@ -10,7 +12,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Server,
 };
-use log::info;
+use log::{info, LevelFilter};
 use structopt::StructOpt;
 use tls_listener::TlsListener;
 
@@ -24,7 +26,17 @@ mod tls_config;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    pretty_env_logger::init();
+    pretty_env_logger::formatted_timed_builder()
+    .format(|buf, record| {
+        writeln!(buf,
+            "{} [{}] - {}",
+            Local::now().format("%Y-%m-%dT%H:%M:%S%.6f"),
+            record.level(),
+            record.args()
+        )
+    })
+    .filter(None, LevelFilter::Info)
+    .init();
     let opt = cli::Options::from_args();
 
     // Load the default certificate authority data on startup once.

--- a/site/content/docs/latest/reference/developer/pinniped-proxy.md
+++ b/site/content/docs/latest/reference/developer/pinniped-proxy.md
@@ -72,7 +72,7 @@ Next, replace `172.18.0.2` with the previous IP (and `172.18.0.3` with the next 
 - Run `make add-pinniped-jwt-authenticator` and additionally `make add-pinniped-jwt-authenticator-additional` for multi-cluster.
 - Open <https://localhost/> and login with `kubeapps-operator@example.com`/`password`
 
-> Note: make sure you are really copying `certificate-authority-data` and not the `client-certificate-data` or `client-certificate-data`. Otherwise, the setup will not work.
+> Note: make sure you are really copying `certificate-authority-data` and not the `client-certificate-data` or `client-key-data`. Otherwise, the setup will not work.
 
 ### Update the pinniped-proxy image in your cluster
 


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

Adds timestamp to logs in Pinniped proxy. Uses the same format than Kubeapps-apis.

Before:
```
INFO  pinniped_proxy::service > GET https://kubernetes.default/apis/kubeapps.com/v1alpha1/apprepositories 200 OK
```

After:
```
2022-09-21T09:49:16.567145 [INFO] - GET https://kubernetes.default/apis/kubeapps.com/v1alpha1/apprepositories 200 OK
```

### Benefits

Logs have the timestamp info

### Possible drawbacks

N/A

### Applicable issues

- related to #4919
