### PR TITLE
Add Flux auth provider option to UI

### DIFF
--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
@@ -983,8 +983,8 @@ describe("auth provider selector for Flux repositories", () => {
     await waitFor(() => {
       wrapper.update();
       expect(wrapper.find("#kubeapps-repo-auth-method-provider").first()).not.toBeDisabled();
-      expect(wrapper.find("#kubeapps-flux-auth-provider")).not.toExist();
     });
+    expect(wrapper.find("#kubeapps-flux-auth-provider")).not.toExist();
   });
 
   it("auth provider dropdown should not appear for other repo types", async () => {
@@ -1055,9 +1055,9 @@ describe("auth provider selector for Flux repositories", () => {
     await waitFor(() => {
       wrapper.update();
       expect(wrapper.find("#kubeapps-repo-auth-method-provider")).not.toBeDisabled();
-      expect(wrapper.find("#kubeapps-flux-auth-provider")).toExist();
-      expect(wrapper.find("#kubeapps-flux-auth-provider")).not.toBeDisabled();
-      expect(wrapper.find("#kubeapps-flux-auth-provider select").props().value).toEqual("aws");
     });
+    expect(wrapper.find("#kubeapps-flux-auth-provider")).toExist();
+    expect(wrapper.find("#kubeapps-flux-auth-provider")).not.toBeDisabled();
+    expect(wrapper.find("#kubeapps-flux-auth-provider select").props().value).toEqual("aws");
   });
 });

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.test.tsx
@@ -12,6 +12,7 @@ import {
   PackageRepositorySummary,
 } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
+import { FluxPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/fluxv2/packages/v1alpha1/fluxv2";
 import { HelmPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
 import { act } from "react-dom/test-utils";
 import * as ReactRedux from "react-redux";
@@ -941,6 +942,122 @@ describe("when the repository info is already populated", () => {
       });
       expect(wrapper.find("#kubeapps-repo-tls-cert").prop("value")).toBe("foo");
       expect(wrapper.find("#kubeapps-repo-tls-key").prop("value")).toBe("bar");
+    });
+  });
+});
+
+describe("auth provider selector for Flux repositories", () => {
+  const packageRepoRef = {
+    identifier: "flux-repo",
+    context: defaultProps.packageRepoRef?.context,
+    plugin: { name: PluginNames.PACKAGES_FLUX, version: "v1alpha1" },
+  } as PackageRepositoryReference;
+  const repo = {
+    name: "",
+    description: "",
+    interval: "",
+    packageRepoRef: packageRepoRef,
+    namespaceScoped: false,
+    type: "",
+    url: "",
+  } as PackageRepositoryDetail;
+
+  it("repository auth provider should appear as a valid option for Flux and OCI", async () => {
+    const testRepo = {
+      ...repo,
+      type: "oci",
+      customDetail: {
+        provider: "",
+      } as Partial<FluxPackageRepositoryCustomDetail>,
+    } as PackageRepositoryDetail;
+    let wrapper: any;
+    await act(async () => {
+      wrapper = mountWrapper(
+        getStore({
+          ...defaultState,
+          repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
+        } as Partial<IStoreState>),
+        <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
+      );
+    });
+    await waitFor(() => {
+      wrapper.update();
+      expect(wrapper.find("#kubeapps-repo-auth-method-provider").first()).not.toBeDisabled();
+      expect(wrapper.find("#kubeapps-flux-auth-provider")).not.toExist();
+    });
+  });
+
+  it("auth provider dropdown should not appear for other repo types", async () => {
+    const testRepo = {
+      ...repo,
+      type: "helm",
+    } as PackageRepositoryDetail;
+    let wrapper: any;
+    await act(async () => {
+      wrapper = mountWrapper(
+        getStore({
+          ...defaultState,
+          repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
+        } as Partial<IStoreState>),
+        <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
+      );
+    });
+    await waitFor(() => {
+      wrapper.update();
+      expect(wrapper.find("#kubeapps-repo-auth-method-provider")).toBeDisabled();
+    });
+  });
+
+  it("auth provider dropdown should not appear for other plugins", async () => {
+    const testRepo = {
+      ...repo,
+      type: "oci",
+      packageRepoRef: {
+        identifier: "helm-repo",
+        context: defaultProps.packageRepoRef?.context,
+        plugin: { name: PluginNames.PACKAGES_HELM, version: "v1alpha1" },
+      } as PackageRepositoryReference,
+    } as PackageRepositoryDetail;
+    let wrapper: any;
+    await act(async () => {
+      wrapper = mountWrapper(
+        getStore({
+          ...defaultState,
+          repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
+        } as Partial<IStoreState>),
+        <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
+      );
+    });
+    await waitFor(() => {
+      wrapper.update();
+      expect(wrapper.find("#kubeapps-repo-auth-method-provider")).toBeDisabled();
+    });
+  });
+
+  it("repository auth provider selected should show the subsequent options dropdown", async () => {
+    const testRepo = {
+      ...repo,
+      type: "oci",
+      customDetail: {
+        provider: "aws",
+      } as Partial<FluxPackageRepositoryCustomDetail>,
+    } as PackageRepositoryDetail;
+    let wrapper: any;
+    await act(async () => {
+      wrapper = mountWrapper(
+        getStore({
+          ...defaultState,
+          repos: { ...defaultState.repos, repoDetail: testRepo } as IPackageRepositoryState,
+        } as Partial<IStoreState>),
+        <PkgRepoForm {...defaultProps} packageRepoRef={packageRepoRef} />,
+      );
+    });
+    await waitFor(() => {
+      wrapper.update();
+      expect(wrapper.find("#kubeapps-repo-auth-method-provider")).not.toBeDisabled();
+      expect(wrapper.find("#kubeapps-flux-auth-provider")).toExist();
+      expect(wrapper.find("#kubeapps-flux-auth-provider")).not.toBeDisabled();
+      expect(wrapper.find("#kubeapps-flux-auth-provider select").props().value).toEqual("aws");
     });
   });
 });

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
@@ -25,7 +25,7 @@ import {
 } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
 import { HelmPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
@@ -271,6 +271,16 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
     }
   }, [repo, namespace, currentCluster, dispatch]);
 
