### PR TITLE
Adjust concurrency in gha workflow

### DIFF
--- a/.github/workflows/kubeapps-main.yaml
+++ b/.github/workflows/kubeapps-main.yaml
@@ -6,6 +6,8 @@ name: Main Pipeline
 
 on:
   push:
+    branches:
+      - main
     tags-ignore:
       - '*'
   pull_request:

--- a/.github/workflows/kubeapps-main.yaml
+++ b/.github/workflows/kubeapps-main.yaml
@@ -6,6 +6,8 @@ name: Main Pipeline
 
 on:
   push:
+    tags-ignore:
+      - '*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/kubeapps-release.yml
+++ b/.github/workflows/kubeapps-release.yml
@@ -10,7 +10,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 concurrency:
-  group: ${{ github.head_ref || github.ref_name }}
+  group: ${{ github.head_ref || github.ref_name }}_release
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
With these changes we achieve the following:
- Do not trigger the `Kubeapps Main Pipeline` workflow for every push, only for pushes to the master branch.
- Use a different concurrency group for the `Release Pipeline`, so a later workflow triggered from a push to the main branch won't cancel the release pipeline.
- Do not trigger the `Kubeapps Main Pipeline` workflow on tags creation. We trigger the release pipeline for this event and don't want a second pipeline running on the same version of the code, that could interfere with the former (eg. canceling the release pipeline because they both run in the same concurrency group).

### Benefits
- Less number of pipelines triggered, and the triggered ones are more meaningful.
- A more resilient release flow.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
- The main pipeline isn't triggered until a PR is triggered so the feedback loop could be larger.
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #4436 

### Additional information
N/A
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
