### PR TITLE
Trigger GHA release workflow on tags following `test-*` pattern

### DIFF
--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -138,8 +138,15 @@ jobs:
           else
             echo "running_on_tag=false" >> $GITHUB_OUTPUT
           fi
-
-          echo "dev_mode=${DEV_MODE}" >> $GITHUB_OUTPUT
+          
+          # TODO(bjesus) Once we've properly tested the release job, we can/should remove this hack, just leave the content from the else branch
+          if [[ ${GITHUB_REF_TYPE} == "tag" &&  ${GITHUB_REF_NAME} == 'test-'* ]]; then
+            echo "DEV_MODE=true" >> $GITHUB_ENV
+            echo "dev_mode=true" >> $GITHUB_OUTPUT
+          else
+            echo "dev_mode=${DEV_MODE}" >> $GITHUB_OUTPUT
+          fi
+          
           echo "golang_version=${GOLANG_VERSION}" >> $GITHUB_OUTPUT
           echo "ssh_key_kubeapps_deploy_filename=${SSH_KEY_KUBEAPPS_DEPLOY_FILENAME}" >> $GITHUB_OUTPUT
           echo "ssh_key_forked_charts_deploy_filename=${SSH_KEY_FORKED_CHARTS_DEPLOY_FILENAME}" >> $GITHUB_OUTPUT

--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -138,7 +138,7 @@ jobs:
           else
             echo "running_on_tag=false" >> $GITHUB_OUTPUT
           fi
-          
+
           # TODO(bjesus) Once we've properly tested the release job, we can/should remove this hack, just leave the content from the else branch
           if [[ ${GITHUB_REF_TYPE} == "tag" &&  ${GITHUB_REF_NAME} == 'test-'* ]]; then
             echo "DEV_MODE=true" >> $GITHUB_ENV
@@ -146,7 +146,7 @@ jobs:
           else
             echo "dev_mode=${DEV_MODE}" >> $GITHUB_OUTPUT
           fi
-          
+
           echo "golang_version=${GOLANG_VERSION}" >> $GITHUB_OUTPUT
           echo "ssh_key_kubeapps_deploy_filename=${SSH_KEY_KUBEAPPS_DEPLOY_FILENAME}" >> $GITHUB_OUTPUT
           echo "ssh_key_forked_charts_deploy_filename=${SSH_KEY_FORKED_CHARTS_DEPLOY_FILENAME}" >> $GITHUB_OUTPUT

--- a/.github/workflows/kubeapps-release.yml
+++ b/.github/workflows/kubeapps-release.yml
@@ -8,6 +8,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'test-.*'
 
 concurrency:
   group: ${{ github.head_ref || github.ref_name }}_release

--- a/.github/workflows/kubeapps-release.yml
+++ b/.github/workflows/kubeapps-release.yml
@@ -8,6 +8,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      # TODO(bjesus) Remove the following line once we have tested the release process
       - 'test-.*'
 
 concurrency:


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
We need a way of being able to test the new release workflow in GHA. So far, it's only triggered on new tags following the pattern `v[0-9]+.[0-9]+.[0-9]+`, so we cannot trigger it unless a new release tag is created. To allow testing without generating new release tags, we have added a new condition that triggers the workflow when new tags following the pattern `tests-*` are created.

### Benefits
The release workflow can be triggered and tested without the need of creating new release tags.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
If we don't control the kind of tag that triggered the workflow, and deactivate the `DEV_MODE` for the `kubeapps-main` workflow, we could generate an actual release on the Bitnami side upon the creation of new `test-*` tags.
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #4436

### Additional information
N/A
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
