### PR TITLE
Add SRP source provenance report

### DIFF
--- a/.github/actions/srp-source-provenance/action.yml
+++ b/.github/actions/srp-source-provenance/action.yml
@@ -1,3 +1,7 @@
+# Copyright 2018-2022 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+---
 name: SRP Report
 description: Install SRP CLI and Submit Provenance
 inputs:
@@ -44,7 +48,7 @@ runs:
         echo "COMP_UID=$COMP_UID"
         mkdir -p /tmp/provenance
         sudo srp provenance source \
-        --verbose\ 
+        --verbose\
         --scm-type git \
         --name "kubeapps" \
         --path ./ \
@@ -64,7 +68,7 @@ runs:
         cat /tmp/provenance/source.json
         srp uid validate ${SRP_UID}
         srp metadata submit \
-        --verbose \ 
+        --verbose \
         --url https://apigw.vmware.com/v1/s1/api/helix-beta \
         --uid "${SRP_UID}" \
         --path /tmp/provenance/source.json

--- a/.github/actions/srp-source-provenance/action.yml
+++ b/.github/actions/srp-source-provenance/action.yml
@@ -5,6 +5,10 @@
 name: SRP Report
 description: Install SRP CLI and Submit Provenance
 inputs:
+  SRP_CLI_VERSION:
+    description: Version of the SRP CLI tool
+    required: false
+    default: latest
   SRP_CLIENT_ID:
     description: ID for SRP API Credentials
     required: true
@@ -19,11 +23,17 @@ runs:
   steps:
     - name: Download SRP CLI
       shell: bash
+      env:
+        SRP_CLI_VERSION: ${{ inputs.SRP_CLI_VERSION }}
       run: |
         set -u
         mkdir -p /tmp/srp-cli
-        curl https://srp-cli.s3.amazonaws.com/srp-cli-latest.tgz -o /tmp/srp-cli/srp-cli-latest.tgz
-        tar xvzf /tmp/srp-cli/srp-cli-latest.tgz -C /tmp/srp-cli/
+        if [[ "${SRP_CLI_VERSION}" == "latest" ]]; then
+          curl https://srp-cli.s3.amazonaws.com/srp-cli-latest.tgz -o /tmp/srp-cli/srp-cli-latest.tgz
+          tar xvzf /tmp/srp-cli/srp-cli-latest.tgz -C /tmp/srp-cli/
+        else
+          wget "https://vmwaresaas.jfrog.io/artifactory/srp-tools/srpcli/${SRP_CLI_VERSION}/linux/srp" -O /tmp/srp-cli/srp
+        fi
         chmod +x /tmp/srp-cli/srp
         sudo mv /tmp/srp-cli/srp /usr/local/bin/.
         srp --version

