### PR TITLE
Skip non-image files when loading docker images in local_e2e_tests

### DIFF
--- a/.github/workflows/kubeapps.yaml
+++ b/.github/workflows/kubeapps.yaml
@@ -456,6 +456,10 @@ jobs:
           source ./script/lib/liblog.sh
           for path in /tmp/images/*; do 
             image=$(basename "$path")
+            if [[ "${image}" != *"-image" ]]; then
+              echo "::notice ::Skipping artifact ${image}, it's not a docker image"          
+              continue
+            fi
             info "Loading image ${image}"
             kind load image-archive "${path}/${image}.tar" --name kubeapps-ci; 
           done


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
The changes in this PR aim to fix [the error](https://github.com/vmware-tanzu/kubeapps/actions/runs/3243474129/jobs/5318724841#step:10:60) raised in the `local_e2e_tests` job of the GitHub Actions "kubeapps general workflow", where it's failing because it's trying to docker-load a non-image artifact.

### Benefits

<!-- What benefits will be realized by the code change? -->
The `local_e2e_tests` job of the GHA workflow should no longer fail for the reason mentioned above.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #4436 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
* Error: https://github.com/vmware-tanzu/kubeapps/actions/runs/3243474129/jobs/5318724841#step:10:60