### PR TITLE
Add flag for disabling dashboard

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/vmware-tanzu/kubeapps
-version: 11.0.2-dev0
+version: 11.0.2-dev1

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -198,6 +198,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 
 | Name                                              | Description                                                                                               | Value                |
 | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | -------------------- |
+| `dashboard.enabled`                               | Specifies whether Kubeapps Dashboard should be deployed or not                                            | `true`               |
 | `dashboard.image.registry`                        | Dashboard image registry                                                                                  | `docker.io`          |
 | `dashboard.image.repository`                      | Dashboard image repository                                                                                | `kubeapps/dashboard` |
 | `dashboard.image.tag`                             | Dashboard image tag (immutable tags are recommended)                                                      | `latest`             |

--- a/chart/kubeapps/templates/dashboard/configmap.yaml
+++ b/chart/kubeapps/templates/dashboard/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dashboard.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -84,3 +85,4 @@ data:
       "skipAvailablePackageDetails": {{ .Values.dashboard.skipAvailablePackageDetails }},
       "createNamespaceLabels": {{ .Values.dashboard.createNamespaceLabels | toJson }}
     }
+{{- end -}}

--- a/chart/kubeapps/templates/dashboard/deployment.yaml
+++ b/chart/kubeapps/templates/dashboard/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dashboard.enabled -}}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -183,3 +184,4 @@ spec:
         {{- if .Values.dashboard.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.dashboard.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
+{{- end -}}

--- a/chart/kubeapps/templates/dashboard/service.yaml
+++ b/chart/kubeapps/templates/dashboard/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dashboard.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -26,3 +27,4 @@ spec:
       name: http
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: dashboard
+{{- end -}}

--- a/chart/kubeapps/templates/frontend/configmap.yaml
+++ b/chart/kubeapps/templates/frontend/configmap.yaml
@@ -125,10 +125,11 @@ data:
         proxy_pass {{ include "kubeapps.kubeappsapis.proxy_pass" . -}};
       }
 
+    {{- if .Values.dashboard.enabled }}
       location / {
         # Add the Authorization header if exists
         add_header Authorization $http_authorization;
-
         proxy_pass {{ printf "http://%s:%d" (include "kubeapps.dashboard.fullname" .) (int .Values.dashboard.service.ports.http) }};
       }
+    {{- end }}
     }

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -508,6 +508,9 @@ frontend:
 ## Dashboard parameters
 ##
 dashboard:
+  ## @param dashboard.enabled Specifies whether Kubeapps Dashboard should be deployed or not
+  ##
+  enabled: true
   ## Bitnami Kubeapps Dashboard image
   ## ref: https://hub.docker.com/r/bitnami/kubeapps-dashboard/
   ## @param dashboard.image.registry Dashboard image registry


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

Adds a chart value to enable/disabled the setup of the Kubeapps Dashboard.
Defaults to enabled, as is now.

When disabled, Kubeapps is deployed in a kind of "API mode" where requests to e.g. `https://<INGRESS_HOST>/apis/*` can still be done.

### Benefits

Possible to deploy a headless Kubeapps

### Possible drawbacks

N/A

### Applicable issues

- N/A

### Additional information

This will be useful when deploying workloads for multicluster, or for scenarios where UI is not needed.