### PR TITLE
Run GHA pipeline on pushes to main branch

### DIFF
--- a/.github/workflows/kubeapps.yaml
+++ b/.github/workflows/kubeapps.yaml
@@ -6,7 +6,7 @@ name: Kubeapps general pipeline
 on:
   push:
     branches:
-      - migrate-ci
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
With this change, the GH Actions workflow will be triggered on pushes to the main branch, as right now it's only being triggered on PRs and pushes to the `migrate-ci` branch (the one used for its development).

### Benefits

<!-- What benefits will be realized by the code change? -->
The workflow will be triggered when it should be.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
Nothing.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #4436 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