+  const hasAuthProvider = useCallback(() => authProvider !== "", [authProvider]);
+
+  const handleFluxAuthProviderAuthChange = useCallback(() => {
+    setAuthMethod(PackageRepositoryAuth_PackageRepositoryAuthType.UNRECOGNIZED);
+    setShowAuthProviderDetails(true);
+    if (!hasAuthProvider()) {
+      setAuthProvider("generic");
+    }
+  }, [setAuthMethod, setShowAuthProviderDetails, hasAuthProvider, setAuthProvider]);
+
   useEffect(() => {
     // Reset auth provider state as soon as there is an auth type selected
     if (
@@ -284,7 +294,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
     } else {
       clearAuthProvider();
     }
-  }, [authMethod, authProvider]);
+  }, [authMethod, authProvider, handleFluxAuthProviderAuthChange, hasAuthProvider]);
 
   const clearAuthProvider = () => {
     setShowAuthProviderDetails(false);
@@ -424,8 +434,6 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
     }
     isInstallingRef.current = false;
   };
-
-  const hasAuthProvider = () => authProvider !== "";
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setName(e.target.value);
@@ -637,13 +645,6 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
   };
   const handleFluxAuthProviderChange = (e: React.FormEvent<HTMLSelectElement>) => {
     setAuthProvider(e.currentTarget.value);
-  };
-  const handleFluxAuthProviderAuthChange = () => {
-    setAuthMethod(PackageRepositoryAuth_PackageRepositoryAuthType.UNRECOGNIZED);
-    setShowAuthProviderDetails(true);
-    if (!hasAuthProvider()) {
-      setAuthProvider("generic");
-    }
   };
 
   const userManagedSecretText = "Use an existing secret";

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
@@ -13,6 +13,7 @@ import { CdsControlMessage, CdsFormGroup } from "@cds/react/forms";
 import { CdsInput } from "@cds/react/input";
 import { CdsRadio, CdsRadioGroup } from "@cds/react/radio";
 import { CdsTextarea } from "@cds/react/textarea";
+import { CdsSelect } from "@cds/react/select";
 import { CdsToggle, CdsToggleGroup } from "@cds/react/toggle";
 import actions from "actions";
 import Alert from "components/js/Alert";
@@ -46,6 +47,7 @@ import {
   k8sObjectNameRegex,
 } from "shared/utils";
 import "./PkgRepoForm.css";
