### PR TITLE
Small changes to check Carvel multicluster support.

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_adapters.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_adapters.go
@@ -364,7 +364,7 @@ func (s *Server) buildPkgInstall(installedPackageName, targetCluster, targetName
 	// Ensure the selected version can be, actually installed to let the user know before installing
 	elegibleVersion, err := versions.HighestConstrainedVersion([]string{pkgVersion}, vendirversions.VersionSelection{Semver: versionSelection})
 	if elegibleVersion == "" || err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "The selected version %q is not elegible to be installed: %v", pkgVersion, err)
+		return nil, status.Errorf(codes.InvalidArgument, "The selected version %q is not eligible to be installed: %v", pkgVersion, err)
 	}
 
 	pkgInstall := &packagingv1alpha1.PackageInstall{

--- a/script/makefiles/deploy-dev.mk
+++ b/script/makefiles/deploy-dev.mk
@@ -57,9 +57,14 @@ reset-dev-kubeapps:
 # The kapp-controller support for the new Package and PackageRepository CRDs is currently
 # only available in an alpha release.
 deploy-kapp-controller:
-	kubectl --kubeconfig=${CLUSTER_CONFIG} apply -f https://github.com/vmware-tanzu/carvel-kapp-controller/releases/download/v0.35.0/release.yml
+	kubectl --kubeconfig=${CLUSTER_CONFIG} apply -f https://github.com/vmware-tanzu/carvel-kapp-controller/releases/download/v0.41.2/release.yml
 	kubectl --kubeconfig=${CLUSTER_CONFIG} apply -f https://raw.githubusercontent.com/vmware-tanzu/carvel-kapp-controller/develop/examples/packaging-with-repo/package-repository.yml
 	kubectl --kubeconfig=${CLUSTER_CONFIG} apply -f ./site/content/docs/latest/reference/manifests/tce-package-repository.yaml
+
+deploy-kapp-controller-additional:
+	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG} apply -f https://github.com/vmware-tanzu/carvel-kapp-controller/releases/download/v0.41.2/release.yml
+	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG} apply -f https://raw.githubusercontent.com/vmware-tanzu/carvel-kapp-controller/develop/examples/packaging-with-repo/package-repository.yml
+	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG} apply -f ./site/content/docs/latest/reference/manifests/tce-package-repository.yaml
 
 # Add the flux controllers used for testing the kubeapps-apis integration.
 deploy-flux-controllers:

--- a/site/content/docs/latest/tutorials/managing-carvel-packages.md
+++ b/site/content/docs/latest/tutorials/managing-carvel-packages.md
@@ -161,7 +161,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: carvel-reconciler
-  namespace: default
+  namespace: kubeapps-user-namespace
 subjects:
 - kind: ServiceAccount
   name: carvel-reconciler


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
I was keen to see exactly what was required to use the Carvel plugin with the existing multicluster support. It turns out, nothing (maybe @antgamdia already checked this and got it working a while ago? Not sure). The only changes I needed were:

* Updating the version of kapp-controller that we run in the cluster (since v0.35 was still requiring secrets attached to service-accounts, which stopped with k8s 1.24, and updated in kapp-controller with v0.37, but I've tested with the latest which works).
* Adding a makefile target to add kapp-controller to the second dev cluster
* Fixing an issue in our carvel docs for creating the reconciliation service account.

With those changes, I can deploy kubeapps on the main cluster, with the patched config:

```diff
diff --git a/site/content/docs/latest/reference/manifests/kubeapps-local-dev-values.yaml b/site/content/docs/latest/reference/manifests/kubeapps-local-dev-values.yaml
index 3cebfad41..56004b56b 100644
--- a/site/content/docs/latest/reference/manifests/kubeapps-local-dev-values.yaml
+++ b/site/content/docs/latest/reference/manifests/kubeapps-local-dev-values.yaml
@@ -32,3 +32,8 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-buffers: "4"
     # Required for ingress-nginx 1.0.0 for a valid ingress.
     kubernetes.io/ingress.class: nginx
+packaging:
+  helm:
+    enabled: true
+  carvel:
+    enabled: true
```

as well as the reconciliation service account as per the carvel docs modified here. I can then login, switch to the second cluster, then browse the catalog to see available apps including the carvel ones available on that cluster:

![carvel-catalog-cluster-2](https://user-images.githubusercontent.com/497518/195221729-f9afb40e-af5c-4669-b3de-a3c65288ce2b.png)

I can then select one to deploy

![carvel-deploy-cluster-2](https://user-images.githubusercontent.com/497518/195221753-0c93c534-84ae-4744-b60b-50d93cfcd9b3.png)

and successfully deploy it

![carvel-deployed-second-cluster](https://user-images.githubusercontent.com/497518/195221774-a96fe376-d9f4-4923-b910-57d24134240c.png)

as well as delete it.

### Benefits

Demonstrates that the carvel plugin can be used with the current multicluster support.

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

Interestingly, we had code that may have been intended to say that this was not supported, when creating a carvel app on a second cluster:

https://github.com/vmware-tanzu/kubeapps/blob/c4d25a4151fd1b5c9c86fe4ecd2b41abf33e9317/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go#L588-L590

but what it actually does is ensure that the package being installed is from the same cluster as that being targeted, which is the case here anyway (since we're browsing available packages on the second cluster). So it allows deploying the package  from the second cluster on the second cluster, but will correctly stop a situation where the API is used to deploy a package from the first cluster on the second cluster.