### PR TITLE
Allow deleting pending pkgs

### DIFF
--- a/dashboard/src/components/AppView/AppControls/DeleteButton/DeleteButton.test.tsx
+++ b/dashboard/src/components/AppView/AppControls/DeleteButton/DeleteButton.test.tsx
@@ -76,7 +76,7 @@ it("renders an error", async () => {
   expect(wrapper.find(Alert)).toIncludeText("Boom!");
 });
 
-it("should render a deactivated button if when passing an in-progress status", async () => {
+it("should render an enabled button and tooltip if when passing a pending status", async () => {
   const disabledProps = {
     ...defaultProps,
     releaseStatus: {
@@ -87,6 +87,21 @@ it("should render a deactivated button if when passing an in-progress status", a
   };
   const wrapper = mountWrapper(defaultStore, <DeleteButton {...disabledProps} />);
 
+  expect(wrapper.find(CdsButton)).not.toBeDisabled();
+  expect(wrapper.find(ReactTooltip)).toIncludeText("The application is pending installation.");
+});
+
+it("should render a deactivated button if when passing a uninstalled status", async () => {
+  const disabledProps = {
+    ...defaultProps,
+    releaseStatus: {
+      ready: false,
+      reason: InstalledPackageStatus_StatusReason.STATUS_REASON_UNINSTALLED,
+      userReason: "Uninstalling",
+    } as InstalledPackageStatus,
+  };
+  const wrapper = mountWrapper(defaultStore, <DeleteButton {...disabledProps} />);
+
   expect(wrapper.find(CdsButton)).toBeDisabled();
-  expect(wrapper.find(ReactTooltip)).toExist();
+  expect(wrapper.find(ReactTooltip)).toIncludeText("The application is being deleted.");
 });

--- a/dashboard/src/components/AppView/AppControls/DeleteButton/DeleteButton.tsx
+++ b/dashboard/src/components/AppView/AppControls/DeleteButton/DeleteButton.tsx
@@ -8,6 +8,7 @@ import { push } from "connected-react-router";
 import {
   InstalledPackageReference,
   InstalledPackageStatus,
+  InstalledPackageStatus_StatusReason,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -61,6 +62,7 @@ export default function DeleteButton({
         releaseStatus={releaseStatus}
         id="delete-button"
         disabled={disabled}
+        statusesToDeactivate={[InstalledPackageStatus_StatusReason.STATUS_REASON_UNINSTALLED]}
       >
         <CdsIcon shape="trash" /> Delete
       </StatusAwareButton>

--- a/dashboard/src/components/AppView/AppControls/StatusAwareButton/StatusAwareButton.test.tsx
+++ b/dashboard/src/components/AppView/AppControls/StatusAwareButton/StatusAwareButton.test.tsx
@@ -8,29 +8,67 @@ import {
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import ReactTooltip from "react-tooltip";
 import { defaultStore, mountWrapper } from "shared/specs/mountWrapper";
-import StatusAwareButton from "./StatusAwareButton";
+import StatusAwareButton, { IStatusAwareButtonProps } from "./StatusAwareButton";
 
-it("tests the disabled flag and tooltip for each release status condition", async () => {
-  type TProps = {
-    code: InstalledPackageStatus_StatusReason | null | undefined;
-    disabled: boolean;
-    tooltip?: string;
-  };
+type TProps = IStatusAwareButtonProps & {
+  code: InstalledPackageStatus_StatusReason | null | undefined;
+  tooltip?: string;
+};
 
+it("tests the disabled flag and tooltip for each release with default and custom status condition", async () => {
   // this should cover all conditions
   const testsProps: TProps[] = [
     {
       code: InstalledPackageStatus_StatusReason.STATUS_REASON_PENDING,
       disabled: true,
       tooltip: "The application is pending installation.",
+      id: "",
+      releaseStatus: {} as InstalledPackageStatus,
     },
     {
       code: InstalledPackageStatus_StatusReason.STATUS_REASON_UNINSTALLED,
       disabled: true,
       tooltip: "The application is being deleted.",
+      id: "",
+      releaseStatus: {} as InstalledPackageStatus,
     },
-    { code: undefined, disabled: true, tooltip: undefined },
-    { code: null, disabled: true, tooltip: undefined },
+    {
+      code: undefined,
+      disabled: true,
+      tooltip: undefined,
+      id: "",
+      releaseStatus: {} as InstalledPackageStatus,
+    },
+    {
+      code: null,
+      disabled: true,
+      tooltip: undefined,
+      id: "",
+      releaseStatus: {} as InstalledPackageStatus,
+    },
+    {
+      code: InstalledPackageStatus_StatusReason.STATUS_REASON_UNINSTALLED,
+      disabled: true,
+      tooltip: "test tooltip for uninstalled",
+      id: "",
+      releaseStatus: {} as InstalledPackageStatus,
+      statusesToDeactivate: [InstalledPackageStatus_StatusReason.STATUS_REASON_UNINSTALLED],
+      statusesToDeactivateTooltips: {
+        [InstalledPackageStatus_StatusReason.STATUS_REASON_UNINSTALLED]:
+          "test tooltip for uninstalled",
+      },
+    },
+    {
+      code: InstalledPackageStatus_StatusReason.STATUS_REASON_PENDING,
+      disabled: false,
+      id: "",
+      releaseStatus: {} as InstalledPackageStatus,
+      statusesToDeactivate: [InstalledPackageStatus_StatusReason.STATUS_REASON_UNINSTALLED],
+      statusesToDeactivateTooltips: {
+        [InstalledPackageStatus_StatusReason.STATUS_REASON_UNINSTALLED]:
+          "test tooltip for uninstalled",
+      },
+    },
   ];
 
   for (const testProps of testsProps) {
@@ -47,21 +85,25 @@ it("tests the disabled flag and tooltip for each release status condition", asyn
           reason: testProps.code,
         } as InstalledPackageStatus;
     }
-    const disabled = testProps.disabled;
-    const tooltip = testProps.tooltip;
     const wrapper = mountWrapper(
       defaultStore,
-      <StatusAwareButton id="test" releaseStatus={releaseStatus} />,
+      <StatusAwareButton
+        id={testProps.id}
+        releaseStatus={releaseStatus}
+        disabled={testProps.disabled}
+        statusesToDeactivate={testProps.statusesToDeactivate}
+        statusesToDeactivateTooltips={testProps.statusesToDeactivateTooltips}
+      />,
     );
 
     // test disabled flag
-    expect(wrapper.find(CdsButton).prop("disabled")).toBe(disabled);
+    expect(wrapper.find(CdsButton).prop("disabled")).toBe(testProps.disabled);
 
     // test tooltip
     const tooltipUI = wrapper.find(ReactTooltip);
-    if (tooltip) {
+    if (testProps.tooltip) {
       expect(tooltipUI).toExist();
-      expect(tooltipUI).toIncludeText(tooltip);
+      expect(tooltipUI).toIncludeText(testProps.tooltip);
     } else {
       expect(tooltipUI.exists()).toBeFalsy();
     }

--- a/dashboard/src/components/AppView/AppControls/StatusAwareButton/StatusAwareButton.tsx
+++ b/dashboard/src/components/AppView/AppControls/StatusAwareButton/StatusAwareButton.tsx
@@ -12,27 +12,45 @@ export interface IStatusAwareButtonProps {
   id: string;
   releaseStatus: InstalledPackageStatus | undefined | null;
   disabled?: boolean;
+  statusesToDeactivate?: InstalledPackageStatus_StatusReason[];
+  statusesToDeactivateTooltips?: { [key: string]: string };
 }
 
 export default function StatusAwareButton<T extends IStatusAwareButtonProps>(props: T) {
-  const { id, releaseStatus, disabled, ...otherProps } = props;
-  // Deactivate the button if: the status code is undefined or null OR the status code is (uninstalled or pending)
-  const isDisabled =
-    disabled || releaseStatus?.reason == null
-      ? true
-      : [
-          InstalledPackageStatus_StatusReason.STATUS_REASON_UNINSTALLED,
-          InstalledPackageStatus_StatusReason.STATUS_REASON_PENDING,
-        ].includes(releaseStatus.reason);
+  const {
+    id,
+    releaseStatus,
+    disabled,
+    statusesToDeactivate,
+    statusesToDeactivateTooltips,
+    ...otherProps
+  } = props;
 
-  const tooltips = {
+  const defaultStatusesToDeactivate = [
+    InstalledPackageStatus_StatusReason.STATUS_REASON_UNINSTALLED,
+    InstalledPackageStatus_StatusReason.STATUS_REASON_PENDING,
+  ];
+  const defaultStatusesToDeactivateTooltips = {
     [InstalledPackageStatus_StatusReason.STATUS_REASON_UNINSTALLED]:
       "The application is being deleted.",
     [InstalledPackageStatus_StatusReason.STATUS_REASON_PENDING]:
       "The application is pending installation.",
   };
 
-  const tooltip = releaseStatus?.reason ? tooltips[releaseStatus.reason] : undefined;
+  // allow buttons to override the default statuses to deactivate
+  const statuses = statusesToDeactivate?.length
+    ? statusesToDeactivate
+    : defaultStatusesToDeactivate;
+
+  const tooltips = statusesToDeactivateTooltips
+    ? statusesToDeactivateTooltips
+    : defaultStatusesToDeactivateTooltips;
+
+  // Deactivate the button if: the status code is undefined or null OR the status code is (uninstalled or pending)
+  const isDisabled =
+    disabled || releaseStatus?.reason == null ? true : statuses.includes(releaseStatus.reason);
+
+  const tooltip = releaseStatus?.reason ? tooltips![releaseStatus.reason] : undefined;
   return (
     <>
       <CdsButton {...otherProps} disabled={isDisabled} data-for={id} data-tip={true} />


### PR DESCRIPTION
### Description of the change

As reported in #5538, sometimes, packages get stuck in a pending state. Currently, Kubeapps UI was preventing the deletion of pending packages, but this might not be a good solution if we really want to delete a package. 
It should be the backend that manages the deletion (or not) of a pending package.

However, the tooltip is still being shown, this way users, at least, will notice something is happening with this package.

### Benefits

No more pending packages stuck

### Possible drawbacks

N/A

### Applicable issues

- fixes #5538

### Additional information

![image](https://user-images.githubusercontent.com/11535726/197772089-1332fcf9-dcf3-4b0f-b7ca-a524a0ca08c6.png)

![image](https://user-images.githubusercontent.com/11535726/197772022-857f5f7c-fb56-4ad9-972e-f36a27259af4.png)