+import { FluxPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/fluxv2/packages/v1alpha1/fluxv2";
 
 export interface IPkgRepoFormProps {
   onSubmit: (data: IPkgRepoFormData) => Promise<boolean>;
@@ -88,6 +90,11 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
   const initialInterval = "10m";
 
   // -- Auth-related variables --
+
+  // Auth provider is only used by Flux plugin
+  const [authProvider, setAuthProvider] = useState("");
+
+  const [showAuthProviderDetails, setShowAuthProviderDetails] = useState(false);
 
   // Auth type of the package repository
   const [authMethod, setAuthMethod] = useState(
@@ -254,8 +261,35 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
           );
         }
       }
+
+      // setting custom details for the Flux plugin
+      if (repo.packageRepoRef?.plugin?.name === PluginNames.PACKAGES_FLUX && repo.customDetail) {
+        const fluxPackageRepositoryCustomDetail =
+          repo.customDetail as Partial<FluxPackageRepositoryCustomDetail>;
+        setAuthProvider(fluxPackageRepositoryCustomDetail?.provider || "");
+      }
     }
   }, [repo, namespace, currentCluster, dispatch]);
+
+  useEffect(() => {
+    // Reset auth provider state as soon as there is an auth type selected
+    if (
+      authMethod === PackageRepositoryAuth_PackageRepositoryAuthType.UNRECOGNIZED ||
+      authMethod ===
+        PackageRepositoryAuth_PackageRepositoryAuthType.PACKAGE_REPOSITORY_AUTH_TYPE_UNSPECIFIED
+    ) {
+      if (hasAuthProvider()) {
+        handleFluxAuthProviderAuthChange();
+      }
+    } else {
+      clearAuthProvider();
+    }
+  }, [authMethod, authProvider]);
+
+  const clearAuthProvider = () => {
+    setShowAuthProviderDetails(false);
+    setAuthProvider("");
+  };
 
   const handleInstallClick = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -297,28 +331,6 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
     if (type === RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_HELM && filterNames !== "") {
       filter = toFilterRule(filterNames, filterRegex, filterExclude);
     }
-
-    // build the custom details object based for each plugin
-    const helmCustomDetail = {
-      ociRepositories: ociRepoList,
-      performValidation,
-      filterRule: filter,
-      imagesPullSecret: {
-        // if using the same credentials toggle is set, use the repo auth's creds instead
-        secretRef: isUserManagedPSSecret ? (useSameAuthCreds ? secretAuthName : secretPSName) : "",
-        credentials: !isUserManagedPSSecret
-          ? {
-              email: useSameAuthCreds ? secretEmail : pullSecretEmail,
-              username: useSameAuthCreds ? secretUser : pullSecretUser,
-              password: useSameAuthCreds ? secretPassword : pullSecretPassword,
-              server: useSameAuthCreds ? secretServer : pullSecretServer,
-            }
-          : undefined,
-      },
-    } as HelmPackageRepositoryCustomDetail;
-
-    //TODO(agamez): add support for kapp's custom details
-    // const kappCustomDetail = undefined as unknown as KappControllerPackageRepositoryCustomDetail;
 
     // build request object for the install call
     const request = {
@@ -365,12 +377,43 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
     // enrich the request object with the corresponding plugin's custom details
     switch (plugin?.name) {
       case PluginNames.PACKAGES_HELM:
-        request.customDetail = helmCustomDetail;
+        request.customDetail = {
+          ociRepositories: ociRepoList,
+          performValidation,
+          filterRule: filter,
+          imagesPullSecret: {
+            // if using the same credentials toggle is set, use the repo auth's creds instead
+            secretRef: isUserManagedPSSecret
+              ? useSameAuthCreds
+                ? secretAuthName
+                : secretPSName
+              : "",
+            credentials: !isUserManagedPSSecret
+              ? {
+                  email: useSameAuthCreds ? secretEmail : pullSecretEmail,
+                  username: useSameAuthCreds ? secretUser : pullSecretUser,
+                  password: useSameAuthCreds ? secretPassword : pullSecretPassword,
+                  server: useSameAuthCreds ? secretServer : pullSecretServer,
+                }
+              : undefined,
+          },
+        } as HelmPackageRepositoryCustomDetail;
         break;
       //TODO(agamez): add it once other PRs get merged
       // case PluginNames.PACKAGES_KAPP:
       //   request.customDetail = kappCustomDetail;
       //   break;
+      case PluginNames.PACKAGES_FLUX:
+        if (hasAuthProvider()) {
+          request.customDetail = {
+            provider: authProvider,
+          } as FluxPackageRepositoryCustomDetail;
+
+          // Backend won't accept UNRECOGNIZED
+          request.authMethod =
+            PackageRepositoryAuth_PackageRepositoryAuthType.PACKAGE_REPOSITORY_AUTH_TYPE_UNSPECIFIED;
+        }
+        break;
       default:
         break;
     }
@@ -381,6 +424,8 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
     }
     isInstallingRef.current = false;
   };
