### PR TITLE
Rename GHA's `main` job to `CI`

### DIFF
--- a/.github/workflows/kubeapps-full-integration.yaml
+++ b/.github/workflows/kubeapps-full-integration.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  main:
+  CI:
     uses: ./.github/workflows/kubeapps-general.yaml
     secrets: inherit
     with:

--- a/.github/workflows/kubeapps-main.yaml
+++ b/.github/workflows/kubeapps-main.yaml
@@ -15,6 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  main:
+  CI:
     uses: ./.github/workflows/kubeapps-general.yaml
     secrets: inherit

--- a/.github/workflows/kubeapps-release.yml
+++ b/.github/workflows/kubeapps-release.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  main:
+  CI:
     uses: ./.github/workflows/kubeapps-general.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This PR renames the `main` job in GHA workflows to `CI`.

### Benefits

<!-- What benefits will be realized by the code change? -->
We get a shorter and (IMHO) more intuitive name for the job that calls the `kubeapps-general` workflow from several top-level workflows.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #4436 

### Additional information
N/A

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
