### PR TITLE
Remove sync_writes optino for pinniped-proxy cred cache.

### DIFF
--- a/cmd/pinniped-proxy/Cargo.lock
+++ b/cmd/pinniped-proxy/Cargo.lock
@@ -463,12 +463,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
 dependencies = [
  "atty",
- "humantime 1.3.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -713,15 +713,6 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
-name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
@@ -732,7 +723,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
- "humantime 2.1.0",
+ "humantime",
  "serde",
 ]
 
@@ -1304,6 +1295,7 @@ dependencies = [
  "cached",
  "chrono",
  "clap",
+ "env_logger",
  "http",
  "hyper",
  "hyper-tls",
@@ -1314,7 +1306,6 @@ dependencies = [
  "log",
  "native-tls",
  "openssl",
- "pretty_env_logger",
  "reqwest",
  "serde",
  "serde_json",
@@ -1339,16 +1330,6 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-
-[[package]]
-name = "pretty_env_logger"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
-dependencies = [
- "env_logger",
- "log",
-]
 
 [[package]]
 name = "proc-macro-error"
@@ -1382,12 +1363,6 @@ checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -2081,7 +2056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1859507c6593597db93d95d228b324da1f04f39014eb26ea492925c31c36a81f"
 dependencies = [
  "glob",
- "humantime 2.1.0",
+ "humantime",
  "humantime-serde",
  "rayon",
  "serde",

--- a/cmd/pinniped-proxy/Cargo.toml
+++ b/cmd/pinniped-proxy/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0"
 base64 = "0.13"
 cached = "0.39"
 chrono = "0.4"
+env_logger = "0.9"
 hyper = { version = "0.14", features = ["server"] }
 hyper-tls = "0.5"
 kube = { version = "0.75.0" }
@@ -24,7 +25,6 @@ k8s-openapi = { version = "0.16.0", default-features = false}
 log = "0.4"
 native-tls = "0.2"
 openssl = "0.10"
-pretty_env_logger = "0.4"
 reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/cmd/pinniped-proxy/src/main.rs
+++ b/cmd/pinniped-proxy/src/main.rs
@@ -13,7 +13,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Server,
 };
-use log::{info, LevelFilter};
+use log::info;
 use tls_listener::TlsListener;
 
 // Ensure the root crate is aware of the child modules.
@@ -26,18 +26,15 @@ mod tls_config;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    pretty_env_logger::formatted_timed_builder()
-        .format(|buf, record| {
-            writeln!(
-                buf,
-                "{} [{}] - {}",
-                Local::now().format("%Y-%m-%dT%H:%M:%S%.6f"),
-                record.level(),
-                record.args()
-            )
-        })
-        .filter(None, LevelFilter::Info)
-        .init();
+    env_logger::Builder::from_default_env().format(|buf, record| {
+        writeln!(
+            buf,
+            "{} [{}] - {}",
+            Local::now().format("%Y-%m-%dT%H:%M:%S%.6f"),
+            record.level(),
+            record.args()
+        )
+    });
     let opt = cli::Options::parse();
 
     // Load the default certificate authority data on startup once.

--- a/cmd/pinniped-proxy/src/pinniped.rs
+++ b/cmd/pinniped-proxy/src/pinniped.rs
@@ -256,9 +256,6 @@ async fn prepare_and_call_pinniped_exchange(
     // We convert the arguments so that we're only using the cred_data as the key.
     convert = r#"{ cred_data.clone() }"#,
     result = true,
-    // If two requests with the same key arrive, only one is sent through on a miss
-    // with the others returning once the result is cached.
-    sync_writes = true,
 )]
 async fn call_pinniped(
     pinniped_namespace: String,

--- a/script/makefiles/deploy-dev-for-pinniped.mk
+++ b/script/makefiles/deploy-dev-for-pinniped.mk
@@ -9,7 +9,7 @@
 
 # Have a look at /docs/reference/developer/pinniped-proxy.md for instructions on how to run this makefile
 
-PINNIPED_VERSION ?= v0.18.0
+PINNIPED_VERSION ?= v0.20.0
 
 deploy-dex-for-pinniped: devel/dex.crt-for-pinniped devel/dex.key-for-pinniped
 	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} create namespace dex

--- a/site/content/docs/latest/howto/OIDC/using-an-OIDC-provider-with-pinniped.md
+++ b/site/content/docs/latest/howto/OIDC/using-an-OIDC-provider-with-pinniped.md
@@ -2,7 +2,7 @@
 
 The [Pinniped project](https://pinniped.dev/) exists to "Simplify user authentication for any Kubernetes cluster" and enables OIDC providers to be configured dynamically, rather than when a cluster is created. Kubeapps can be configured so that users must authenticate with the same OIDC provider and then authenticated requests from Kubeapps to the API server will be proxied via Pinniped, with the signed OIDC `id_token` being verified by Pinniped and exchanged for a client certificate accepted trusted by the API server.
 
-## Installing Pinniped
+## Installing Pinniped Concierge
 
 Install Pinniped on your cluster with:
 
@@ -12,7 +12,7 @@ kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/v0.1
 kubectl apply -f  https://github.com/vmware-tanzu/pinniped/releases/download/v0.18.0/install-pinniped-concierge.yaml
 ```
 
-## Configure Pinniped to trust your OIDC identity provider
+## Configure Pinniped Concierge to trust your OIDC identity provider
 
 Once Pinniped is running, you can add a `JWTAuthenticator` custom resource so that Pinniped knows to trust your OIDC identity provider.
 

--- a/site/content/docs/latest/reference/developer/pinniped-proxy.md
+++ b/site/content/docs/latest/reference/developer/pinniped-proxy.md
@@ -66,9 +66,9 @@ Next, replace `172.18.0.2` with the previous IP (and `172.18.0.3` with the next 
 ### Launching the dev environment
 
 - Run `make cluster-kind-for-pinniped` or `make multi-cluster-kind-for-pinniped` for multi-cluster.
-- Update [https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-local-dev-additional-kind-cluster-for-pinniped.yaml](https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-local-dev-additional-kind-cluster-for-pinniped.yaml) copying the certificate-authority-data from the additional cluster (`~/.kube/kind-config-kubeapps-additional`) to the `certificate-authority-data` of the second cluster.
+- Update [https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-local-dev-additional-kind-cluster-for-pinniped.yaml](https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-local-dev-additional-kind-cluster-for-pinniped.yaml) copying the certificate-authority-data from the additional cluster (`~/.kube/kind-config-kubeapps-for-pinniped-additional`) to the `certificate-authority-data` of the second cluster.
 - Run `make deploy-dev-for-pinniped` and additionally `make deploy-pinniped-additional` for multi-cluster.
-- Edit [https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-pinniped-jwt-authenticator.yaml](https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-pinniped-jwt-authenticator.yaml) with the `certificate-authority-data` from the main cluster (`~/.kube/kind-config-kubeapps`).
+- Edit [https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-pinniped-jwt-authenticator.yaml](https://github.com/vmware-tanzu/kubeapps/blob/main/site/content/docs/latest/reference/manifests/kubeapps-pinniped-jwt-authenticator.yaml) with the `certificate-authority-data` from the main cluster (`~/.kube/kind-config-kubeapps-for-pinniped`).
 - Run `make add-pinniped-jwt-authenticator` and additionally `make add-pinniped-jwt-authenticator-additional` for multi-cluster.
 - Open <https://localhost/> and login with `kubeapps-operator@example.com`/`password`
 


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This PR is the result of the investigation described on #5407 , the end result of which is a single line removal, though I've left some other changes that were helpful during debugging (logging related).

### Benefits

Pinniped-proxy is faster when hit with lots of simultaneous requests.

NOTE: Leaving in draft as although the requests are serviced more quickly in pinniped-proxy, it's still taking 5s for the kubeapps-apis to respond. Investigating why...

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

None.
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #5407

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

After

```
2022-10-20T02:22:19.383560 [TRACE] - registering event source with poller: token=Token(1), interests=READABLE | WRITABLE
2022-10-20T02:22:19.383685 [INFO] - Listening on http://0.0.0.0:3333
2022-10-20T02:22:37.624364 [TRACE] - registering event source with poller: token=Token(2), interests=READABLE | WRITABLE
2022-10-20T02:22:37.626434 [TRACE] - registering event source with poller: token=Token(3), interests=READABLE | WRITABLE
2022-10-20T02:22:37.627386 [TRACE] - registering event source with poller: token=Token(4), interests=READABLE | WRITABLE
2022-10-20T02:22:37.627472 [TRACE] - registering event source with poller: token=Token(5), interests=READABLE | WRITABLE
2022-10-20T02:22:37.643862 [INFO] - prep_and_call took 17ms, 0 of which was call_pinniped
2022-10-20T02:22:37.649102 [TRACE] - deregistering event source from poller
2022-10-20T02:22:37.649281 [INFO] - prep_and_call took 22ms, 0 of which was call_pinniped
2022-10-20T02:22:37.654546 [TRACE] - deregistering event source from poller
2022-10-20T02:22:37.654692 [TRACE] - registering event source with poller: token=Token(16777220), interests=READABLE | WRITABLE
2022-10-20T02:22:37.655035 [TRACE] - registering event source with poller: token=Token(16777221), interests=READABLE | WRITABLE
2022-10-20T02:22:37.659207 [INFO] - POST https://kubernetes.default/apis/authorization.k8s.io/v1/selfsubjectaccessreviews 201 Created
2022-10-20T02:22:37.659305 [TRACE] - deregistering event source from poller
2022-10-20T02:22:37.660266 [INFO] - GET https://kubernetes.default/api?timeout=32s 200 OK
2022-10-20T02:22:37.660348 [TRACE] - deregistering event source from poller
2022-10-20T02:22:37.667275 [INFO] - prep_and_call took 6ms, 6 of which was call_pinniped
2022-10-20T02:22:37.714108 [TRACE] - registering event source with poller: token=Token(33554436), interests=READABLE | WRITABLE
2022-10-20T02:22:37.718380 [INFO] - GET https://kubernetes.default/apis?timeout=32s 200 OK
2022-10-20T02:22:37.718613 [TRACE] - deregistering event source from poller
```

First request from the barrage of apis starting at around 37.725

```
2022-10-20T02:22:37.725487 [INFO] - prep_and_call took 5ms, 5 of which was call_pinniped
2022-10-20T02:22:37.735112 [INFO] - prep_and_call took 3ms, 3 of which was call_pinniped
2022-10-20T02:22:37.813940 [TRACE] - registering event source with poller: token=Token(50331652), interests=READABLE | WRITABLE
2022-10-20T02:22:37.814030 [TRACE] - registering event source with poller: token=Token(33554437), interests=READABLE | WRITABLE
2022-10-20T02:22:37.814074 [TRACE] - registering event source with poller: token=Token(6), interests=READABLE | WRITABLE
2022-10-20T02:22:37.814383 [TRACE] - registering event source with poller: token=Token(7), interests=READABLE | WRITABLE
2022-10-20T02:22:37.814481 [TRACE] - registering event source with poller: token=Token(8), interests=READABLE | WRITABLE
2022-10-20T02:22:37.814709 [TRACE] - registering event source with poller: token=Token(9), interests=READABLE | WRITABLE
2022-10-20T02:22:37.814813 [TRACE] - registering event source with poller: token=Token(10), interests=READABLE | WRITABLE
2022-10-20T02:22:37.814831 [TRACE] - registering event source with poller: token=Token(11), interests=READABLE | WRITABLE
2022-10-20T02:22:37.814843 [TRACE] - registering event source with poller: token=Token(12), interests=READABLE | WRITABLE
2022-10-20T02:22:37.814871 [TRACE] - registering event source with poller: token=Token(13), interests=READABLE | WRITABLE
2022-10-20T02:22:37.814902 [TRACE] - registering event source with poller: token=Token(14), interests=READABLE | WRITABLE
2022-10-20T02:22:37.814962 [TRACE] - registering event source with poller: token=Token(15), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815016 [TRACE] - registering event source with poller: token=Token(16), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815034 [TRACE] - registering event source with poller: token=Token(17), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815047 [TRACE] - registering event source with poller: token=Token(18), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815077 [TRACE] - registering event source with poller: token=Token(19), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815105 [TRACE] - registering event source with poller: token=Token(20), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815139 [TRACE] - registering event source with poller: token=Token(21), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815171 [TRACE] - registering event source with poller: token=Token(22), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815189 [TRACE] - registering event source with poller: token=Token(23), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815203 [TRACE] - registering event source with poller: token=Token(24), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815243 [TRACE] - registering event source with poller: token=Token(25), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815258 [TRACE] - registering event source with poller: token=Token(26), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815270 [TRACE] - registering event source with poller: token=Token(27), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815286 [TRACE] - registering event source with poller: token=Token(28), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815296 [TRACE] - registering event source with poller: token=Token(29), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815331 [TRACE] - registering event source with poller: token=Token(30), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815347 [TRACE] - registering event source with poller: token=Token(31), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815364 [TRACE] - registering event source with poller: token=Token(32), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815379 [TRACE] - registering event source with poller: token=Token(33), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815391 [TRACE] - registering event source with poller: token=Token(34), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815402 [TRACE] - registering event source with poller: token=Token(35), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815415 [TRACE] - registering event source with poller: token=Token(36), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815445 [TRACE] - registering event source with poller: token=Token(37), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815481 [TRACE] - registering event source with poller: token=Token(38), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815524 [TRACE] - registering event source with poller: token=Token(39), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815538 [TRACE] - registering event source with poller: token=Token(40), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815549 [TRACE] - registering event source with poller: token=Token(41), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815556 [TRACE] - registering event source with poller: token=Token(42), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815563 [TRACE] - registering event source with poller: token=Token(43), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815571 [TRACE] - registering event source with poller: token=Token(44), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815586 [TRACE] - registering event source with poller: token=Token(45), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815600 [TRACE] - registering event source with poller: token=Token(46), interests=READABLE | WRITABLE
2022-10-20T02:22:37.815617 [TRACE] - registering event source with poller: token=Token(47), interests=READABLE | WRITABLE
2022-10-20T02:22:37.821099 [INFO] - prep_and_call took 6ms, 6 of which was call_pinniped
2022-10-20T02:22:37.831622 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:37.921448 [INFO] - prep_and_call took 5ms, 5 of which was call_pinniped
2022-10-20T02:22:37.930303 [TRACE] - registering event source with poller: token=Token(48), interests=READABLE | WRITABLE
2022-10-20T02:22:37.930452 [TRACE] - registering event source with poller: token=Token(49), interests=READABLE | WRITABLE
2022-10-20T02:22:37.930515 [TRACE] - registering event source with poller: token=Token(50), interests=READABLE | WRITABLE
2022-10-20T02:22:38.012687 [INFO] - prep_and_call took 81ms, 81 of which was call_pinniped
2022-10-20T02:22:38.025039 [INFO] - prep_and_call took 5ms, 5 of which was call_pinniped
2022-10-20T02:22:38.032356 [TRACE] - registering event source with poller: token=Token(51), interests=READABLE | WRITABLE
2022-10-20T02:22:38.112794 [INFO] - prep_and_call took 79ms, 79 of which was call_pinniped
2022-10-20T02:22:38.123357 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:38.134328 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:38.219670 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:38.232215 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:38.318885 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:38.331095 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:38.422437 [INFO] - prep_and_call took 8ms, 8 of which was call_pinniped
2022-10-20T02:22:38.513544 [INFO] - prep_and_call took 81ms, 81 of which was call_pinniped
2022-10-20T02:22:38.524671 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:38.611596 [INFO] - prep_and_call took 80ms, 80 of which was call_pinniped
2022-10-20T02:22:38.623105 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:38.710381 [INFO] - prep_and_call took 79ms, 79 of which was call_pinniped
2022-10-20T02:22:38.720621 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:38.731765 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:38.818281 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:38.830398 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:38.916853 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:38.928562 [INFO] - prep_and_call took 5ms, 5 of which was call_pinniped
2022-10-20T02:22:39.016400 [INFO] - prep_and_call took 5ms, 5 of which was call_pinniped
2022-10-20T02:22:39.027385 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:39.116275 [INFO] - prep_and_call took 82ms, 82 of which was call_pinniped
2022-10-20T02:22:39.134202 [INFO] - prep_and_call took 7ms, 7 of which was call_pinniped
2022-10-20T02:22:39.220496 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:39.232862 [INFO] - prep_and_call took 5ms, 5 of which was call_pinniped
2022-10-20T02:22:39.319704 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:39.332127 [INFO] - prep_and_call took 5ms, 5 of which was call_pinniped
2022-10-20T02:22:39.419896 [INFO] - prep_and_call took 5ms, 5 of which was call_pinniped
2022-10-20T02:22:39.432999 [INFO] - prep_and_call took 5ms, 5 of which was call_pinniped
2022-10-20T02:22:39.519121 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:39.530998 [INFO] - prep_and_call took 5ms, 5 of which was call_pinniped
2022-10-20T02:22:39.617987 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:39.629855 [INFO] - prep_and_call took 5ms, 5 of which was call_pinniped
2022-10-20T02:22:39.812817 [INFO] - prep_and_call took 85ms, 85 of which was call_pinniped
2022-10-20T02:22:39.823702 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:39.912236 [INFO] - prep_and_call took 81ms, 81 of which was call_pinniped
2022-10-20T02:22:39.923353 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:39.931401 [TRACE] - registering event source with poller: token=Token(52), interests=READABLE | WRITABLE
2022-10-20T02:22:39.931456 [TRACE] - registering event source with poller: token=Token(53), interests=READABLE | WRITABLE
2022-10-20T02:22:39.931498 [TRACE] - registering event source with poller: token=Token(54), interests=READABLE | WRITABLE
2022-10-20T02:22:39.931548 [TRACE] - registering event source with poller: token=Token(55), interests=READABLE | WRITABLE
2022-10-20T02:22:39.954760 [TRACE] - registering event source with poller: token=Token(56), interests=READABLE | WRITABLE
2022-10-20T02:22:39.954840 [TRACE] - registering event source with poller: token=Token(57), interests=READABLE | WRITABLE
2022-10-20T02:22:39.954905 [TRACE] - registering event source with poller: token=Token(58), interests=READABLE | WRITABLE
2022-10-20T02:22:39.954955 [TRACE] - registering event source with poller: token=Token(59), interests=READABLE | WRITABLE
2022-10-20T02:22:39.955027 [TRACE] - registering event source with poller: token=Token(60), interests=READABLE | WRITABLE
2022-10-20T02:22:39.955093 [TRACE] - registering event source with poller: token=Token(61), interests=READABLE | WRITABLE
2022-10-20T02:22:39.955123 [TRACE] - registering event source with poller: token=Token(62), interests=READABLE | WRITABLE
2022-10-20T02:22:39.955170 [TRACE] - registering event source with poller: token=Token(63), interests=READABLE | WRITABLE
2022-10-20T02:22:39.955215 [TRACE] - registering event source with poller: token=Token(64), interests=READABLE | WRITABLE
2022-10-20T02:22:39.955267 [TRACE] - registering event source with poller: token=Token(65), interests=READABLE | WRITABLE
2022-10-20T02:22:39.955320 [TRACE] - registering event source with poller: token=Token(66), interests=READABLE | WRITABLE
2022-10-20T02:22:39.955369 [TRACE] - registering event source with poller: token=Token(67), interests=READABLE | WRITABLE
2022-10-20T02:22:39.955417 [TRACE] - registering event source with poller: token=Token(68), interests=READABLE | WRITABLE
2022-10-20T02:22:39.955465 [TRACE] - registering event source with poller: token=Token(69), interests=READABLE | WRITABLE
2022-10-20T02:22:39.955509 [TRACE] - registering event source with poller: token=Token(70), interests=READABLE | WRITABLE
2022-10-20T02:22:39.955572 [TRACE] - registering event source with poller: token=Token(71), interests=READABLE | WRITABLE
```

First request completing at around 39.956, over 2s after first request began. This is a CPU resource issue.

```
2022-10-20T02:22:39.956047 [INFO] - GET https://kubernetes.default/apis/autoscaling/v2?timeout=32s 200 OK
2022-10-20T02:22:39.956134 [TRACE] - deregistering event source from poller
2022-10-20T02:22:39.957093 [INFO] - GET https://kubernetes.default/apis/authentication.k8s.io/v1?timeout=32s 200 OK
2022-10-20T02:22:39.957180 [TRACE] - deregistering event source from poller
2022-10-20T02:22:39.958238 [INFO] - GET https://kubernetes.default/apis/batch/v1beta1?timeout=32s 200 OK
2022-10-20T02:22:39.958330 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.014544 [TRACE] - registering event source with poller: token=Token(50331653), interests=READABLE | WRITABLE
2022-10-20T02:22:40.014639 [TRACE] - registering event source with poller: token=Token(67108868), interests=READABLE | WRITABLE
2022-10-20T02:22:40.014690 [TRACE] - registering event source with poller: token=Token(16777266), interests=READABLE | WRITABLE
2022-10-20T02:22:40.014729 [TRACE] - registering event source with poller: token=Token(72), interests=READABLE | WRITABLE
2022-10-20T02:22:40.014772 [TRACE] - registering event source with poller: token=Token(73), interests=READABLE | WRITABLE
2022-10-20T02:22:40.014813 [TRACE] - registering event source with poller: token=Token(74), interests=READABLE | WRITABLE
2022-10-20T02:22:40.014854 [TRACE] - registering event source with poller: token=Token(75), interests=READABLE | WRITABLE
2022-10-20T02:22:40.014894 [TRACE] - registering event source with poller: token=Token(76), interests=READABLE | WRITABLE
2022-10-20T02:22:40.014937 [TRACE] - registering event source with poller: token=Token(77), interests=READABLE | WRITABLE
2022-10-20T02:22:40.014985 [TRACE] - registering event source with poller: token=Token(78), interests=READABLE | WRITABLE
2022-10-20T02:22:40.015027 [TRACE] - registering event source with poller: token=Token(79), interests=READABLE | WRITABLE
2022-10-20T02:22:40.015067 [TRACE] - registering event source with poller: token=Token(80), interests=READABLE | WRITABLE
2022-10-20T02:22:40.015108 [TRACE] - registering event source with poller: token=Token(81), interests=READABLE | WRITABLE
2022-10-20T02:22:40.015149 [TRACE] - registering event source with poller: token=Token(82), interests=READABLE | WRITABLE
2022-10-20T02:22:40.015191 [TRACE] - registering event source with poller: token=Token(83), interests=READABLE | WRITABLE
2022-10-20T02:22:40.015233 [TRACE] - registering event source with poller: token=Token(84), interests=READABLE | WRITABLE
2022-10-20T02:22:40.015274 [TRACE] - registering event source with poller: token=Token(85), interests=READABLE | WRITABLE
2022-10-20T02:22:40.015317 [TRACE] - registering event source with poller: token=Token(86), interests=READABLE | WRITABLE
2022-10-20T02:22:40.016517 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.019156 [INFO] - GET https://kubernetes.default/apis/source.toolkit.fluxcd.io/v1beta1?timeout=32s 200 OK
2022-10-20T02:22:40.021892 [INFO] - GET https://kubernetes.default/apis/image.toolkit.fluxcd.io/v1beta1?timeout=32s 200 OK
2022-10-20T02:22:40.022073 [INFO] - GET https://kubernetes.default/apis/node.k8s.io/v1beta1?timeout=32s 200 OK
2022-10-20T02:22:40.022158 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.024756 [INFO] - GET https://kubernetes.default/apis/autoscaling/v1?timeout=32s 200 OK
2022-10-20T02:22:40.024892 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.027852 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.028785 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.032641 [INFO] - GET https://kubernetes.default/apis/discovery.k8s.io/v1beta1?timeout=32s 200 OK
2022-10-20T02:22:40.032719 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.110407 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.113248 [INFO] - GET https://kubernetes.default/apis/apps/v1?timeout=32s 200 OK
2022-10-20T02:22:40.115571 [INFO] - GET https://kubernetes.default/apis/batch/v1?timeout=32s 200 OK
2022-10-20T02:22:40.115676 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.116315 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.117171 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.118771 [INFO] - GET https://kubernetes.default/apis/kustomize.toolkit.fluxcd.io/v1beta1?timeout=32s 200 OK
2022-10-20T02:22:40.118880 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.120530 [INFO] - GET https://kubernetes.default/apis/flowcontrol.apiserver.k8s.io/v1beta1?timeout=32s 200 OK
2022-10-20T02:22:40.120626 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.121607 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.125078 [INFO] - GET https://kubernetes.default/apis/config.concierge.pinniped.dev/v1alpha1?timeout=32s 200 OK
2022-10-20T02:22:40.125212 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.126904 [INFO] - GET https://kubernetes.default/apis/discovery.k8s.io/v1?timeout=32s 200 OK
2022-10-20T02:22:40.127009 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.128477 [INFO] - GET https://kubernetes.default/apis/image.toolkit.fluxcd.io/v1alpha1?timeout=32s 200 OK
2022-10-20T02:22:40.128658 [INFO] - GET https://kubernetes.default/apis/coordination.k8s.io/v1?timeout=32s 200 OK
2022-10-20T02:22:40.128736 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.129578 [INFO] - GET https://kubernetes.default/apis/notification.toolkit.fluxcd.io/v1beta1?timeout=32s 200 OK
2022-10-20T02:22:40.129732 [INFO] - GET https://kubernetes.default/apis/autoscaling/v2beta2?timeout=32s 200 OK
2022-10-20T02:22:40.129812 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.130651 [INFO] - GET https://kubernetes.default/apis/helm.toolkit.fluxcd.io/v2beta1?timeout=32s 200 OK
2022-10-20T02:22:40.130717 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.131487 [INFO] - GET https://kubernetes.default/apis/login.concierge.pinniped.dev/v1alpha1?timeout=32s 200 OK
2022-10-20T02:22:40.131560 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.132391 [INFO] - GET https://kubernetes.default/apis/events.k8s.io/v1beta1?timeout=32s 200 OK
2022-10-20T02:22:40.132476 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.133136 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.133555 [INFO] - GET https://kubernetes.default/apis/apiextensions.k8s.io/v1?timeout=32s 200 OK
2022-10-20T02:22:40.133642 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.134493 [INFO] - GET https://kubernetes.default/apis/flowcontrol.apiserver.k8s.io/v1beta2?timeout=32s 200 OK
2022-10-20T02:22:40.134563 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.211088 [INFO] - GET https://kubernetes.default/apis/kustomize.toolkit.fluxcd.io/v1beta2?timeout=32s 200 OK
2022-10-20T02:22:40.211219 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.212448 [INFO] - GET https://kubernetes.default/apis/authorization.k8s.io/v1?timeout=32s 200 OK
2022-10-20T02:22:40.212532 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.213441 [INFO] - GET https://kubernetes.default/apis/autoscaling/v2beta1?timeout=32s 200 OK
2022-10-20T02:22:40.213522 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.214477 [INFO] - GET https://kubernetes.default/apis/storage.k8s.io/v1beta1?timeout=32s 200 OK
2022-10-20T02:22:40.214570 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.215547 [INFO] - GET https://kubernetes.default/apis/kubeapps.com/v1alpha1?timeout=32s 200 OK
2022-10-20T02:22:40.215634 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.216534 [INFO] - GET https://kubernetes.default/apis/policy/v1?timeout=32s 200 OK
2022-10-20T02:22:40.216624 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.217609 [INFO] - GET https://kubernetes.default/apis/policy/v1beta1?timeout=32s 200 OK
2022-10-20T02:22:40.217708 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.218823 [INFO] - GET https://kubernetes.default/apis/identity.concierge.pinniped.dev/v1alpha1?timeout=32s 200 OK
2022-10-20T02:22:40.218909 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.219800 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.219963 [INFO] - GET https://kubernetes.default/apis/scheduling.k8s.io/v1?timeout=32s 200 OK
2022-10-20T02:22:40.220029 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.220923 [INFO] - GET https://kubernetes.default/apis/authentication.concierge.pinniped.dev/v1alpha1?timeout=32s 200 OK
2022-10-20T02:22:40.221066 [INFO] - GET https://kubernetes.default/apis/certificates.k8s.io/v1?timeout=32s 200 OK
2022-10-20T02:22:40.221144 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.221779 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.222160 [INFO] - GET https://kubernetes.default/apis/storage.k8s.io/v1?timeout=32s 200 OK
2022-10-20T02:22:40.222272 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.222379 [INFO] - GET https://kubernetes.default/apis/admissionregistration.k8s.io/v1?timeout=32s 200 OK
2022-10-20T02:22:40.222452 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.223313 [INFO] - GET https://kubernetes.default/apis/node.k8s.io/v1?timeout=32s 200 OK
2022-10-20T02:22:40.223396 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.224187 [INFO] - GET https://kubernetes.default/apis/image.toolkit.fluxcd.io/v1alpha2?timeout=32s 200 OK
2022-10-20T02:22:40.224313 [INFO] - GET https://kubernetes.default/apis/source.toolkit.fluxcd.io/v1beta2?timeout=32s 200 OK
2022-10-20T02:22:40.224443 [INFO] - GET https://kubernetes.default/apis/rbac.authorization.k8s.io/v1?timeout=32s 200 OK
2022-10-20T02:22:40.224559 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.225451 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.226311 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.227192 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.227325 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.228209 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.229009 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.229787 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.230548 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.231378 [INFO] - GET https://kubernetes.default/apis/networking.k8s.io/v1?timeout=32s 200 OK
2022-10-20T02:22:40.231561 [INFO] - GET https://kubernetes.default/apis/apiregistration.k8s.io/v1?timeout=32s 200 OK
2022-10-20T02:22:40.231645 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.232596 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.232729 [INFO] - GET https://kubernetes.default/api/v1?timeout=32s 200 OK
2022-10-20T02:22:40.232888 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.232967 [INFO] - GET https://kubernetes.default/apis/events.k8s.io/v1?timeout=32s 200 OK
```

Last request completing at around 40.232, under 3 seconds after first request began?

So why does API response still take 5s?

```
2022-10-20T02:22:40.233035 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.233805 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.233844 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.233873 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.233902 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.233933 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.233965 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234001 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234032 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234064 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234096 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234129 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234161 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234190 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234220 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234255 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234286 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234315 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234343 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234372 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234401 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234438 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234475 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234514 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234552 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.234587 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.310359 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.310558 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.311595 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.312614 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.312658 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.312693 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.312727 [TRACE] - deregistering event source from poller
2022-10-20T02:22:40.317308 [INFO] - prep_and_call took 4ms, 4 of which was call_pinniped
2022-10-20T02:22:40.322523 [TRACE] - registering event source with poller: token=Token(16777228), interests=READABLE | WRITABLE
2022-10-20T02:22:40.327968 [INFO] - GET https://kubernetes.default/apis/helm.toolkit.fluxcd.io/v2beta1/namespaces/default/helmreleases 200 OK
2022-10-20T02:22:40.328106 [TRACE] - deregistering event source from poller

```