+
+  const hasAuthProvider = () => authProvider !== "";
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setName(e.target.value);
@@ -408,6 +453,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
   };
   const handleAuthRadioButtonChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setAuthMethod(PackageRepositoryAuth_PackageRepositoryAuthType[e.target.value]);
+    clearAuthProvider();
 
     // reset the pull secret copy from auth
     setUseSameAuthCreds(false);
@@ -589,6 +635,16 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
   const handelUseSameAuthCredsChange = (_e: React.ChangeEvent<HTMLInputElement>) => {
     setUseSameAuthCreds(!useSameAuthCreds);
   };
+  const handleFluxAuthProviderChange = (e: React.FormEvent<HTMLSelectElement>) => {
+    setAuthProvider(e.currentTarget.value);
+  };
+  const handleFluxAuthProviderAuthChange = () => {
+    setAuthMethod(PackageRepositoryAuth_PackageRepositoryAuthType.UNRECOGNIZED);
+    setShowAuthProviderDetails(true);
+    if (!hasAuthProvider()) {
+      setAuthProvider("generic");
+    }
+  };
 
   const userManagedSecretText = "Use an existing secret";
   const kubeappsManagedSecretText = "Provide the secret values";
@@ -647,10 +703,12 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
     </>
   );
 
+  /* eslint-disable jsx-a11y/label-has-associated-control */
   return (
     <>
       <form onSubmit={handleInstallClick}>
         <CdsAccordion>
+          {/* Begin Basic panel */}
           <CdsAccordionPanel id="panel-basic" expanded={accordion[0]}>
             <CdsAccordionHeader onClick={() => toggleAccordion(0)}>
               Basic information
@@ -968,7 +1026,9 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
               </CdsFormGroup>
             </CdsAccordionContent>
           </CdsAccordionPanel>
+          {/* End Basic panel */}
 
+          {/* Begin Authentication panel */}
           <CdsAccordionPanel id="panel-auth" expanded={accordion[1]}>
             <CdsAccordionHeader onClick={() => toggleAccordion(1)}>
               Authentication
@@ -998,6 +1058,28 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                         }
                         onChange={handleAuthRadioButtonChange}
                         disabled={!!repo.auth?.type}
+                      />
+                    </CdsRadio>
+                    <CdsRadio>
+                      <label htmlFor="kubeapps-repo-auth-method-provider">Auth provider</label>
+                      <input
+                        id="kubeapps-repo-auth-method-provider"
+                        type="radio"
+                        name="flux-auth-provider"
+                        value="flux-auth-provider"
+                        checked={
+                          authMethod ===
+                            PackageRepositoryAuth_PackageRepositoryAuthType.UNRECOGNIZED &&
+                          showAuthProviderDetails
+                        }
+                        onChange={handleFluxAuthProviderAuthChange}
+                        disabled={
+                          !(
+                            plugin?.name === PluginNames.PACKAGES_FLUX &&
+                            type === "oci" &&
+                            !repo.name
+                          )
+                        }
                       />
                     </CdsRadio>
                     <CdsRadio>
@@ -1239,7 +1321,6 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                       )}
                     </div>
                     {/* End basic authentication */}
-
                     {/* Begin http bearer authentication */}
                     <div
                       id="kubeapps-repo-auth-details-bearer"
@@ -1273,7 +1354,6 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                       )}
                     </div>
                     {/* End http bearer authentication */}
-
                     {/* Begin docker creds authentication */}
                     <div
                       id="kubeapps-repo-auth-details-docker"
@@ -1348,7 +1428,6 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                       )}
                     </div>
                     {/* End docker creds authentication */}