--- a/.github/actions/srp-source-provenance/action.yml
+++ b/.github/actions/srp-source-provenance/action.yml
@@ -1,0 +1,75 @@
+name: SRP Report
+description: Install SRP CLI and Submit Provenance
+inputs:
+  SRP_CLIENT_ID:
+    description: ID for SRP API Credentials
+    required: true
+  SRP_CLIENT_SECRET:
+    description: SECRET for SRP API Credentials
+    required: true
+  VERSION:
+    description: Release Version
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Download SRP CLI
+      shell: bash
+      run: |
+        set -u
+        mkdir -p /tmp/srp-cli
+        curl https://srp-cli.s3.amazonaws.com/srp-cli-latest.tgz -o /tmp/srp-cli/srp-cli-latest.tgz
+        tar xvzf /tmp/srp-cli/srp-cli-latest.tgz -C /tmp/srp-cli/
+        chmod +x /tmp/srp-cli/srp
+        sudo mv /tmp/srp-cli/srp /usr/local/bin/.
+        srp --version
+    - name: Configure SRP
+      env:
+        SRP_CLIENT_ID: ${{ inputs.SRP_CLIENT_ID }}
+        SRP_CLIENT_SECRET: ${{ inputs.SRP_CLIENT_SECRET }}
+      shell: bash
+      run: |
+        set -u
+        srp config auth --client-id=${SRP_CLIENT_ID} --client-secret=${SRP_CLIENT_SECRET}
+    - name: Create Source Provenance File
+      env:
+        VERSION: ${{ inputs.VERSION }}
+      shell: bash
+      run: |
+        set -eu
+        export GITHUB_FQDN=$(echo "${GITHUB_SERVER_URL}" | sed -e "s/^https:\/\///")
+        export BUILD_ID=${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}
+        export COMP_UID="uid.obj.build.github(instance='${GITHUB_FQDN}',namespace='${GITHUB_REPOSITORY}',ref='${GITHUB_REF}',action='${GITHUB_ACTION}',build_id='$BUILD_ID')"
+        echo "COMP_UID=$COMP_UID" >> $GITHUB_ENV
+        echo "COMP_UID=$COMP_UID"
+        mkdir -p /tmp/provenance
+        sudo srp provenance source \
+        --verbose\ 
+        --scm-type git \
+        --name "kubeapps" \
+        --path ./ \
+        --saveto /tmp/provenance/source.json \
+        --comp-uid ${COMP_UID} \
+        --build-number ${BUILD_ID} \
+        --version ${VERSION} \
+        --all-ephemeral true \
+        --build-type release
+    - name: Validate and submit the source provenance files to the SRP Metadata service
+      shell: bash
+      run: |
+        echo "COMP_UID: $COMP_UID"
+        export COMP_UID=${COMP_UID//\//\%2f}
+        export SRP_UID="uid.mtd.provenance_2_5.fragment(obj_uid=$COMP_UID,revision='')"
+        echo "SRP_UID: ${SRP_UID}"
+        cat /tmp/provenance/source.json
+        srp uid validate ${SRP_UID}
+        srp metadata submit \
+        --verbose \ 
+        --url https://apigw.vmware.com/v1/s1/api/helix-beta \
+        --uid "${SRP_UID}" \
+        --path /tmp/provenance/source.json
+    - name: Upload SRP file as a build artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: srp-source-provenance-file
+        path: /tmp/provenance/source.json

--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -124,7 +124,7 @@ jobs:
             echo "version=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
           else
             echo "img_prod_tag=latest" >> $GITHUB_OUTPUT
-            echo "version=" >> $GITHUB_OUTPUT
+            echo "version=${GITHUB_SHA}" >> $GITHUB_OUTPUT
           fi;
 
           if [[ ${GITHUB_REF_NAME} == ${BRANCH_KUBEAPPS_REPO} ]]; then
@@ -601,6 +601,20 @@ jobs:
             echo "::notice ::Pushing image ${prod_image}"
             docker push $prod_image
           done
+
+  srp_report:
+    if: false # Deactivated until the new SRP UID for GHA is registered
+#    if: needs.setup.outputs.running_on_main == 'true' || needs.setup.outputs.running_on_tag == 'true'
+    needs:
+      - setup
+      - push_images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/srp-source-provenance
+        with:
+          SRP_CLIENT_ID: ${{secrets.SRP_CLIENT_ID}}
+          SRP_CLIENT_SECRET: ${{secrets.SRP_CLIENT_SECRET}}
+          VERSION: ${{needs.setup.outputs.version}}
 
   sync_chart_from_bitnami:
     needs:

--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -603,8 +603,7 @@ jobs:
           done
 
   srp_report:
-    if: false # Deactivated until the new SRP UID for GHA is registered
-#    if: needs.setup.outputs.running_on_main == 'true' || needs.setup.outputs.running_on_tag == 'true'
+    if: needs.setup.outputs.running_on_main == 'true' || needs.setup.outputs.running_on_tag == 'true'
     needs:
       - setup
       - push_images

--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -71,6 +71,7 @@ env:
   GKE_ZONE: "us-east1-c"
   GKE_PROJECT: "vmware-kubeapps-ci"
   GKE_CLUSTER: "kubeapps-test"
+  SRP_CLI_VERSION: "0.2.20220825211752-571e676-57"
 
 jobs:
   setup:
@@ -603,7 +604,6 @@ jobs:
           done
 
   srp_report:
-    if: needs.setup.outputs.running_on_main == 'true' || needs.setup.outputs.running_on_tag == 'true'
     needs:
       - setup
       - push_images
@@ -611,6 +611,7 @@ jobs:
     steps:
       - uses: ./.github/actions/srp-source-provenance
         with:
+          SRP_CLI_VERSION: ${SRP_CLI_VERSION}
           SRP_CLIENT_ID: ${{secrets.SRP_CLIENT_ID}}
           SRP_CLIENT_SECRET: ${{secrets.SRP_CLIENT_SECRET}}
           VERSION: ${{needs.setup.outputs.version}}


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This PR adds the required SRP source provenance report to the GHA pipeline. Currently, the report is being done in the CircleCI pipeline, but as part of the migration to GHA, we need to implement it there. For this report to work, we need to register a new SRP UID for GHA, which will be something like `uid.mtd.provenance_2_5.fragment(obj_uid=uid.obj.build.github(instance='github.com',namespace='vmware-tanzu/kubeapps',...),version='')`. An [issue](https://servicedesk.eng.vmware.com/servicedesk/customer/portal/12/INTSVC-54793) has been created in the Jira Service Desk for this task, and we will maintain this PR as a draft until that request is fulfilled. 

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

* Report SRP source provenance from GHA pipeline.
* GHA pipeline is complete and we can finally decommission the CircleCI pipeline
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

None.
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #4436 

### Additional information

* https://servicedesk.eng.vmware.com/servicedesk/customer/portal/12/INTSVC-54793
* https://confluence.eng.vmware.com/display/SRPIPELINE/Onboarding+to+SRP+APIs
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
