### PR TITLE
Fix the job push_dev_images from GHA workflow

### DIFF
--- a/.github/workflows/kubeapps.yaml
+++ b/.github/workflows/kubeapps.yaml
@@ -339,9 +339,10 @@ jobs:
       - build_dashboard_image
       - build_e2e_runner_image
     env:
-      IMAGES_TO_PUSH: ${IMAGES_TO_PUSH} integration-tests
+      ADDITIONAL_IMAGES_TO_PUSH: integration-tests
       IMG_PREFIX: ${{ needs.setup.outputs.img_prefix }}
     steps:
+      - run: echo "IMAGES_TO_PUSH=\"${IMAGES_TO_PUSH} ${ADDITIONAL_IMAGES_TO_PUSH}\"" >> $GITHUB_ENV
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -349,8 +350,8 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: actions/download-artifact@v3
       - run: |
-          for path in ./*; do
-            artifact=$(basename "$path")
+          for artifact in *; do
+            echo "::debug::Processing artifact '${artifact}'"
           
             if [[ "${artifact}" != *"-image" ]]; then
               echo "::notice ::Skipping artifact ${artifact}, it's not a docker image"          
@@ -364,7 +365,7 @@ jobs:
             fi
 
             echo "::notice ::Loading image ${image}"
-            docker load --input "${image}-image.tar"
+            docker load --input "${artifact}/${artifact}.tar"
 
             dev_image=${IMG_PREFIX}${image}${IMG_MODIFIER}:${IMG_DEV_TAG}
             echo "::notice ::Pushing image ${dev_image}"


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Currently, we have a bug in the job `push_dev_images` from GitHub Actions workflow, that fails for two reasons:
* The env var `IMAGES_TO_PUSH` redefined at the job level is not taking the right value.
* The path used to load the images previously generated, uploaded and downloaded, is wrong.

### Benefits

<!-- What benefits will be realized by the code change? -->
The job `push_dev_images` will work as it is expected to do.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
Nothing.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #4436 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
