### PR TITLE
Search table nested params

### DIFF
--- a/dashboard/src/components/DeploymentForm/DeploymentFormBody/BasicDeploymentForm/TabularSchemaEditorTable/TabularSchemaEditorTable.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentFormBody/BasicDeploymentForm/TabularSchemaEditorTable/TabularSchemaEditorTable.tsx
@@ -21,10 +21,10 @@ import Column from "components/js/Column";
 import Row from "components/js/Row";
 import LoadingWrapper from "components/LoadingWrapper";
 import { useState } from "react";
-import DebouncedInput from "./DebouncedInput";
-import { fuzzyFilter } from "./TabularSchemaEditorTableHelpers";
-import "./TabularSchemaEditorTable.css";
 import { IBasicFormParam } from "shared/types";
+import DebouncedInput from "./DebouncedInput";
+import "./TabularSchemaEditorTable.css";
+import { fuzzyFilter } from "./TabularSchemaEditorTableHelpers";
 
 export interface TabularSchemaEditorTableProps {
   columns: any;
@@ -45,9 +45,6 @@ export default function TabularSchemaEditorTable(props: TabularSchemaEditorTable
   const table = useReactTable({
     data,
     columns,
-    filterFns: {
-      fuzzy: fuzzyFilter,
-    },
     state: {
       columnFilters,
       globalFilter,
@@ -64,6 +61,7 @@ export default function TabularSchemaEditorTable(props: TabularSchemaEditorTable
     getSortedRowModel: getSortedRowModel(),
     getSubRows: (row: IBasicFormParam) => row.params,
     globalFilterFn: fuzzyFilter,
+    filterFromLeafRows: true,
     onColumnFiltersChange: setColumnFilters,
     onExpandedChange: setGlobalExpanded,
     onGlobalFilterChange: setGlobalFilter,

--- a/dashboard/src/components/DeploymentForm/DeploymentFormBody/BasicDeploymentForm/TabularSchemaEditorTable/TabularSchemaEditorTableHelpers.ts
+++ b/dashboard/src/components/DeploymentForm/DeploymentFormBody/BasicDeploymentForm/TabularSchemaEditorTable/TabularSchemaEditorTableHelpers.ts
@@ -7,6 +7,15 @@ import { FilterFn, SortingFn, sortingFns } from "@tanstack/react-table";
 export const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
   // Rank the item
   const itemRank = rankItem(row.getValue(columnId), value);
+
+  // The search in nested rows should be supported by the library, but it's not yet
+  // We will mark a parent row as a match if any of its children match
+  // https://github.com/vmware-tanzu/kubeapps/issues/5437
+  row.subRows?.forEach((subRow: any) => {
+    const subRowRank = rankItem(subRow.getValue(columnId), value);
+    itemRank.passed = subRowRank.passed || itemRank.passed;
+  });
+
   // Store the itemRank info
   addMeta({ itemRank });
   // Return if the item should be filtered in/out


### PR DESCRIPTION
### Description of the change

This PR adds a workaround while the TabStack table bug is being fixed (adding the `filterFromLeafRows` should be enough to get what we want). We just mark a row as "passing" if it matches the search query (existing behavior) OR it has a child that matches the query (workaround)

### Benefits

Users will be able to search by any nested value in the table.

### Possible drawbacks

I was a little reluctant to add this workaround for the performance implications I was foreseeing... but I have tested IRL and it is performing pretty well (see gif below), so I decided to to ahead.

### Applicable issues

- fixes #5437

### Additional information

(unedited speed)

![filterFromLeafRows](https://user-images.githubusercontent.com/11535726/194730591-2828cadc-989b-4ffd-aa3b-c32e9a797cfa.gif)

