### PR TITLE
Fix push_images job from GH Actions workflow

### DIFF
--- a/.github/workflows/kubeapps.yaml
+++ b/.github/workflows/kubeapps.yaml
@@ -512,9 +512,9 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: actions/download-artifact@v3
       - run: |
-          for path in ./*; do
-            artifact=$(basename "$path")
-          
+          for artifact in *; do
+            echo "::debug::Processing artifact '${artifact}'"
+            
             if [[ "${artifact}" != *"-image" ]]; then
               echo "::notice ::Skipping artifact ${artifact}, it's not a docker image"          
               continue
@@ -527,7 +527,7 @@ jobs:
             fi
 
             echo "::notice ::Loading image ${image}"
-            docker load --input "${image}-image.tar"
+            docker load --input "${artifact}/${artifact}.tar"
 
             dev_image=${IMG_PREFIX}${image}${IMG_MODIFIER}:${IMG_DEV_TAG}
             prod_image=${IMG_PREFIX}${image}:${IMG_PROD_TAG}


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This PR fixes some errors in the `push_images` job from the `Kubeapps general workflow` in GH Actions.

### Benefits

<!-- What benefits will be realized by the code change? -->
The `push_images` job works as expected and images are uploaded to Docker Hub upon commits to the main branch.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #4436 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
