### PR TITLE
Fix for Kapp app suffix

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_resources.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_resources.go
@@ -506,7 +506,7 @@ func (s *Server) updatePkgInstall(ctx context.Context, cluster, namespace string
 // getAppUsedGVs returns the list of GVs used by the given app, falling back to pre 0.47 Kapp version behavior with regards to suffixes
 func getAppUsedGVs(appsClient ctlapp.Apps, packageId string, namespace string, useNewCtrlAppSuffix bool) ([]schema.GroupVersion, ctlapp.App, error) {
 	// We first try to fetch the app using the suffixed name (kapp >= 0.47)
-	appName := fmt.Sprintf("%s%s", packageId, ctlapp.AppSuffix)
+	appName := fmt.Sprintf("%s%s", packageId, ".app")
 
 	// Workaround to also support pre-0.47 kapp versions, whose ConfigMap were suffixed with "-ctrl" instead of ".apps.k14s.io"
 	if !useNewCtrlAppSuffix {

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
@@ -6267,7 +6267,7 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
-						Name:      "my-installation.apps.k14s.io",
+						Name:      "my-installation.app",
 					},
 					Data: map[string]string{
 						"spec": "{\"labelKey\":\"kapp.k14s.io/app\",\"labelValue\":\"my-id\"}",

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -16,7 +16,7 @@ IMG_MODIFIER=${4:-""}
 TEST_TIMEOUT_MINUTES=${5:-"4"}
 DEX_IP=${6:-"172.18.0.2"}
 ADDITIONAL_CLUSTER_IP=${7:-"172.18.0.3"}
-KAPP_CONTROLLER_VERSION=${8:-"v0.32.0"}
+KAPP_CONTROLLER_VERSION=${8:-"v0.41.2"}
 CHARTMUSEUM_VERSION=${9:-"3.9.0"}
 
 # TODO(andresmgot): While we work with beta releases, the Bitnami pipeline
@@ -48,6 +48,7 @@ info "Image repo suffix: ${IMG_MODIFIER}"
 info "Dex IP: ${DEX_IP}"
 info "Additional cluster IP : ${ADDITIONAL_CLUSTER_IP}"
 info "Test timeout minutes: ${TEST_TIMEOUT_MINUTES}"
+info "Kapp Controller version: ${KAPP_CONTROLLER_VERSION}"
 info "Cluster Version: $(kubectl version -o json | jq -r '.serverVersion.gitVersion')"
 info "Kubectl Version: $(kubectl version -o json | jq -r '.clientVersion.gitVersion')"
 echo ""


### PR DESCRIPTION
### Description of the change

Kapp controller has introduced a [new suffix for apps identifier since v0.39.0](https://github.com/vmware-tanzu/carvel-kapp-controller/blob/v0.39.0/pkg/deploy/factory.go#L46).
In our CircleCI we were actually using and old version of Kapp Controller (v0.32.0) due to some problem in passing variables to `e2e-test.sh`.

We discovered that changes done in #4767 were not being correctly tested in E2E. That PR adds a fix for handling the app identifier suffix in Kapp Controller versions >0.47, with a fallback to previous versions (using suffix `-ctrl`). E2E was only testing the fallback scenario. Suffix used was [`.apps.k14s.io`](https://github.com/vmware-tanzu/carvel-kapp/blob/develop/pkg/kapp/app/recorded_app.go#L28). Actual suffix for `ConfigMap` used by Carvel has suffix `.app`.

This PR fixes the current suffix usage.

### Benefits

CircleCI should use the latest version of Kapp Controller by now. Although the underlying problem with variables not being passed to `e2e-test.sh` remains.

### Possible drawbacks

We are not covering the right set of suffixes (`.app`/`.pkgr` or `.apps.k14s.io`)

### Applicable issues

- related #4672
- related #4767

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
