### PR TITLE
Increase timeout for local_e2e_tests(opeartor) to avoid flaky tests

### DIFF
--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -435,6 +435,9 @@ jobs:
         include: # Override the default timeout for the operators group, to avoid flaky tests
           - tests_group: operator
             timeout_minutes: 6
+        exclude:
+          - tests_group: operator
+            timeout_minutes: 4
     env:
       DEFAULT_DEX_IP: "172.18.0.2"
       IMG_PREFIX: ${{ needs.setup.outputs.img_prefix }}

--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -430,13 +430,18 @@ jobs:
           - multicluster-nokubeapps
           - carvel
           - operator
+        timeout_minutes:
+          - 4
+        include: # Override the default timeout for the operators group, to avoid flaky tests
+          - tests_group: operator
+            timeout_minutes: 6
     env:
       DEFAULT_DEX_IP: "172.18.0.2"
       IMG_PREFIX: ${{ needs.setup.outputs.img_prefix }}
       TESTS_GROUP: ${{ matrix.tests_group }}
       TEST_OPERATORS: "1"
       TEST_UPGRADE: "1"
-      TEST_TIMEOUT_MINUTES: 4  # Timeout minutes for each test
+      TEST_TIMEOUT_MINUTES: ${{ matrix.timeout_minutes }}  # Timeout minutes for each test
       USE_MULTICLUSTER_OIDC_ENV: "true"
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This PR increases the timeout for the `operator` group of the `local_e2e_tests` job of the `kubeapps-general.yml` workflow.

### Benefits

<!-- What benefits will be realized by the code change? -->
Prevent flaky tests due to timeouts.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #4436 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
N/A
