### PR TITLE
Fix website search issue

### DIFF
--- a/site/themes/template/layouts/_default/baseof.html
+++ b/site/themes/template/layouts/_default/baseof.html
@@ -58,15 +58,19 @@
     {{ if in $permalinkAsTitle "Latest" }}
       {{ $title = "Documentation" }}
       {{ $description = "Kubeapps Documentation" }}
-      {{ else }}
-      {{ $title = $permalinkAsTitle }}
-      {{ $description = printf "%s %s" "Kubeapps" $permalinkAsTitle }}
+    {{ else }}
+        {{ $title = $permalinkAsTitle }}
+        {{ if in $permalinkAsTitle "Kubeapps" }}
+          {{ $description = $permalinkAsTitle }}
+        {{ else }}
+          {{ $description = printf "%s %s" "Kubeapps" $permalinkAsTitle }}
+        {{ end }}
     {{ end }}
   {{ else if .Title }}
     {{ $title = .Title }}
     {{ if in .Title "Kubeapps" }}
       {{ $title = "Home" }}
-      {{ $description =  .Site.Params.description  }}
+      {{ $description = .Site.Params.description }}
     {{ end }}
   {{ else }}
     {{ $title = $permalinkAsTitle }}

--- a/site/themes/template/layouts/_default/search.html
+++ b/site/themes/template/layouts/_default/search.html
@@ -1,3 +1,22 @@
 {{ if .Site.Params.docs_search }}
+<script type="text/javascript">
+    // Since the Algolia is loaded asynchronously, we need to wait for it to be loaded before we can use it.
+    document.addEventListener("DOMContentLoaded", function () {
+        if (algoliasearchNetlify) {
+            algoliasearchNetlify({
+                appId: '{{ .Site.Params.docs_search_app_id }}',
+                apiKey: '{{ .Site.Params.docs_search_api_key }}',
+                siteId: '{{ .Site.Params.docs_search_site_id }}',
+                branch: 'main',
+                selector: 'div#search',
+            });
+        }
+        // Replace the "submit" title with a more descriptive one
+        var button = document.querySelector(".aa-SubmitButton")
+        if (button) {
+            button.setAttribute("title", "Search");
+        }
+    });
+</script>
 <div id="search"></div>
 {{ end }}

--- a/site/themes/template/static/js/main.js
+++ b/site/themes/template/static/js/main.js
@@ -35,19 +35,6 @@ document.querySelectorAll("pre").forEach(function (codeBlock) {
   codeBlock.setAttribute("tabindex", "-1");
 });
 
-// Since the Algolia script is loaded asynchronously, we need to wait for it to be loaded before we can use it.
-document.addEventListener("DOMContentLoaded", function () {
-  algoliasearchNetlify({
-    appId: "{{ .Site.Params.docs_search_app_id }}",
-    apiKey: "{{ .Site.Params.docs_search_api_key }}",
-    siteId: "{{ .Site.Params.docs_search_site_id }}",
-    branch: "main",
-    selector: "div#search",
-  });
-  // Replace the "submit" title with a more descriptive one
-  document.querySelector(".aa-SubmitButton").setAttribute("title", "Search");
-});
-
 // Make the "cookie setting" link also clickable via keyboard for a11y purposes
 // snippet based on https://community.cookiepro.com/s/article/UUID-69162cb7-c4a2-ac70-39a1-ca69c9340046
 document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
### Description of the change

This PR is a hotfix for a bug introduced at #5579: the searchbox init code was moved to a `static` folder, which is unable to retrieve the values from the site params. Therefore, the API key is  literally `.Site.Params.docs_search_api_key` instead of the replaced value.

Also, squeezing a minor fix to prevent `Kubeapps Kubeapps ...`  to appear in the descriptions.

### Benefits

 Search will work again

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
