### PR TITLE
Add remaining schema renderers

### DIFF
--- a/dashboard/src/components/DeploymentForm/DeploymentFormBody/BasicDeploymentForm/TabularSchemaEditorTable/Params/BooleanParam.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentFormBody/BasicDeploymentForm/TabularSchemaEditorTable/Params/BooleanParam.tsx
@@ -7,6 +7,7 @@ import Column from "components/js/Column";
 import Row from "components/js/Row";
 import { useState } from "react";
 import { IBasicFormParam } from "shared/types";
+import { getStringValue } from "shared/utils";
 
 export interface IBooleanParamProps {
   id: string;
@@ -19,7 +20,7 @@ export interface IBooleanParamProps {
 export default function BooleanParam(props: IBooleanParamProps) {
   const { id, label, param, handleBasicFormParamChange } = props;
 
-  const [currentValue, setCurrentValue] = useState(param.currentValue);
+  const [currentValue, setCurrentValue] = useState(param.currentValue || false);
   const [isValueModified, setIsValueModified] = useState(false);
 
   const onChange = (e: React.FormEvent<HTMLInputElement>) => {
@@ -27,7 +28,7 @@ export default function BooleanParam(props: IBooleanParamProps) {
     const event = {
       currentTarget: {
         //convert the boolean "checked" prop to a normal "value" string one
-        value: e.currentTarget?.checked?.toString(),
+        value: getStringValue(e.currentTarget?.checked),
         type: "checkbox",
       },
     } as React.FormEvent<HTMLInputElement>;

--- a/dashboard/src/components/DeploymentForm/DeploymentFormBody/BasicDeploymentForm/TabularSchemaEditorTable/Params/TextParam.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentFormBody/BasicDeploymentForm/TabularSchemaEditorTable/Params/TextParam.tsx
@@ -11,63 +11,47 @@ import { isEmpty } from "lodash";
 import { useState } from "react";
 import { validateValuesSchema } from "shared/schema";
 import { IAjvValidateResult, IBasicFormParam } from "shared/types";
-import { basicFormsDebounceTime } from "shared/utils";
+import { basicFormsDebounceTime, getStringValue, getValueFromString } from "shared/utils";
 
 export interface ITextParamProps {
   id: string;
   label: string;
-  inputType?: "text" | "textarea" | string;
+  inputType?: "text" | "textarea" | "password" | string;
   param: IBasicFormParam;
   handleBasicFormParamChange: (
     param: IBasicFormParam,
   ) => (e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
 }
 
-function getStringValue(param: IBasicFormParam, value?: any) {
-  if (["array", "object"].includes(param?.type)) {
-    return JSON.stringify(value || param?.currentValue);
-  } else {
-    return value?.toString() || param?.currentValue?.toString();
-  }
-}
-function getValueFromString(param: IBasicFormParam, value: any) {
-  if (["array", "object"].includes(param?.type)) {
-    try {
-      return JSON.parse(value);
-    } catch (e) {
-      return value?.toString();
-    }
-  } else {
-    return value?.toString();
-  }
-}
-
-function toStringValue(value: any) {
-  return JSON.stringify(value?.toString() || "");
-}
-
 export default function TextParam(props: ITextParamProps) {
   const { id, label, inputType, param, handleBasicFormParamChange } = props;
 
   const [validated, setValidated] = useState<IAjvValidateResult>();
-  const [currentValue, setCurrentValue] = useState(getStringValue(param));
+  const [currentValue, setCurrentValue] = useState(getStringValue(param.currentValue));
   const [isValueModified, setIsValueModified] = useState(false);
   const [timeout, setThisTimeout] = useState({} as NodeJS.Timeout);
 
   const onChange = (
     e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
   ) => {
-    setValidated(validateValuesSchema(e.currentTarget.value, param.schema));
+    // update the current value
     setCurrentValue(e.currentTarget.value);
-    setIsValueModified(toStringValue(e.currentTarget.value) !== toStringValue(param.currentValue));
+    setIsValueModified(
+      getStringValue(e.currentTarget.value) !== getStringValue(param.currentValue),
+    );
+
+    // twofold validation: using the json schema (with ajv) and the html5 validation
+    setValidated(validateValuesSchema(e.currentTarget.value, param.schema));
+    e.currentTarget.reportValidity();
+
     // Gather changes before submitting
     clearTimeout(timeout);
     const func = handleBasicFormParamChange(param);
     // The reference to target get lost, so we need to keep a copy
     const targetCopy = {
       currentTarget: {
-        value: getValueFromString(param, e.currentTarget?.value),
-        type: e.currentTarget?.type,
+        value: getStringValue(e.currentTarget?.value),
+        type: param.type === "object" ? param.type : e.currentTarget?.type,
       },
     } as React.FormEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>;
     setThisTimeout(setTimeout(() => func(targetCopy), basicFormsDebounceTime));
@@ -75,9 +59,11 @@ export default function TextParam(props: ITextParamProps) {
 
   const unsavedMessage = isValueModified ? "Unsaved" : "";
   const isDiffCurrentVsDefault =
-    toStringValue(param.currentValue) !== toStringValue(param.defaultValue);
+    getStringValue(param.currentValue, param.type) !==
+    getStringValue(param.defaultValue, param.type);
   const isDiffCurrentVsDeployed =
-    toStringValue(param.currentValue) !== toStringValue(param.defaultValue);
+    getStringValue(param.currentValue, param.type) !==
+    getStringValue(param.defaultValue, param.type);
   const isModified =
     isValueModified ||
     (isDiffCurrentVsDefault && (!param.deployedValue || isDiffCurrentVsDeployed));
@@ -96,58 +82,105 @@ export default function TextParam(props: ITextParamProps) {
       <CdsControlMessage>{unsavedMessage}</CdsControlMessage>
     );
 
-  let input = (
-    <>
-      <CdsInput className={isModified ? "bolder" : ""}>
-        <input
-          required={param.required}
-          aria-label={label}
-          id={id}
-          type={inputType ?? "text"}
-          value={currentValue ?? ""}
-          onChange={onChange}
-        />
-        {renderControlMsg()}
-      </CdsInput>
-    </>
-  );
-  if (inputType === "textarea") {
-    input = (
-      <CdsTextarea className={isModified ? "bolder" : ""}>
-        <textarea
-          required={param.required}
-          aria-label={label}
-          id={id}
-          value={currentValue ?? ""}
-          onChange={onChange}
-        />
-        {renderControlMsg()}
-      </CdsTextarea>
-    );
-  } else if (!isEmpty(param.enum)) {
-    input = (
-      <>
-        <CdsSelect layout="horizontal" className={isModified ? "bolder" : ""}>
-          <select
-            required={param.required}
-            aria-label={label}
-            id={id}
-            onChange={onChange}
-            value={currentValue}
-          >
-            {param?.enum?.map((enumValue: any) => (
-              <option key={enumValue}>{enumValue}</option>
-            ))}
-          </select>
-          {renderControlMsg()}
-        </CdsSelect>
-      </>
-    );
-  }
+  const renderInput = () => {
+    if (!isEmpty(param.enum)) {
+      return (
+        <>
+          <CdsSelect layout="horizontal">
+            <select
+              required={param.required}
+              disabled={param.readOnly}
+              aria-label={label}
+              id={id}
+              value={getStringValue(currentValue, param.type)}
+              onChange={onChange}
+            >
+              <option disabled={true} key={""}>
+                {""}
+              </option>
+              {param?.enum?.map((enumValue: any) => (
+                <option value={getValueFromString(enumValue)} key={enumValue}>
+                  {enumValue}
+                </option>
+              ))}
+            </select>
+            {renderControlMsg()}
+          </CdsSelect>
+        </>
+      );
+    } else if (param.type === "string") {
+      switch (inputType) {
+        case undefined:
+        case "textarea":
+          return (
+            <CdsTextarea className={isModified ? "bolder" : ""}>
+              <textarea
+                required={param.required}
+                disabled={param.readOnly}
+                maxLength={param.maxLength}
+                minLength={param.minLength}
+                aria-label={label}
+                id={id}
+                value={getStringValue(currentValue, param.type)}
+                onChange={onChange}
+              />
+              {renderControlMsg()}
+            </CdsTextarea>
+          );
+        default:
+          return (
+            <>
+              <datalist id={`${id}-examples`}>
+                {param?.examples?.map((example: any) => (
+                  <option value={getValueFromString(example)} key={example}>
+                    {example}
+                  </option>
+                ))}
+              </datalist>
+              <CdsInput className={isModified ? "bolder" : ""}>
+                <input
+                  required={param.required}
+                  disabled={param.readOnly}
+                  maxLength={param.maxLength}
+                  minLength={param.minLength}
+                  pattern={param.pattern}
+                  aria-label={label}
+                  id={id}
+                  list={param.examples ? `${id}-examples` : ""}
+                  type={inputType}
+                  value={getStringValue(currentValue, param.type)}
+                  onChange={onChange}
+                />
+                {renderControlMsg()}
+              </CdsInput>
+            </>
+          );
+      }
+      // is an object
+    } else {
+      return (
+        <>
+          <CdsTextarea className={isModified ? "bolder" : ""}>
+            <textarea
+              required={param.required}
+              disabled={param.readOnly}
+              maxLength={param.maxLength}
+              minLength={param.minLength}
+              aria-label={label}
+              id={id}
+              value={getStringValue(currentValue)}
+              onChange={onChange}
+            />
+            {renderControlMsg()}
+          </CdsTextarea>
+        </>
+      );
+    }
+  };
 
   return (
     <Row>
-      <Column span={10}>{input}</Column>
+      <Column span={10}>{renderInput()}</Column>
     </Row>
   );
 }

--- a/dashboard/src/components/DeploymentForm/DeploymentFormBody/BasicDeploymentForm/TabularSchemaEditorTable/TabularSchemaEditorTableRenderer.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentFormBody/BasicDeploymentForm/TabularSchemaEditorTable/TabularSchemaEditorTableRenderer.tsx
@@ -160,19 +160,6 @@ export function renderConfigCurrentValuePro(
 
   // if it isn't a custom component or an with more properties, render an input
   switch (param.type) {
-    case "string":
-      return (
-        <TextParam
-          id={param.key}
-          label={param.title || param.path}
-          param={param}
-          inputType={
-            [param.title, param.key].some(s => s.match(/password/i)) ? "password" : "string"
-          }
-          handleBasicFormParamChange={handleBasicFormParamChange}
-        />
-      );
-
     case "boolean":
       return (
         <BooleanParam
@@ -196,35 +183,33 @@ export function renderConfigCurrentValuePro(
         />
       );
     case "array":
-      if (param?.schema?.items?.type !== "object") {
-        return (
-          <ArrayParam
-            id={param.key}
-            label={param.title || param.path}
-            param={param}
-            handleBasicFormParamChange={handleBasicFormParamChange}
-            type={param?.schema?.items?.type ?? "string"}
-          />
-        );
-      } else {
-        // TODO(agamez): render the object properties
-        return (
-          <TextParam
-            id={param.key}
-            label={param.title || param.path}
-            param={param}
-            inputType={"textarea"}
-            handleBasicFormParamChange={handleBasicFormParamChange}
-          />
-        );
-      }
+      return (
+        <ArrayParam
+          id={param.key}
+          label={param.title || param.path}
+          param={param}
+          handleBasicFormParamChange={handleBasicFormParamChange}
+          type={param?.schema?.items?.type ?? "string"}
+          step={param?.multipleOf || (param.schema?.type === "number" ? 0.5 : 1)}
+        />
+      );
+    case "string":
+      return (
+        <TextParam
+          id={param.key}
+          label={param.title || param.path}
+          param={param}
+          inputType={[param.title, param.key].some(s => s.match(/password/i)) ? "password" : "text"}
+          handleBasicFormParamChange={handleBasicFormParamChange}
+        />
+      );
+    case "object":
     default:
       return (
         <TextParam
           id={param.key}
           label={param.title || param.path}
           param={param}
-          inputType={"textarea"}
           handleBasicFormParamChange={handleBasicFormParamChange}
         />
       );

--- a/dashboard/src/shared/utils.ts
+++ b/dashboard/src/shared/utils.ts
@@ -80,8 +80,12 @@ export function getValueFromEvent(
     case "range":
       // value is a number
       return toNumber(value);
+    case "array":
+      return getValueFromString(value, "array");
+    case "object":
+      return getValueFromString(value, "object");
     default:
-      return value;
+      return getValueFromString(value);
   }
 }
 


### PR DESCRIPTION
### Description of the change

In #5436 we mentioned that several fields were still pending, namely

-  1st level: object (at least, as array of tuples <string, any> for defining each property.
-  Array level:  enum, arrays, objects

WRT the top-level objects, it is not an actual problem: if they have `properties`, they will get rendered as any other nested param more. It is only the case when it lacks the `properties` fields that we need to handle.
- Solution: allow any serialized object like `{"foo": 1234}` and add more validation messages.

WRT the array-level properties:
- Solution for enum: use the same approach as in the top-level enum.
- Solution for arrays and objects: use the same approach as in the top-level objects: render a text field but enforce validation.

Additionally, the array now enforces `maxItems` and `minItems`

### Benefits

Every json schema datatype is now supported.

### Possible drawbacks

N/A

### Applicable issues

- fixes #5436 

### Additional information

> **Note**
> This PR is part of a series of PRs aimed at closing [this milestone](https://github.com/vmware-tanzu/kubeapps/milestone/27). I have split the changes to ease the review process, but as there are many interrelated changes, the tests will be performed in a separate PR (on top of the branch containing all the changes).
>  PR 5 out of 6

#### `Top-level objects`:

![image](https://user-images.githubusercontent.com/11535726/197029146-c81a3001-4ca3-4251-87a1-d2eab55df864.png)

#### `Array<enum>`:

![image](https://user-images.githubusercontent.com/11535726/197028415-653f1e3d-f7b3-4d49-aca1-ac788ca2924f.png)

#### `Array<array>`:

![image](https://user-images.githubusercontent.com/11535726/197028515-a64aee32-5796-4dac-9eb3-8fc179435e71.png)

#### `Array<object>`:

![image](https://user-images.githubusercontent.com/11535726/197028310-fd815a03-4f5b-4004-bd0d-c3640f0dd023.png)

#### `YAML output`

![image](https://user-images.githubusercontent.com/11535726/197028679-83146445-7dc1-4516-9b37-d180e403ccee.png)

#### `Array max/min items`

Min items:
![image](https://user-images.githubusercontent.com/11535726/197030005-98e84cca-d78f-4fff-91ac-b02ec84c6a53.png)

Max items:
![image](https://user-images.githubusercontent.com/11535726/197029933-a162625e-da17-4846-be73-4339b97f9f1c.png)
