### PR TITLE
Update Hugo version

### DIFF
--- a/script/makefiles/site.mk
+++ b/script/makefiles/site.mk
@@ -3,7 +3,7 @@
 
 WORKDIR = $(shell pwd)
 # HUGO_VERSION should be in sync with the one set in ../../site/netlify.toml
-HUGO_VERSION = 0.98.0
+HUGO_VERSION = 0.104.3
 
 # This file provides targets that helps with the development of the kubeapps.dev site.
 

--- a/site/content/docs/latest/reference/developer/release-process.md
+++ b/site/content/docs/latest/reference/developer/release-process.md
@@ -116,7 +116,7 @@ Note: If there are certain dependencies which cannot be updated currently, `yarn
 
 #### Golang dependencies
 
-Check the outdated [golang dependencies](https://github.com/vmware-tanzu/kubeapps/blob/maingo.mod) by running the following (from [How to upgrade and downgrade dependencies](https://github.com/golang/go/wiki/Modules#how-to-upgrade-and-downgrade-dependencies)):
+Check the outdated [golang dependencies](https://github.com/vmware-tanzu/kubeapps/blob/main/go.mod) by running the following (from [How to upgrade and downgrade dependencies](https://github.com/golang/go/wiki/Modules#how-to-upgrade-and-downgrade-dependencies)):
 
 ```bash
 go mod tidy
@@ -149,6 +149,13 @@ Finally, look at the [pull requests](https://github.com/vmware-tanzu/kubeapps/pu
 #### Send a PR with the upgrades
 
 Now create a Pull Request containing all these changes (only if no major versions have been bumped up) and wait until for another Kubeapps maintainer to review and accept so you can merge it.
+
+### 0.5 - Update the website engine
+
+The Kubeapps website is built using [Hugo](https://gohugo.io/). Hugo is a static site generator written in Go. It is used to generate the Kubeapps website from Markdown files and HTML templates.
+The Kubeapps website is hosted on [Netlify](https://www.netlify.com/). Netlify is a cloud-based platform that automatically builds and deploys websites when new code is pushed to a Git repository.
+
+To update the website engine, you need to Update the `HUGO_VERSION` variable in the [netlify.toml](https://github.com/vmware-tanzu/kubeapps/blob/main/site/netlify.toml) to the latest [Hugo release](https://github.com/gohugoio/hugo/releases/).
 
 ## 1 - Select the commit to be tagged and perform some tests
 

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -4,7 +4,7 @@ command = "hugo --gc --minify"
 ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ."
 
 [context.production.environment]
-HUGO_VERSION = "0.98.0"
+HUGO_VERSION = "0.104.3"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
@@ -12,20 +12,20 @@ HUGO_ENABLEGITINFO = "true"
 command = "hugo --gc --minify --enableGitInfo"
 
 [context.split1.environment]
-HUGO_VERSION = "0.98.0"
+HUGO_VERSION = "0.104.3"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.98.0"
+HUGO_VERSION = "0.104.3"
 
 [context.branch-deploy]
 command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.98.0"
+HUGO_VERSION = "0.104.3"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"
@@ -34,12 +34,3 @@ HUGO_ENABLEGITINFO = "true"
 from = "/*"
 to = "/404/"
 status = 404
-
-# [[headers]]
-#   for = "/*"
-#   [headers.values]
-#     # disabled to support docsearch until https://github.com/algolia/instantsearch.js/issues/2868 is fixed.
-#     # Content-Security-Policy = "default-src 'self'; img-src *"
-#     X-Content-Type-Options = "nosniff"
-#     X-Frame-Options = "DENY"
-#     X-XSS-Protection = "1; mode=block"


### PR DESCRIPTION
### Description of the change

It's been a long time since we don't update the website's engine version; mainly because it wasn't documented in our guidelines.
This PR is updating Hugo to the latest version, as well as adding the instructions on how to do it for future reference.

### Benefits

We will benefit from the latest changes in Hugo, for instance, in v100 they finally supported shortcodes in the main template (we had to add some hacky workarounds bc of it) and support for previewing 404 error pages.

### Possible drawbacks

N/A  (this hugo dependency is not being reported to OSM, as it is not part of the actual Kubeapps build)

### Applicable issues

- fixes #  TBD ( I will create an issue soon)

### Additional information

N/A