### PR TITLE
Add explicit token for Kubeapps cluster reference

### DIFF
--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
@@ -323,9 +323,8 @@ func createConfigGetterWithParams(inClusterConfig *rest.Config, serveOpts core.S
 		var config *rest.Config
 
 		// Enable existing plugins to pass an empty cluster name to get the
-		// kubeapps cluster for now, until we support (or otherwise decide)
-		// multicluster configuration of all plugins.
-		if cluster == "" {
+		// kubeapps cluster
+		if kube.IsKubeappsClusterRef(cluster) {
 			cluster = clustersConfig.KubeappsClusterName
 		}
 

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -1035,9 +1035,9 @@ func (s *Server) AddPackageRepository(ctx context.Context, request *corev1.AddPa
 		return nil, status.Errorf(codes.InvalidArgument, "no package repository Name provided")
 	}
 
-	name := request.GetName()
-	url := request.GetUrl()
-	log.Infof("+helm AddPackageRepository '%s' pointing to '%s'", name, url)
+	repoName := request.GetName()
+	repoUrl := request.GetUrl()
+	log.Infof("+helm AddPackageRepository '%s' pointing to '%s'", repoName, repoUrl)
 
 	cluster := request.GetContext().GetCluster()
 	if cluster == "" {
@@ -1052,7 +1052,7 @@ func (s *Server) AddPackageRepository(ctx context.Context, request *corev1.AddPa
 		return nil, status.Errorf(codes.InvalidArgument, "Namespace Scope is inconsistent with the provided Namespace")
 	}
 	name := types.NamespacedName{
-		Name:      request.Name,
+		Name:      repoName,
 		Namespace: namespace,
 	}
 

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -1035,7 +1035,9 @@ func (s *Server) AddPackageRepository(ctx context.Context, request *corev1.AddPa
 		return nil, status.Errorf(codes.InvalidArgument, "no package repository Name provided")
 	}
 
-	log.Infof("+helm AddPackageRepository '%s' pointing to '%s'", request.GetName(), request.GetUrl())
+	name := request.GetName()
+	url := request.GetUrl()
+	log.Infof("+helm AddPackageRepository '%s' pointing to '%s'", name, url)
 
 	cluster := request.GetContext().GetCluster()
 	if cluster == "" {

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -1035,9 +1035,8 @@ func (s *Server) AddPackageRepository(ctx context.Context, request *corev1.AddPa
 		return nil, status.Errorf(codes.InvalidArgument, "no package repository Name provided")
 	}
 
-	repoName := request.GetName()
-	repoUrl := request.GetUrl()
-	log.Infof("+helm AddPackageRepository '%s' pointing to '%s'", repoName, repoUrl)
+	repoName := request.Name
+	log.Infof("+helm AddPackageRepository '%s'", repoName)
 
 	cluster := request.GetContext().GetCluster()
 	if cluster == "" {

--- a/pkg/kube/cluster_config.go
+++ b/pkg/kube/cluster_config.go
@@ -13,6 +13,16 @@ import (
 	"path/filepath"
 )
 
+const (
+	// KUBEAPPS_GLOBAL_PACKAGING_CLUSTER_TOKEN
+	// Kubeapps can be configured such that users cannot target the cluster
+	// on which Kubeapps is itself installed (ie. it's not listed in the
+	// clusters config). In this specific case, there is no way to refer
+	// to a configured name for the global packaging cluster, so we define
+	// one to be used that does not clash with user-configurable names.
+	KUBEAPPS_GLOBAL_PACKAGING_CLUSTER_TOKEN = "-"
+)
+
 // ClusterConfig contains required info to talk to additional clusters.
 type ClusterConfig struct {
 	Name                     string `json:"name"`
@@ -82,10 +92,11 @@ func NewClusterConfig(inClusterConfig *rest.Config, userToken string, cluster st
 	config.BearerToken = userToken
 	config.BearerTokenFile = ""
 
-	// If the cluster is empty, we assume the rest of the inClusterConfig is correct. This can be the case when
-	// the cluster on which Kubeapps is installed is not one presented in the UI as a target (hence not in the
-	// `clusters` configuration).
-	if cluster == "" {
+	// If the cluster name is the Kubeapps global packaging cluster then the
+	// inClusterConfig is already correct. This can be the case when the cluster
+	// on which Kubeapps is installed is not one presented in the UI as a target
+	// (hence not in the `clusters` configuration).
+	if IsKubeappsClusterRef(cluster) {
 		return config, nil
 	}
 
@@ -195,5 +206,16 @@ func ParseClusterConfig(configPath, caFilesPrefix string, pinnipedProxyURL, Pinn
 		}
 		configs.Clusters[c.Name] = c
 	}
+	// If the cluster on which Kubeapps is installed was not present in
+	// the clusters config, we explicitly use a token to identify this
+	// cluster when needed (such as for global available packages).
+	if configs.KubeappsClusterName == "" {
+		configs.KubeappsClusterName = KUBEAPPS_GLOBAL_PACKAGING_CLUSTER_TOKEN
+	}
 	return configs, deferFn, nil
+}
+
+// IsKubeappsClusterRef checks if the provided cluster name references the global packaging Kubeapps cluster
+func IsKubeappsClusterRef(cluster string) bool {
+	return cluster == "" || cluster == KUBEAPPS_GLOBAL_PACKAGING_CLUSTER_TOKEN
 }

--- a/pkg/kube/cluster_config_test.go
+++ b/pkg/kube/cluster_config_test.go
@@ -45,9 +45,9 @@ func TestNewClusterConfig(t *testing.T) {
 			},
 		},
 		{
-			name:      "returns an in-cluster config when no cluster is specified",
+			name:      "returns an in-cluster config when the global packaging cluster token is specified",
 			userToken: "token-1",
-			cluster:   "",
+			cluster:   KUBEAPPS_GLOBAL_PACKAGING_CLUSTER_TOKEN,
 			clustersConfig: ClustersConfig{
 				KubeappsClusterName: "",
 				Clusters: map[string]ClusterConfig{
@@ -339,7 +339,7 @@ func TestParseClusterConfig(t *testing.T) {
 				{"name": "cluster-3", "apiServiceURL": "https://example.com/cluster-3", "certificateAuthorityData": "Y2EtY2VydC1kYXRhLWFkZGl0aW9uYWwK"}
 			]`,
 			expectedConfig: ClustersConfig{
-				KubeappsClusterName: "",
+				KubeappsClusterName: KUBEAPPS_GLOBAL_PACKAGING_CLUSTER_TOKEN,
 				Clusters: map[string]ClusterConfig{
 					"cluster-2": {
 						Name:                            "cluster-2",


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

Adapted version of the outdated PR #4591. After removing kubeops, there has been a refactor of places changes by the old PR.
It fixes the scenario in which the cluster where Kubeapps is installed is not part of the configured list of clusters.
For example:

```yaml
clusters:
  - name: second-cluster
    domain: ...
    apiServiceURL: ....
    certificateAuthorityData: ...
    serviceToken: eyJhbGciOiJS...
```

For doing so, it uses a token to reference the Kubeapps cluster: `-`.
Also empty string `''` is accepted as cluster reference, for allowing payloads in which there is no cluster specified in context.

Therefore, if a cluster string is empty or `-`, backend logic assumes that the Kubeapps cluster will be used.

### Benefits

User can work in a multicluster setups in which the Kubeapps cluster is not part of the allowed clusters.

### Possible drawbacks

N/A

### Applicable issues

- fixes #4564

### Additional information

Manual tests have been done with Helm plugin (only one working in multicluster so far).
CI E2E test will be done in #4563