-
                     {/* Begin HTTP custom authentication */}
                     <div
                       id="kubeapps-repo-auth-details-custom"
@@ -1384,7 +1463,6 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                       )}
                     </div>
                     {/* End HTTP custom authentication */}
-
                     {/* Begin SSH authentication */}
                     <div
                       id="kubeapps-repo-auth-details-ssh"
@@ -1440,7 +1518,6 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                       )}
                     </div>
                     {/* End SSH authentication */}
-
                     {/* Begin TLS authentication */}
                     <div
                       id="kubeapps-repo-auth-details-tls"
@@ -1494,7 +1571,6 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                       )}
                     </div>
                     {/* End TLS authentication */}
-
                     {/* Begin opaque authentication */}
                     <div
                       id="kubeapps-repo-auth-details-opaque"
@@ -1530,6 +1606,45 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                       )}
                     </div>
                     {/* End opaque authentication */}
+                    {/* Begin Flux Auth provider details */}
+                    {showAuthProviderDetails && (
+                      <div cds-layout="col@xs:8">
+                        <CdsSelect cds-layout="col@xs:6" id="kubeapps-flux-auth-provider">
+                          <label>Provider</label>
+                          <select
+                            value={authProvider}
+                            onChange={handleFluxAuthProviderChange}
+                            required={true}
+                            disabled={selectedPkgRepo !== undefined}
+                          >
+                            <option key="generic" value="generic">
+                              Generic
+                            </option>
+                            <option key="aws" value="aws">
+                              Amazon Web Services (AWS)
+                            </option>
+                            <option key="azure" value="azure">
+                              Azure
+                            </option>
+                            <option key="gcp" value="gcp">
+                              Google Cloud Platform (GCP)
+                            </option>
+                          </select>
+                          <CdsControlMessage error="valueMissing">
+                            The{" "}
+                            <a
+                              href="https://fluxcd.io/flux/components/source/helmrepositories/#provider"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              OIDC provider
+                            </a>{" "}
+                            that Flux will use for authentication
+                          </CdsControlMessage>
+                        </CdsSelect>
+                      </div>
+                    )}
+                    {/* End Flux Auth provider details */}
                   </div>
                   {/* End authentication details */}
                 </div>
@@ -1800,7 +1915,9 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
               </CdsFormGroup>
             </CdsAccordionContent>
           </CdsAccordionPanel>
+          {/* End Filtering panel */}
 
+          {/* Begin Filtering panel */}
           <CdsAccordionPanel
             id="panel-filtering"
             expanded={accordion[2]}
@@ -1875,6 +1992,9 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
               </CdsFormGroup>
             </CdsAccordionContent>
           </CdsAccordionPanel>
+          {/* End Filtering panel */}
+
+          {/* Begin Advanced panel */}
           <CdsAccordionPanel id="panel-advanced" expanded={accordion[3]}>
             <CdsAccordionHeader onClick={() => toggleAccordion(3)}>Advanced</CdsAccordionHeader>
             <CdsAccordionContent>
@@ -2035,6 +2155,7 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
               </CdsFormGroup>
             </CdsAccordionContent>
           </CdsAccordionPanel>
