### PR TITLE
Open add end-2-end tests that test core api server and plug-ins features #2881 

### DIFF
--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/chart_cache.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/chart_cache.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -75,8 +74,9 @@ type DownloadChartFn func(chartID, chartUrl, chartVersion string) ([]byte, error
 
 // chartCacheStoreEntry is what we'll be storing in the processing store
 // note that url and delete fields are mutually exclusive, you must either:
-//  - set url to non-empty string or
-//  - deleted flag to true
+//   - set url to non-empty string or
+//   - deleted flag to true
+//
 // setting both for a given entry does not make sense
 type chartCacheStoreEntry struct {
 	namespace  string
@@ -377,7 +377,7 @@ func (c *ChartCache) syncHandler(workerName, key string) error {
 
 	chart, ok := entry.(chartCacheStoreEntry)
 	if !ok {
-		return fmt.Errorf("unexpected object in cache store: [%s]", reflect.TypeOf(entry))
+		return fmt.Errorf("unexpected object in cache store: [%T]", entry)
 	}
 
 	if chart.deleted {
@@ -453,18 +453,18 @@ func (c *ChartCache) Fetch(key string) ([]byte, error) {
 }
 
 /*
- Get() is like Fetch() but if there is a cache miss, it will then get chart data based on
- the corresponding repo object, process it and then add it to the cache and return the
- result.
- This func should:
+Get() is like Fetch() but if there is a cache miss, it will then get chart data based on
+the corresponding repo object, process it and then add it to the cache and return the
+result.
+This func should:
 
- • return an error if the entry could not be computed due to not being able to read
- repos secretRef.
+• return an error if the entry could not be computed due to not being able to read
+repos secretRef.
 
- • return nil for any invalid chart name.
+• return nil for any invalid chart name.
 
- • otherwise return the bytes stored in the
- chart cache for the given entry
+• otherwise return the bytes stored in the
+chart cache for the given entry
 */
 func (c *ChartCache) Get(key string, chart *models.Chart, downloadFn DownloadChartFn) ([]byte, error) {
 	// TODO (gfichtenholt) it'd be nice to get rid of all arguments except for the key, similar to that of
@@ -583,7 +583,7 @@ func (c *ChartCache) WaitUntilResyncComplete() {
 
 func chartCacheKeyFunc(obj interface{}) (string, error) {
 	if entry, ok := obj.(chartCacheStoreEntry); !ok {
-		return "", fmt.Errorf("unexpected object in chartCacheKeyFunc: [%s]", reflect.TypeOf(obj))
+		return "", fmt.Errorf("unexpected object in chartCacheKeyFunc: [%T]", obj)
 	} else {
 		return chartCacheKeyFor(entry.namespace, entry.id, entry.version)
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/rate_limiting_queue.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/rate_limiting_queue.go
@@ -5,7 +5,6 @@ package cache
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -58,8 +57,7 @@ func (q *rateLimitingType) AddRateLimited(item interface{}) {
 	}
 	if itemstr, ok := item.(string); !ok {
 		// workqueue.Interface does not allow returning errors, so
-		runtime.HandleError(fmt.Errorf("invalid argument: expected string, found: [%s]",
-			reflect.TypeOf(item)))
+		runtime.HandleError(fmt.Errorf("invalid argument: expected string, found: [%T]", item))
 	} else {
 		q.DelayingInterface.AddAfter(itemstr, duration)
 	}
@@ -167,8 +165,7 @@ func (q *Type) Add(item interface{}) {
 	}
 	if itemstr, ok := item.(string); !ok {
 		// workqueue.Interface does not allow returning errors, so
-		runtime.HandleError(fmt.Errorf("invalid argument: expected string, found: [%s]",
-			reflect.TypeOf(item)))
+		runtime.HandleError(fmt.Errorf("invalid argument: expected string, found: [%T]", item))
 	} else {
 		q.expected.Delete(itemstr)
 		if q.dirty.Has(itemstr) {
@@ -237,8 +234,7 @@ func (q *Type) Done(item interface{}) {
 
 	if itemstr, ok := item.(string); !ok {
 		// workqueue.Interface does not allow returning errors, so
-		runtime.HandleError(fmt.Errorf("invalid argument: expected string, found: [%s]",
-			reflect.TypeOf(item)))
+		runtime.HandleError(fmt.Errorf("invalid argument: expected string, found: [%T]", item))
 	} else {
 		q.processing.Delete(itemstr)
 		if q.dirty.Has(itemstr) {

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/watcher_cache.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/watcher_cache.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -521,7 +520,7 @@ func (c *NamespacedResourceWatcherCache) processOneEvent(event watch.Event) {
 	switch event.Type {
 	case watch.Added, watch.Modified, watch.Deleted:
 		if obj, ok := event.Object.(ctrlclient.Object); !ok {
-			runtime.HandleError(fmt.Errorf("could not cast %s to *ctrlclient.Object", reflect.TypeOf(event.Object)))
+			runtime.HandleError(fmt.Errorf("could not cast %T to *ctrlclient.Object", event.Object))
 		} else if key, err := c.keyFor(obj); err != nil {
 			runtime.HandleError(err)
 		} else {

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart_integration_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart_integration_test.go
@@ -14,11 +14,13 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	corev1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	plugins "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	fluxplugin "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common"
 	"golang.org/x/sync/semaphore"
+	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	apiv1 "k8s.io/api/core/v1"
@@ -251,24 +253,25 @@ func TestKindClusterGetAvailablePackageSummariesForLargeReposAndTinyRedis(t *tes
 }
 
 // scenario:
-// 1) create two namespaces
-// 2) create two helm repositories, each containing a single package: one in each of the namespaces from (1)
-// 3) create 3 service-accounts in default namespace:
-//   a) - "...-admin", with cluster-wide access
-//   b) - "...-loser", without cluster-wide access or any access to any of the namespaces
-//   c) - "...-limited", without cluster-wide access, but with read access to one namespace
-// 4) execute GetAvailablePackageSummaries():
-//   a) with 3a) => should return 2 packages
-//   b) with 3b) => should return 0 packages
-//   c) with 3c) => should return 1 package
-// 5) execute GetAvailablePackageDetail():
-//   a) with 3a) => should work 2 times
-//   b) with 3b) => should fail 2 times with PermissionDenied error
-//   c) with 3c) => should fail once and work once
-// 6) execute GetAvailablePackageVersions():
-//   a) with 3a) => should work 2 times
-//   b) with 3b) => should fail 2 times with PermissionDenied error
-//   c) with 3c) => should fail once and work once
+//  1. create two namespaces
+//  2. create two helm repositories, each containing a single package: one in each of the namespaces from (1)
+//  3. create 3 service-accounts in default namespace:
+//     a) - "...-admin", with cluster-wide access
+//     b) - "...-loser", without cluster-wide access or any access to any of the namespaces
+//     c) - "...-limited", without cluster-wide access, but with read access to one namespace
+//  4. execute GetAvailablePackageSummaries():
+//     a) with 3a) => should return 2 packages
+//     b) with 3b) => should return 0 packages
+//     c) with 3c) => should return 1 package
+//  5. execute GetAvailablePackageDetail():
+//     a) with 3a) => should work 2 times
+//     b) with 3b) => should fail 2 times with PermissionDenied error
+//     c) with 3c) => should fail once and work once
+//  6. execute GetAvailablePackageVersions():
+//     a) with 3a) => should work 2 times
+//     b) with 3b) => should fail 2 times with PermissionDenied error
+//     c) with 3c) => should fail once and work once
+//
 // ref https://github.com/vmware-tanzu/kubeapps/issues/4390
 func TestKindClusterRepoAndChartRBAC(t *testing.T) {
 	fluxPluginClient, _, err := checkEnv(t)
@@ -815,12 +818,38 @@ func testKindClusterAvailablePackageEndpointsForOCIHelper(
 				t.Fatal(err)
 			}
 
-			grpcContext, cancel := context.WithTimeout(grpcContext, defaultContextTimeout)
-			defer cancel()
+			// ocassionally, on the server-side, I see a request that takes a really long time:
+			// I0923 03:26:42.829561       1 oci_repo.go:739] about to call helmGetter.Get(us-west1-docker.pkg.dev/vmware-kubeapps-ci/stefanprodan-podinfo-clone/podinfo:6.1.6)
+			// I0923 03:27:10.036728       1 oci_repo.go:742] helmGetter.Get(us-west1-docker.pkg.dev/vmware-kubeapps-ci/stefanprodan-podinfo-clone/podinfo:6.1.6) returned buffer size: [13544] error: <nil>
+			// so we'll use a longer timeout for these calls. Even so, every once in a while I get
+			// I0923 04:18:29.278764       1 oci_repo.go:739] about to call helmGetter.Get(us-west1-docker.pkg.dev/vmware-kubeapps-ci/stefanprodan-podinfo-clone/podinfo:6.1.6)
+			// I0923 04:23:30.391277       1 oci_repo.go:742] helmGetter.Get(us-west1-docker.pkg.dev/vmware-kubeapps-ci/stefanprodan-podinfo-clone/podinfo:6.1.6) returned buffer size: [13544] error: <nil>
+			//  i.e. an RPC call that takes > 4 minutes.
+			// DeadlineExceeded errors should not be retried because it means the server hasn't
+			// quite finished the original request even though the client is proceeding. The way the
+			// cache works is that a 2nd request is just going not going to get past rate limiting
+			// and in the end both will fail. There is no way for the client to know when the server finishes
+			// processing the 1st request, so for now, let's just allow a really long timeout
+			// I also ocassionally see
+			// I0923 08:03:07.519347       1 oci_repo.go:649] login(us-west1-docker.pkg.dev): Get "https://us-west1-docker.pkg.dev/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
+			// and
+			// I0923 17:35:12.800491       1 oci_repo.go:649] login(us-west1-docker.pkg.dev): Get "https://us-west1-docker.pkg.dev/v2/": Get "https://us-west1-docker.pkg.dev/v2/token?account=_json_key&client_id=docker&offline_token=true": dial tcp 142.251.2.82:443: i/o timeout (Client.Timeout exceeded while awaiting headers)
+			// These errors I would like retried
+			timeout := 5 * time.Minute
+			maxTries := 2
+			retryOptions := []grpc.CallOption{
+				grpc_retry.WithPerRetryTimeout(timeout),
+				grpc_retry.WithMax(uint(maxTries)),
+				grpc_retry.WithCodes(codes.Internal),
+			}
 
+			hour, minute, second := time.Now().Clock()
+			t.Logf("[%d:%d:%d] Calling GetAvailablePackageSummaries() blocking for up to [%s]...",
+				hour, minute, second, time.Duration(int64(timeout)*int64(maxTries)))
 			resp, err := fluxPluginClient.GetAvailablePackageSummaries(
 				grpcContext,
-				&corev1.GetAvailablePackageSummariesRequest{})
+				&corev1.GetAvailablePackageSummariesRequest{},
+				retryOptions...)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -844,8 +873,9 @@ func testKindClusterAvailablePackageEndpointsForOCIHelper(
 				return // nothing more to check
 			}
 
-			grpcContext, cancel = context.WithTimeout(grpcContext, defaultContextTimeout)
-			defer cancel()
+			hour, minute, second = time.Now().Clock()
+			t.Logf("[%d:%d:%d] Calling GetAvailablePackageVersions() blocking for up to [%s]...",
+				hour, minute, second, time.Duration(int64(timeout)*int64(maxTries)))
 			resp2, err := fluxPluginClient.GetAvailablePackageVersions(
 				grpcContext, &corev1.GetAvailablePackageVersionsRequest{
 					AvailablePackageRef: &corev1.AvailablePackageReference{
@@ -854,7 +884,8 @@ func testKindClusterAvailablePackageEndpointsForOCIHelper(
 						},
 						Identifier: repoName.Name + "/podinfo",
 					},
-				})
+				},
+				retryOptions...)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -865,8 +896,9 @@ func testKindClusterAvailablePackageEndpointsForOCIHelper(
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, opts))
 			}
 
-			grpcContext, cancel = context.WithTimeout(grpcContext, defaultContextTimeout)
-			defer cancel()
+			hour, minute, second = time.Now().Clock()
+			t.Logf("[%d:%d:%d] Calling GetAvailablePackageDetail(latest version) blocking for up to [%s]...",
+				hour, minute, second, time.Duration(int64(timeout)*int64(maxTries)))
 			resp3, err := fluxPluginClient.GetAvailablePackageDetail(
 				grpcContext,
 				&corev1.GetAvailablePackageDetailRequest{
@@ -876,7 +908,8 @@ func testKindClusterAvailablePackageEndpointsForOCIHelper(
 						},
 						Identifier: repoName.Name + "/podinfo",
 					},
-				})
+				},
+				retryOptions...)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -886,11 +919,10 @@ func testKindClusterAvailablePackageEndpointsForOCIHelper(
 				resp3.AvailablePackageDetail,
 				expected_detail_oci_stefanprodan_podinfo(repoName.Name, tc.registryUrl).AvailablePackageDetail)
 
-			// try a few older versions
-			grpcContext, cancel = context.WithTimeout(grpcContext, defaultContextTimeout)
-			defer cancel()
-			resp4, err := fluxPluginClient.GetAvailablePackageDetail(
-				grpcContext,
+			// try an older version
+			t.Logf("[%d:%d:%d] Calling GetAvailablePackageDetail(specific version) blocking for up to [%s]...",
+				hour, minute, second, time.Duration(int64(timeout)*int64(maxTries)))
+			resp4, err := fluxPluginClient.GetAvailablePackageDetail(grpcContext,
 				&corev1.GetAvailablePackageDetailRequest{
 					AvailablePackageRef: &corev1.AvailablePackageReference{
 						Context: &corev1.Context{
@@ -899,7 +931,7 @@ func testKindClusterAvailablePackageEndpointsForOCIHelper(
 						Identifier: repoName.Name + "/podinfo",
 					},
 					PkgVersion: "6.1.6",
-				})
+				}, retryOptions...)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/global_vars_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/global_vars_test.go
@@ -3603,6 +3603,35 @@ var (
 		}
 	}
 
+	expected_oci_repo_with_2_charts_available_summaries = func(name string) *corev1.GetAvailablePackageSummariesResponse {
+		return &corev1.GetAvailablePackageSummariesResponse{
+			AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
+				{
+					Name:                "airflow",
+					AvailablePackageRef: availableRef(name+"/airflow", "default"),
+					LatestVersion: &corev1.PackageAppVersion{
+						PkgVersion: "6.7.1",
+					},
+					IconUrl:          "https://bitnami.com/assets/stacks/airflow/img/airflow-stack-110x117.png",
+					DisplayName:      "airflow",
+					ShortDescription: "Apache Airflow is a platform to programmatically author, schedule and monitor workflows.",
+					Categories:       []string{"WorkFlow"},
+				},
+				{
+					Name:                "redis",
+					AvailablePackageRef: availableRef(name+"/redis", "default"),
+					LatestVersion: &corev1.PackageAppVersion{
+						PkgVersion: "14.4.0",
+					},
+					IconUrl:          "https://bitnami.com/assets/stacks/redis/img/redis-stack-220x234.png",
+					DisplayName:      "redis",
+					ShortDescription: "Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.",
+					Categories:       []string{"Database"},
+				},
+			},
+		}
+	}
+
 	no_available_summaries = func(name string) *corev1.GetAvailablePackageSummariesResponse {
 		return &corev1.GetAvailablePackageSummariesResponse{}
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/integration_utils_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/integration_utils_test.go
@@ -89,6 +89,7 @@ const (
 	harbor_stefanprodan_podinfo_oci_registry_url         = "oci://demo.goharbor.io/stefanprodan-podinfo-clone"
 	harbor_stefanprodan_podinfo_private_oci_registry_url = "oci://demo.goharbor.io/stefanprodan-podinfo-clone-private"
 	gcp_stefanprodan_podinfo_oci_registry_url            = "oci://us-west1-docker.pkg.dev/vmware-kubeapps-ci/stefanprodan-podinfo-clone"
+	harbor_repo_with_2_charts_oci_registry_url           = "oci://demo.goharbor.io/repo-with-2-charts"
 
 	// the URL of local in cluster helm registry. Gets deployed via ./integ-test-env.sh
 	// in_cluster_oci_registry_url = "oci://registry-app-svc.default.svc.cluster.local:5000/helm-charts"
@@ -1370,12 +1371,12 @@ func deleteChartFromMyGithubRegistry(t *testing.T, version string) error {
 	return err
 }
 
-func setupHarborStefanProdanClone(t *testing.T) error {
-	t.Logf("+setupHarborStefanProdanClone()")
-	defer t.Logf("-setupHarborStefanProdanClone()")
+func setupHarborForIntegrationTest(t *testing.T) error {
+	t.Logf("+setupHarborForIntegrationTest()")
+	defer t.Logf("-setupHarborForIntegrationTest()")
 
 	args := []string{
-		"setupHarborStefanProdanClone",
+		"setupHarbor",
 		"--quick",
 	}
 

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/oci_repo.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/oci_repo.go
@@ -26,7 +26,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"reflect"
 	"sort"
 	"strings"
 
@@ -229,8 +228,8 @@ func (r *OCIChartRepository) listRepositoryNames() ([]string, error) {
 				r.repositoryLister = lister
 				break
 			} else {
-				log.Infof("Lister [%v] not applicable for registry with URL [%s] due to: [%v]",
-					reflect.TypeOf(lister), r.url.String(), err)
+				log.Infof("Lister [%T] not applicable for registry with URL [%s] due to: [%v]",
+					lister, r.url.String(), err)
 			}
 		}
 	}
@@ -289,6 +288,7 @@ func (r *OCIChartRepository) getTags(ref string) ([]string, error) {
 
 // TODO (gfichtenholt) Call this at some point :)
 // logout attempts to logout from the OCI registry.
+//
 //nolint:unused
 func (r *OCIChartRepository) logout() error {
 	log.Info("+logout")
@@ -646,9 +646,9 @@ func (s *repoEventSink) newOCIChartRepositoryAndLoginWithOptions(registryURL str
 	// Attempt to login to the registry if credentials are provided.
 	if loginOpts != nil {
 		err := ociRepo.registryClient.Login(ociRepo.url.Host, loginOpts...)
-		log.Infof("login(%s): %v", ociRepo.url.Host, err)
+		log.Infof("login(%s): err code: [%d], %v", ociRepo.url.Host, status.Code(err), err)
 		if err != nil {
-			return nil, err
+			return nil, status.Errorf(codes.Internal, "failed to login to registry '%s' due to %v", registryURL, err)
 		}
 	}
 	return ociRepo, nil

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
@@ -6,7 +6,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
@@ -113,7 +112,7 @@ func NewServer(configGetter core.KubernetesConfigGetter, kubeappsCluster string,
 			NewListFunc:  func() ctrlclient.ObjectList { return &sourcev1.HelmRepositoryList{} },
 			ListItemsFunc: func(ol ctrlclient.ObjectList) []ctrlclient.Object {
 				if hl, ok := ol.(*sourcev1.HelmRepositoryList); !ok {
-					log.Errorf("Expected: *sourcev1.HelmRepositoryList, got: %s", reflect.TypeOf(ol))
+					log.Errorf("Expected: *sourcev1.HelmRepositoryList, got: %T", ol)
 					return nil
 				} else {
 					ret := make([]ctrlclient.Object, len(hl.Items))

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server_test.go
@@ -6,7 +6,6 @@ package main
 import (
 	"context"
 	"io"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -368,7 +367,7 @@ func newServer(t *testing.T,
 		NewListFunc:  func() ctrlclient.ObjectList { return &sourcev1.HelmRepositoryList{} },
 		ListItemsFunc: func(ol ctrlclient.ObjectList) []ctrlclient.Object {
 			if hl, ok := ol.(*sourcev1.HelmRepositoryList); !ok {
-				t.Fatalf("Expected: *sourcev1.HelmRepositoryList, got: %s", reflect.TypeOf(ol))
+				t.Fatalf("Expected: *sourcev1.HelmRepositoryList, got: %T", ol)
 				return nil
 			} else {
 				ret := make([]ctrlclient.Object, len(hl.Items))

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/test_util_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/test_util_test.go
@@ -94,9 +94,7 @@ func (w *withWatchWrapper) Watch(ctx context.Context, list client.ObjectList, op
 	if err != nil {
 		return wi, err
 	} else if watcher, ok := wi.(*watch.RaceFreeFakeWatcher); !ok {
-		return wi, fmt.Errorf(
-			"Unexpected type for watcher, expected *watch.RaceFreeFakeWatcher, got: %s",
-			reflect.TypeOf(wi))
+		return wi, fmt.Errorf("Unexpected type for watcher, expected *watch.RaceFreeFakeWatcher, got: %T", wi)
 	} else {
 		w.watcher = watcher
 		return wi, err
@@ -374,7 +372,7 @@ func ctrlClientAndWatcher(t *testing.T, s *Server) (client.WithWatch, *watch.Rac
 	if ctrlClient, err := s.clientGetter.ControllerRuntime(ctx, s.kubeappsCluster); err != nil {
 		return nil, nil, err
 	} else if ww, ok := ctrlClient.(*withWatchWrapper); !ok {
-		return nil, nil, fmt.Errorf("Could not cast %s to: *withWatchWrapper", reflect.TypeOf(ctrlClient))
+		return nil, nil, fmt.Errorf("Could not cast %T to: *withWatchWrapper", ctrlClient)
 	} else if watcher := ww.watcher; watcher == nil {
 		return nil, nil, fmt.Errorf("Unexpected condition watcher is nil")
 	} else {

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/testdata/gcloud-setup.md
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/testdata/gcloud-setup.md
@@ -467,7 +467,7 @@ $ grpcurl -plaintext -d '{"available_package_ref": {"context": {"cluster": "defa
   }
 }
 
-$ $ grpcurl -plaintext -d '{"installed_package_ref": {"context": {"cluster": "default", "namespace": "default"}, "plugin": {"name": "fluxv2.packages", "version": "v1alpha1"}, "identifier": "podinfo-1"}}' -H "Authorization: Bearer $token" localhost:8081 kubeappsapis.core.packages.v1alpha1.PackagesService.GetInstalledPackageDetail
+$ grpcurl -plaintext -d '{"installed_package_ref": {"context": {"cluster": "default", "namespace": "default"}, "plugin": {"name": "fluxv2.packages", "version": "v1alpha1"}, "identifier": "podinfo-1"}}' -H "Authorization: Bearer $token" localhost:8081 kubeappsapis.core.packages.v1alpha1.PackagesService.GetInstalledPackageDetail
 {
   "installedPackageDetail": {
     "installedPackageRef": {

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/testdata/integ-test-env.sh
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/testdata/integ-test-env.sh
@@ -203,7 +203,7 @@ function logs {
 
 if [ $# -lt 1 ]
 then
-  echo "Usage : $0 deploy|undeploy|redeploy|shell|logs|pushChartToMyGithub|deleteChartVersionFromMyGitHub|setupGithubStefanProdanClone|setupHarborStefanProdanClone|setupGcrStefanProdanClone"
+  echo "Usage : $0 deploy|undeploy|redeploy|shell|logs|pushChartToMyGithub|deleteChartVersionFromMyGitHub|setupGithubStefanProdanClone|setupHarbor|setupGcrStefanProdanClone"
   exit
 fi
 
@@ -228,7 +228,7 @@ deleteChartVersionFromMyGitHub) deleteChartVersionFromMyGitHubRegistry $2
     ;;
 setupGithubStefanProdanClone) setupGithubStefanProdanClone
     ;;
-setupHarborStefanProdanClone) setupHarborStefanProdanClone ${2: }
+setupHarbor) setupHarbor ${2: }
     ;;
 setupHarborRobotAccount) setupHarborRobotAccount
     ;;

--- a/go.mod
+++ b/go.mod
@@ -165,6 +165,7 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -595,6 +595,7 @@ github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:Fecb
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
+github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=

--- a/integration/tests/flux/04-default-deployment.spec.js
+++ b/integration/tests/flux/04-default-deployment.spec.js
@@ -1,0 +1,51 @@
+// Copyright 2022 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+const { test, expect } = require("@playwright/test");
+const { KubeappsLogin } = require("../utils/kubeapps-login");
+const utils = require("../utils/util-functions");
+
+test("Deploys podinfo package with default values in main cluster", async ({ page }) => {
+  // Log in
+  const k = new KubeappsLogin(page);
+  await k.doLogin("kubeapps-operator@example.com", "password", process.env.ADMIN_TOKEN);
+
+  // Switch to user's namespace using UI
+  await page.click(".kubeapps-dropdown .kubeapps-nav-link");
+  await page.selectOption('select[name="namespaces"]', "kubeapps-user-namespace");
+  await page.click('cds-button:has-text("Change Context")');
+
+  // Select package to deploy
+  await page.click('a.nav-link:has-text("Catalog")');
+  await page.locator("input#search").fill("podinfo");
+  await page.waitForTimeout(3000);
+  await page.click('a:has-text("Podinfo Helm chart for Kubernetes")');
+  await page.click('cds-button:has-text("Deploy") >> nth=0');
+
+  // Deploy package
+  await page.waitForSelector('select[name="package-versions"]');
+  const versionSelector = await page.locator('select[name="package-versions"]');
+  await versionSelector?.selectOption("6.2.0");
+  await expect(versionSelector).toHaveValue("6.2.0", { timeout: 5000 });
+
+  const releaseNameLocator = page.locator("#releaseName");
+  await releaseNameLocator.waitFor();
+  await expect(releaseNameLocator).toHaveText("");
+  const releaseName = utils.getRandomName("test-04-release");
+  await releaseNameLocator.fill(releaseName);
+  await page.selectOption("#serviceaccount-selector select", "flux-reconciler");
+  await page.locator('cds-button:has-text("Deploy")').click();
+  console.log(`Creating release "${releaseName}"`);
+
+  // Assertions
+  await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
+    timeout: utils.getDeploymentTimeout(),
+  });
+  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
+    timeout: utils.getDeploymentTimeout(),
+  });
+
+  // Clean up
+  await page.locator('cds-button:has-text("Delete")').click();
+  await page.locator('cds-modal-actions button:has-text("Delete")').click();
+});

--- a/script/local-docker-registry.sh
+++ b/script/local-docker-registry.sh
@@ -88,6 +88,7 @@ pushContainerToLocalRegistry() {
     # Access through Ingress TLS
     DOCKER_REGISTRY="$DOCKER_REGISTRY_HOST:443"
 
+    echo You may be prompted for sudo Password in order to append to /etc/hosts
     echo "127.0.0.1  $DOCKER_REGISTRY_HOST" | sudo tee -a /etc/hosts
 
     docker pull nginx


### PR DESCRIPTION
Also added some logic to make flux integration tests that rely on external repos (harbor, gcp, github) to handle infrequent intermittent errors due to long latencies and network failures by using grpc_retry package