### PR TITLE
Change IMG_MODIFIER suffix for the GHA workflow

### DIFF
--- a/.github/workflows/kubeapps.yaml
+++ b/.github/workflows/kubeapps.yaml
@@ -6,7 +6,7 @@ name: Kubeapps general pipeline
 on:
   push:
     branches:
-      - migrate-ci
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/kubeapps.yaml
+++ b/.github/workflows/kubeapps.yaml
@@ -42,7 +42,7 @@ env:
   # as an output of the `setup` job.
   IMG_DEV_TAG: "build-${{ github.sha }}"
   # Apart from using a dev tag we use a different image ID to avoid polluting the tag history of the production tag
-  IMG_MODIFIER: "-ci"
+  IMG_MODIFIER: "-ci-gha"
   IMG_PREFIX: "kubeapps/"
   # We use IMG_PREFIX_FOR_FORKS for development purposes, it's used when the workflow is run from a fork of the kubeapps repo
   IMG_PREFIX_FOR_FORKS: "beni0888/"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Currently, both GHA and CircleCI workflows (aka. pipelines), are running in parallel and configured to generate the development docker images using the same suffix `-ci` to avoid polluting the canonical images repository. However, this leads us to a situation where both pipelines overlap when it comes to pushing the images to Dockerhub, and cannot make sure which was the pipeline that generated each published image (it will depend on which finishes last).

### Benefits

<!-- What benefits will be realized by the code change? -->
We can clearly identify which workflow generated what image and avoid overlap by having the images generated by both repositories publicly available in Dockerhub, under different suffixes.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
Nothing, as we're in the development phase of the GHA workflow, it should have any negative consequences in case we break anything on it.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #4436 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
