### PR TITLE
[CI,GKE] Use `gke-gcloud-auth-plugin` for `kubectl` auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,6 +574,8 @@ gke_test: &gke_test
           if [ -a $GOOGLE_APPLICATION_CREDENTIALS ]; then
             gcloud -q auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS;
           fi
+          gcloud components install gke-gcloud-auth-plugin
+          export USE_GKE_GCLOUD_AUTH_PLUGIN=True
     - <<: *install_kubectl
     # A GKE cluster name cannot contain non-alphanumeric characters (nor uppercase letters)
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ build_on_tag_or_prerelease: &build_on_tag_or_prerelease
     tags:
       only: /^v.*/
     branches:
-      only: 5427-gcloud-auth-plugin
+      only: prerelease
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ build_on_tag_or_prerelease: &build_on_tag_or_prerelease
     tags:
       only: /^v.*/
     branches:
-      only: prerelease
+      only: 5427-gcloud-auth-plugin
 
 workflows:
   version: 2


### PR DESCRIPTION
### Description of the change

Gcloud CLI operations in CI were throwing warning like this in console:

```bash
WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.25+; use gcloud instead.
To learn more, consult https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
```

and an action request (in CI step `Start GKE environment`):

```bash
CRITICAL: ACTION REQUIRED: gke-gcloud-auth-plugin, which is needed for continued use of kubectl, was not found or is not executable. Install gke-gcloud-auth-plugin for use with kubectl by following https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
```

With this PR, we are now using the new auth plugin.
Related messages are now gone.

[CI pipeline run on GKE with the new plugin.](https://app.circleci.com/pipelines/github/vmware-tanzu/kubeapps/8957/workflows/02e4970a-031e-479e-b1e1-675001a23355/jobs/99736)

### Benefits

When going beyond Kubernetes 1.26 there should not be any problem with auth in GKE.

### Possible drawbacks

N/A

### Applicable issues

- fixes #5427