+          {/* End Advanced panel */}
         </CdsAccordion>
 
         {repo &&

--- a/dashboard/src/reducers/repos.ts
+++ b/dashboard/src/reducers/repos.ts
@@ -6,6 +6,7 @@ import {
   PackageRepositoryDetail,
   PackageRepositorySummary,
 } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
+import { FluxPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/fluxv2/packages/v1alpha1/fluxv2";
 import { HelmPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
 import {
   KappControllerPackageRepositoryCustomDetail,
@@ -47,6 +48,10 @@ const kappPackageRepositoryCustomDetail = {
   fetch: {} as PackageRepositoryFetch,
 } as KappControllerPackageRepositoryCustomDetail;
 
+const fluxPackageRepositoryCustomDetail = {
+  provider: "",
+} as FluxPackageRepositoryCustomDetail;
+
 const reposReducer = (
   state: IPackageRepositoryState = initialState,
   action: PkgReposAction | LocationChangeAction,
@@ -81,6 +86,17 @@ const reposReducer = (
             customDetail = kappPackageRepositoryCustomDetail;
             try {
               customDetail = KappControllerPackageRepositoryCustomDetail.decode(
+                action.payload.customDetail.value,
+              );
+              repoWithCustomDetail = { ...action.payload, customDetail };
+            } catch (error) {
+              repoWithCustomDetail = { ...action.payload };
+            }
+            break;
+          case PluginNames.PACKAGES_FLUX:
+            customDetail = fluxPackageRepositoryCustomDetail;
+            try {
+              customDetail = FluxPackageRepositoryCustomDetail.decode(
                 action.payload.customDetail.value,
               );
               repoWithCustomDetail = { ...action.payload, customDetail };

--- a/dashboard/src/shared/PackageRepositoriesService.ts
+++ b/dashboard/src/shared/PackageRepositoriesService.ts
@@ -28,6 +28,10 @@ import {
   KappControllerPackageRepositoryCustomDetail,
   protobufPackage as kappControllerProtobufPackage,
 } from "gen/kubeappsapis/plugins/kapp_controller/packages/v1alpha1/kapp_controller";
+import {
+  FluxPackageRepositoryCustomDetail,
+  protobufPackage as fluxv2ProtobufPackage,
+} from "gen/kubeappsapis/plugins/fluxv2/packages/v1alpha1/fluxv2";
 import KubeappsGrpcClient from "./KubeappsGrpcClient";
 import { IPkgRepoFormData, PluginNames } from "./types";
 import { convertGrpcAuthError } from "./utils";
@@ -257,6 +261,13 @@ export class PackageRepositoriesService {
           typeUrl: `${kappControllerProtobufPackage}.KappControllerPackageRepositoryCustomDetail`,
           value: KappControllerPackageRepositoryCustomDetail.encode(
             request.customDetail as KappControllerPackageRepositoryCustomDetail,
+          ).finish(),
+        } as Any;
+      case PluginNames.PACKAGES_FLUX:
+        return {
+          typeUrl: `${fluxv2ProtobufPackage}.FluxPackageRepositoryCustomDetail`,
+          value: FluxPackageRepositoryCustomDetail.encode(
+            request.customDetail as FluxPackageRepositoryCustomDetail,
           ).finish(),
         } as Any;
       default:

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -21,6 +21,7 @@ import {
   UsernamePassword,
 } from "gen/kubeappsapis/core/packages/v1alpha1/repositories";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
+import { FluxPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/fluxv2/packages/v1alpha1/fluxv2";
 import { HelmPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
 import { KappControllerPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/kapp_controller/packages/v1alpha1/kapp_controller";
 import { IOperatorsState } from "reducers/operators";
@@ -476,7 +477,9 @@ export interface IPkgRepoFormData {
   url: string;
   // add more types if necessary
   customDetail?: Partial<
-    HelmPackageRepositoryCustomDetail | KappControllerPackageRepositoryCustomDetail
+    | HelmPackageRepositoryCustomDetail
+    | KappControllerPackageRepositoryCustomDetail
+    | FluxPackageRepositoryCustomDetail
   >;
   namespace: string;
   isNamespaceScoped: boolean;


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

This PR implements #5378. Adds to the package repositories management UI the possibility to select an auth provider for the so called auto-login.
It only works for Flux plugin and OCI repositories, and it is added as another authentication method available.

![image](https://user-images.githubusercontent.com/67455978/193828803-6d36d708-be98-45a7-8e7c-9c8f9552bdc5.png)

Following the backend logic that swallows an update on this field (`customDetails.provider`), the update in the UI is disabled. Although I incline more towards throwing an error from backend in those cases, it hasn't been implemented like that, so I tried to mitigate from UI.

![image](https://user-images.githubusercontent.com/67455978/193828686-5649f65a-cf1c-4858-be8e-a4bb8676aee4.png)


### Benefits

The backend/API part implemented in #5368 is finally available through UI.

### Possible drawbacks

There is a bit of a mix in the concepts of `spec.provider` and actual authentication. In theory, according to Flux documentation: `The generic provider can be used for public repositories or when static credentials are used for authentication. If you do not specify .spec.provider, it defaults to generic.`.
Therefore, if a non-generic provider is selected (e.g. `aws`), the regular authentication won't work. But the field is implemented in the `customDetails` section of the Kubeapps APIs package repository DTOs, not as another regular authentication method.

### Applicable issues

- implements #5378
