### PR TITLE
Switch cache to custom without write-lock for reads.

### DIFF
--- a/chart/kubeapps/templates/frontend/deployment.yaml
+++ b/chart/kubeapps/templates/frontend/deployment.yaml
@@ -262,6 +262,7 @@ spec:
             - name: DEFAULT_PINNIPED_API_SUFFIX
               value: {{ .Values.pinnipedProxy.defaultPinnipedAPISuffix | quote }}
             - name: RUST_LOG
+              # Use info,pinniped_proxy::pinniped=debug for module control.
               value: info
               {{- if .Values.pinnipedProxy.extraEnvVars }}
               {{- include "common.tplvalues.render" (dict "value" .Values.pinnipedProxy.extraEnvVars "context" $) | nindent 12 }}

--- a/cmd/pinniped-proxy/Cargo.lock
+++ b/cmd/pinniped-proxy/Cargo.lock
@@ -60,23 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "async_once"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce4f10ea3abcd6617873bae9f91d1c5332b4a778bd9ce34d0cd517474c1de82"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,43 +110,6 @@ name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
-
-[[package]]
-name = "cached"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b4147cd94d5fbdc2ab71b11d50a2f45493625576b3bb70257f59eedea69f3d"
-dependencies = [
- "async-trait",
- "async_once",
- "cached_proc_macro",
- "cached_proc_macro_types",
- "futures",
- "hashbrown",
- "instant",
- "lazy_static",
- "once_cell",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751f7f4e7a091545e7f6c65bacc404eaee7e87bfb1f9ece234a1caa173dc16f2"
-dependencies = [
- "cached_proc_macro_types",
- "darling 0.13.4",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "cached_proc_macro_types"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "cc"
@@ -381,36 +327,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
 dependencies = [
- "darling_core 0.14.1",
- "darling_macro 0.14.1",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -429,22 +351,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core 0.13.4",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
- "darling_core 0.14.1",
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -1029,7 +940,7 @@ version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98459d53b2841237392cd6959956185b2df15c19d32c3b275ed6ca7b7ee1adae"
 dependencies = [
- "darling 0.14.1",
+ "darling",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -1353,7 +1264,6 @@ version = "0.0.0-devel"
 dependencies = [
  "anyhow",
  "base64",
- "cached",
  "chrono",
  "clap",
  "env_logger",

--- a/cmd/pinniped-proxy/Cargo.toml
+++ b/cmd/pinniped-proxy/Cargo.toml
@@ -13,7 +13,6 @@ build = "build.rs"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.13"
-cached = "0.40"
 chrono = "0.4"
 env_logger = "0.9"
 hyper = { version = "0.14", features = ["server"] }

--- a/cmd/pinniped-proxy/src/cache.rs
+++ b/cmd/pinniped-proxy/src/cache.rs
@@ -1,0 +1,134 @@
+// Copyright 2020-2022 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashMap, hash::Hash, sync::RwLock};
+
+/// An unlimited cache that can be RwLocked across threads.
+///
+/// Importantly, checking the cache does not require a write-lock
+/// (unlike the [`Cached` trait's `cache_get`](https://github.com/jaemk/cached/blob/f5911dc3fbc03e1db9f87192eb854fac2ee6ac98/src/lib.rs#L203))
+#[derive(Default)]
+struct LockableCache<K, V>(RwLock<HashMap<K, V>>);
+
+impl<K, V> LockableCache<K, V> {
+    fn get(&self, k: &K) -> Option<V>
+    where
+        K: Eq + Hash,
+        V: Eq + Hash + Clone,
+    {
+        (*self.0.read().unwrap())
+            .get(k)
+            .and_then(|v| Some((*v).clone()))
+    }
+
+    // insert is called in PrunableCache via a write lock guard, but compiler
+    // doesn't see this, apparently.
+    #[allow(dead_code)]
+    fn insert(&self, k: K, v: V)
+    where
+        K: Eq + Hash,
+        V: Eq + Hash,
+    {
+        self.0.write().unwrap().insert(k, v);
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        (*self.0.read().unwrap()).len()
+    }
+}
+
+/// A cache that additionally prunes itself whenever it holds the write-lock.
+pub struct PruningCache<K, V> {
+    cache: LockableCache<K, V>,
+    prune_fn: fn(&(K, V)) -> bool,
+}
+
+impl<K, V> PruningCache<K, V> {
+    pub fn new(f: fn(&(K, V)) -> bool) -> PruningCache<K, V>
+    where
+        K: Default,
+        V: Default,
+    {
+        PruningCache {
+            cache: LockableCache::default(),
+            prune_fn: f,
+        }
+    }
+
+    pub fn get(&self, k: &K) -> Option<V>
+    where
+        K: Eq + Hash + Clone,
+        V: Eq + Hash + Clone,
+    {
+        // Only return the value from the cache if it should not have been
+        // pruned.
+        self.cache
+            .get(k)
+            .and_then(|v| (self.prune_fn)(&(k.clone(), v.clone())).then_some(v))
+    }
+
+    // Prunes the cache while holding the write-lock during an insert.
+    pub fn insert(&self, k: K, v: V)
+    where
+        K: Eq + Hash + Clone,
+        V: Eq + Hash + Clone,
+    {
+        let mut write_guard = self.cache.0.write().unwrap();
+        write_guard.insert(k, v);
+        // Replace the cache with one where items are pruned.
+        let cache = std::mem::take(&mut *write_guard);
+        *write_guard = cache.into_iter().filter(self.prune_fn).collect();
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.cache.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lockable_cache_get() {
+        let c = LockableCache::default();
+
+        c.insert(1, 5);
+        c.insert(2, 3);
+
+        assert_eq!(c.get(&1), Some(5));
+        assert_eq!(c.get(&2), Some(3));
+        assert_eq!(c.len(), 2);
+    }
+
+    #[test]
+    fn test_lockable_cache_overwrite() {
+        let c = LockableCache::default();
+
+        c.insert(1, 5);
+        assert_eq!(c.get(&1), Some(5));
+
+        c.insert(1, 6);
+        assert_eq!(c.get(&1), Some(6));
+        assert_eq!(c.len(), 1);
+    }
+
+    #[test]
+    fn test_pruning_cache_get() {
+        // Create a cache that prunes all odd numbers (keeps evens only).
+        let c = PruningCache::new(|(_k, v)| *v % 2 == 0);
+
+        c.insert(1, 1);
+        c.insert(2, 2);
+        c.insert(3, 3);
+        c.insert(4, 4);
+
+        assert_eq!(c.get(&1), None);
+        assert_eq!(c.get(&2), Some(2));
+        assert_eq!(c.get(&3), None);
+        assert_eq!(c.get(&4), Some(4));
+        assert_eq!(c.len(), 2);
+    }
+}

--- a/cmd/pinniped-proxy/src/main.rs
+++ b/cmd/pinniped-proxy/src/main.rs
@@ -17,6 +17,7 @@ use log::info;
 use tls_listener::TlsListener;
 
 // Ensure the root crate is aware of the child modules.
+mod cache;
 mod cli;
 mod https;
 mod logging;
@@ -26,15 +27,17 @@ mod tls_config;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_default_env().format(|buf, record| {
-        writeln!(
-            buf,
-            "{} [{}] - {}",
-            Local::now().format("%Y-%m-%dT%H:%M:%S%.6f"),
-            record.level(),
-            record.args()
-        )
-    });
+    env_logger::Builder::from_default_env()
+        .format(|buf, record| {
+            writeln!(
+                buf,
+                "{} [{}] - {}",
+                Local::now().format("%Y-%m-%dT%H:%M:%S%.6f"),
+                record.level(),
+                record.args()
+            )
+        })
+        .init();
     let opt = cli::Options::parse();
 
     // Load the default certificate authority data on startup once.
@@ -47,6 +50,10 @@ async fn main() -> Result<()> {
     if !with_tls && (opt.proxy_tls_cert != "" || opt.proxy_tls_cert_key != "") {
         panic!("If configuring TLS support, you must set both --proxy-tls-cert and --proxy-tls-cert-key");
     }
+
+    // Create a credential cache that will keep only non-expired credentials and
+    // can be shared across threads.
+    let credential_cache = pinniped::new_credential_cache();
 
     // Run the server for ever. If it returns with an error, return the
     // result, otherwise, if it completes, we return Ok.
@@ -66,10 +73,17 @@ async fn main() -> Result<()> {
         // to service_fn here so we can pass the default certificate authority
         // data.
         let make_svc = make_service_fn(|_conn| {
+            // These need to be cloned since this closure can (and will) be called
+            // multiple times.
             let default_ca_data = default_ca_data.clone();
+            let credential_cache = credential_cache.clone();
             async {
                 Ok::<_, Infallible>(service_fn(move |req| {
-                    service::proxy(req, default_ca_data.clone().into_bytes())
+                    service::proxy(
+                        req,
+                        default_ca_data.clone().into_bytes(),
+                        credential_cache.clone(),
+                    )
                 }))
             }
         });
@@ -87,9 +101,14 @@ async fn main() -> Result<()> {
         // compiler uses a different type for the non-tls version.
         let make_svc = make_service_fn(|_conn| {
             let default_ca_data = default_ca_data.clone();
+            let credential_cache = credential_cache.clone();
             async {
                 Ok::<_, Infallible>(service_fn(move |req| {
-                    service::proxy(req, default_ca_data.clone().into_bytes())
+                    service::proxy(
+                        req,
+                        default_ca_data.clone().into_bytes(),
+                        credential_cache.clone(),
+                    )
                 }))
             }
         });

--- a/cmd/pinniped-proxy/src/service.rs
+++ b/cmd/pinniped-proxy/src/service.rs
@@ -9,17 +9,21 @@ use hyper::{Body, Request, Response, StatusCode};
 use log::{error, info};
 use native_tls::TlsConnector;
 
-use crate::https;
-use crate::logging;
-use crate::pinniped;
+use crate::{
+    https, logging,
+    {pinniped, pinniped::CredentialCache},
+};
 
-/// The proxy service accepts a request and returns the proxied response from the api server.
+/// The proxy service accepts a request and returns the proxied response from
+/// the api server.
 ///
-/// The request must include an authorization token which is exchanged with pinniped-concierge
-/// for an X509 client identity cert with which the request is forwarded on.
+/// The request must include an authorization token which is exchanged with
+/// pinniped-concierge for an X509 client identity cert with which the request
+/// is forwarded on.
 pub async fn proxy(
     mut req: Request<Body>,
     default_ca_data: Vec<u8>,
+    credential_cache: CredentialCache,
 ) -> Result<Response<Body>, Infallible> {
     let mut log_data = logging::request_log_data(&req);
     let k8s_api_server_url = match https::get_api_server_url(req.headers()) {
@@ -65,14 +69,17 @@ pub async fn proxy(
     // the client cert. It'd be nice if we could do the construction once and just
     // clone to add the client cert?
     let mut tls_builder = &mut TlsConnector::builder();
-    // Ensure we can talk to the k8s api server via TLS by setting the api server cert.
+    // Ensure we can talk to the k8s api server via TLS by setting the api server
+    // cert.
     tls_builder = tls_builder.add_root_certificate(k8s_api_cert.clone());
-    // Ensure the user is authenticated by exchanging the header authz token for a client identity X509 cert.
+    // Ensure the user is authenticated by exchanging the header authz token for a
+    // client identity X509 cert.
     tls_builder = match https::include_client_identity_for_headers(
         tls_builder,
         req.headers().clone(),
         &k8s_api_server_url,
         &cert_auth_data,
+        credential_cache,
     )
     .await
     {


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

Follows on from #5518, this time replacing the `cached` package with a custom credential cache.

### Description of the change

After further digging, I found that one cause of the slow handling of 50 concurrent requests going through the pinniped-proxy was that:
 - We were caching a function with an async/await signature which means that even the cached version must have that signature as well - which means a blocking i/o call (which switches the task), and
 - The `Cached` trait specifies that even a `cache_get` operation mutates the cache (in our case, just for statistics of hits/misses), which, as a result, requires acquiring a *write* lock to the cache to read a cached value.

For more details, please see the [discussion with the `Cached` author](https://github.com/jaemk/cached/issues/133).

To avoid both of those issues, this PR:
1. Adds a `cache` module that provides a generic read/write `LockableCache` (for multiple readers, single writer) and builds on that with a `PruningCache` that will prune entries (given a test function) when they should no longer be cached,
2. Uses (1) to create a single `CredentialCache` on startup (in `main.rs`) specifically for caching `TokenCredentialRequest` objects and pruning expired entries, and then passes this through for use in different threads concurrently.
3. Uses the cache to fetch the credentials.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Fetching from the cache is now non-blocking (generally, except when an entry is being added) and so leads to less task switching, improving the total query time by ~2s (down to 3-4). 

There is still something else using significant CPU when creating the client itself (cert-related), which I'm investigating now in a separate PR.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Ref #5407 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

Example log when using `RUST_LOG=info,pinniped_proxy::pinniped=debug` which shows the cache being used after the first request. I've not included it in the output generally, but the cache get is now always under a millisecond. As above, the significant delays (some calls to prepare_and_call_pinniped_exchange only 4ms, others 98ms) are what I'll look at next.

```
2022-10-27T01:42:47.820245 [INFO] - Listening on http://0.0.0.0:3333
2022-10-27T01:43:05.077116 [DEBUG] - prepare_and_call_pinniped_exchange took 17ms. Used cache?: false
2022-10-27T01:43:05.085273 [INFO] - GET https://kubernetes.default/api?timeout=32s 200 OK
2022-10-27T01:43:05.091663 [DEBUG] - prepare_and_call_pinniped_exchange took 5ms. Used cache?: true
2022-10-27T01:43:05.100437 [INFO] - GET https://kubernetes.default/apis?timeout=32s 200 OK
2022-10-27T01:43:05.106005 [DEBUG] - prepare_and_call_pinniped_exchange took 4ms. Used cache?: true
2022-10-27T01:43:05.209952 [DEBUG] - prepare_and_call_pinniped_exchange took 21ms. Used cache?: true
2022-10-27T01:43:05.299424 [DEBUG] - prepare_and_call_pinniped_exchange took 5ms. Used cache?: true
2022-10-27T01:43:05.311599 [DEBUG] - prepare_and_call_pinniped_exchange took 5ms. Used cache?: true
2022-10-27T01:43:05.493269 [DEBUG] - prepare_and_call_pinniped_exchange took 98ms. Used cache?: true
2022-10-27T01:43:05.593683 [DEBUG] - prepare_and_call_pinniped_exchange took 4ms. Used cache?: true
2022-10-27T01:43:05.604348 [DEBUG] - prepare_and_call_pinniped_exchange took 4ms. Used cache?: true
2022-10-27T01:43:05.697828 [DEBUG] - prepare_and_call_pinniped_exchange took 87ms. Used cache?: true
2022-10-27T01:43:05.811590 [DEBUG] - prepare_and_call_pinniped_exchange took 20ms. Used cache?: true
2022-10-27T01:43:06.004358 [DEBUG] - prepare_and_call_pinniped_exchange took 94ms. Used cache?: true
2022-10-27T01:43:06.098603 [DEBUG] - prepare_and_call_pinniped_exchange took 5ms. Used cache?: true
2022-10-27T01:43:06.108756 [DEBUG] - prepare_and_call_pinniped_exchange took 4ms. Used cache?: true

```
