### PR TITLE
[Dashboard] Fix for error flashing when deleting repo

### DIFF
--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoControl.test.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoControl.test.tsx
@@ -103,11 +103,6 @@ it("show error message when package repository deletion fails ", async () => {
   });
   expect(deleteRepo).toHaveBeenCalled();
   expect(refetchRepos).not.toHaveBeenCalled();
-  expect(
-    wrapper
-      .find("div")
-      .filterWhere(div => div.text().includes("An error occurred while deleting the repository:")),
-  );
 });
 
 it("renders the button to edit the repo", () => {

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoControl.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoControl.tsx
@@ -36,8 +36,10 @@ export function PkgRepoControl({
 
   const handleDeleteClick = (packageRepoRef: PackageRepositoryReference) => {
     return async () => {
-      await dispatch(actions.repos.deleteRepo(packageRepoRef));
-      refetchRepos();
+      const deleted = await dispatch(actions.repos.deleteRepo(packageRepoRef));
+      if (deleted) {
+        refetchRepos();
+      }
       closeModal();
     };
   };


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

This PR fixes a problem in the package repositories deletion action. When the user didn't have enough permissions to delete the repo (or any other error at deletion), the error message was shown flashing and disappearing.
This was confusing: user was seeing an error for a fraction of a second, and the repository not deleted.

The user now can see the error message, after the confirmation popup is automatically closed:

![image](https://user-images.githubusercontent.com/67455978/195631430-c26c8835-a437-47f4-986b-816c3c2fa594.png)

Repos are now re-fetched only when there is no error in the deletion action.

### Benefits

User is able to see the actual error message and repos are not unnecessarily re-fetched.

### Possible drawbacks

N/A

### Applicable issues

- fixes #4220

