### PR TITLE
Yaml decoding fix

### DIFF
--- a/dashboard/src/shared/yamlUtils.ts
+++ b/dashboard/src/shared/yamlUtils.ts
@@ -85,7 +85,15 @@ export function getPathValueInYamlNode(
   path: string,
 ) {
   const splittedPath = parsePath(path);
-  const value = values?.getIn(splittedPath);
+  let value = values?.getIn(splittedPath);
+
+  // if the value from getIn is an object, it means
+  // it is a YamlSeq or YamlMap, so we need to convert it
+  // back to a plain JS object
+  if (typeof value === "object") {
+    value = (value as any)?.toJSON();
+  }
+
   return value;
 }
 


### PR DESCRIPTION
### Description of the change

While working on #5436, I noticed some errors during the YAML parsing; well not errors, but unexpected (for me) values being returned by the `genIn` method. In collections, the returned thing is not a js object, but a custom data type from the YAML library. 

This PR is just to convert collections (YAML sequences and YAML maps) back to plain js objects (even if the function says `toJSON()` 😅 

### Benefits

We will be able to use arrays and object fields in the form.

### Possible drawbacks

N/A

### Applicable issues

- fixes #5519

### Additional information

> **Note**
> This PR is part of a series of PRs aimed at closing [this milestone](https://github.com/vmware-tanzu/kubeapps/milestone/27). I have split the changes to ease the review process, but as there are many interrelated changes, the tests will be performed in a separate PR (on top of the branch containing all the changes).
>  PR 2 out of 6



