### PR TITLE
Repos global list on additional clusters

### DIFF
--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -69,12 +69,12 @@ export const fetchRepoSummaries = (
   return async (dispatch, getState) => {
     const {
       clusters: { currentCluster },
-      config: { helmGlobalNamespace, carvelGlobalNamespace },
+      config: { kubeappsCluster, helmGlobalNamespace, carvelGlobalNamespace },
     } = getState();
     try {
       dispatch(requestRepoSummaries(namespace));
       const repos = await PackageRepositoriesService.getPackageRepositorySummaries({
-        cluster: currentCluster,
+        cluster: namespace ? currentCluster : kubeappsCluster,
         namespace: namespace,
       });
       if (!listGlobal || [helmGlobalNamespace, carvelGlobalNamespace].includes(namespace)) {
@@ -85,8 +85,9 @@ export const fetchRepoSummaries = (
         // however, this can cause issues when using unprivileged users, see #5215
         let totalRepos = repos.packageRepositorySummaries;
         dispatch(requestRepoSummaries(""));
+        // Global repos are only related to the Kubeapps cluster
         const globalRepos = await PackageRepositoriesService.getPackageRepositorySummaries({
-          cluster: currentCluster,
+          cluster: kubeappsCluster,
           namespace: "",
         });
         // Avoid adding duplicated repos: if two repos have the same uid, filter out

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoList.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoList.tsx
@@ -160,6 +160,30 @@ function PkgRepoList() {
     });
   };
 
+  const getGlobalReposTable = (
+    globalRepos: PackageRepositorySummary[],
+    disableControls: boolean,
+  ) => {
+    return (
+      <>
+        <h3>Global Repositories:</h3>
+        <p>Global Package Repositories are available for all Kubeapps users.</p>
+        {globalRepos.length ? (
+          <Table
+            valign="center"
+            columns={tableColumns}
+            data={getTableData(globalRepos, disableControls)}
+          />
+        ) : (
+          <p>
+            There are no <i>global</i> Package Repositories yet. Click on the "Add Package
+            Repository" button to create one.
+          </p>
+        )}
+      </>
+    );
+  };
+
   /* eslint-disable jsx-a11y/label-has-associated-control */
   return (
     <>
@@ -172,6 +196,7 @@ function PkgRepoList() {
             namespace={currentNamespace}
             helmGlobalNamespace={helmGlobalNamespace}
             carvelGlobalNamespace={carvelGlobalNamespace}
+            disabled={!supportedCluster}
           />,
         ]}
         filter={
@@ -189,20 +214,23 @@ function PkgRepoList() {
       />
       <div className="catalog-container">
         {!supportedCluster ? (
-          <Alert theme="warning">
-            <h5>Package Repositories can't be managed from this cluster.</h5>
-            <p>
-              Currently, the Package Repositories must be managed from the default cluster (the one
-              on which Kubeapps has been installed).
-            </p>
-            <p>
-              Any <i>global</i> Package Repository defined in the default cluster can be later used
-              across any target cluster.
-              <br />
-              However, <i>namespaced</i> Package Repositories can only be used on the default
-              cluster.
-            </p>
-          </Alert>
+          <div className="page-content">
+            <Alert theme="warning">
+              <h5>Package Repositories can't be managed from this cluster.</h5>
+              <p>
+                Currently, the Package Repositories must be managed from the default cluster (the
+                one on which Kubeapps has been installed).
+              </p>
+              <p>
+                Any <i>global</i> Package Repository defined in the default cluster can be later
+                used across any target cluster.
+                <br />
+                However, <i>namespaced</i> Package Repositories can only be used on the default
+                cluster.
+              </p>
+            </Alert>
+            {getGlobalReposTable(globalRepos, true)}
+          </div>
         ) : (
           <div className="page-content">
             {errors.fetch && (
@@ -222,20 +250,7 @@ function PkgRepoList() {
                   loadingText="Fetching Package Repositories..."
                   loaded={!isFetching}
                 >
-                  <h3>Global Repositories:</h3>
-                  <p>Global Package Repositories are available for all Kubeapps users.</p>
-                  {globalRepos.length ? (
-                    <Table
-                      valign="center"
-                      columns={tableColumns}
-                      data={getTableData(globalRepos, !canEditGlobalRepos)}
-                    />
-                  ) : (
-                    <p>
-                      There are no <i>global</i> Package Repositories yet. Click on the "Add Package
-                      Repository" button to create one.
-                    </p>
-                  )}
+                  {getGlobalReposTable(globalRepos, !canEditGlobalRepos)}
                   {![helmGlobalNamespace, carvelGlobalNamespace].includes(namespace) && (
                     <>
                       <h3>Namespaced Repositories: {namespace}</h3>


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

This PR adds the list of global repos when context is set to a cluster other than the default one.
List is set on read only mode.
Same UI warning message is kept, as it still describes correctly the situation.

![image](https://user-images.githubusercontent.com/67455978/196126149-1fe16b63-2695-4957-a1b2-0682abd6c220.png)

Targeted at the case stated in #2717, users that do not have access to the main/default cluster where Kubeapps is installed.

### Benefits

- Users in non-default cluster can see the list of global repositories, at least in read-only mode.

### Possible drawbacks

N/A

### Applicable issues

- fixes #2717

