### PR TITLE
Avoid docker production images overlapping between GHA and CircleCI

### DIFF
--- a/.github/workflows/kubeapps.yaml
+++ b/.github/workflows/kubeapps.yaml
@@ -508,6 +508,10 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: actions/download-artifact@v3
       - run: |
+          if [[ "${DEV_MODE}" == true && "IMG_PROD_TAG" == latest ]]; then
+            IMG_PROD_TAG="${IMG_PROD_TAG}-gha"
+          fi
+          
           for artifact in *; do
             echo "::debug::Processing artifact '${artifact}'"
 


### PR DESCRIPTION

Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Right now, when Docker production images are generated from the GHA kubeapps general workflow, those are pushed to Docker Hub in the `kubeapps` workspace (eg. `kubeapps/kubeapps-apis`, `kubeapps/dashboard`, etc) and tagged with `latest` or the release version `x.y.z`,  so they overlap with the ones generated in the CircleCI workflow that runs in parallel (until we finish the migration to GHA and decommission the CircleCI workflow). To avoid images from both workflows to overwrite each other, this PR adds a `-gha` suffix to the tag for the images generated from the GHA workflow (eg. `kubeapps/dashboard:latest-gha)`.

### Benefits

<!-- What benefits will be realized by the code change? -->
Production images generated from each of the different workflows are clearly identifiable and don't overwrite each other.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
In case you want to use the images generated from GHA, you'll have to use a tag that don't follows the standard convention.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #4436 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
