### PR TITLE
Add makefile lint target

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -16,6 +16,7 @@ header:
     - LICENSE
     - NOTICE
     - open_source_licenses.txt
+    - dashboard/src/setupProxy.js
     - "**/*.css"
     - "**/*.dccache"
     - "**/*.html"

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -5,12 +5,12 @@
 extends: default
 ignore: |
   #  Ignore folders
-  chart/kubeapps/
-  integration/charts/simplechart/
-  dashboard/node_modules/
-  devel/
+  **/chart/kubeapps/
+  **/integration/charts/simplechart/
+  **/dashboard/node_modules/
+  **/devel/
   #  Ignore files
-  cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/testdata/charts/single-package-template.yaml
+  **/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/testdata/charts/single-package-template.yaml
 rules:
   line-length: disable
   comments: disable

--- a/Makefile
+++ b/Makefile
@@ -65,4 +65,9 @@ fmt:
 vet:
 	$(GO) vet $(GO_PACKAGES)
 
-.PHONY: default all test-all test test-dashboard fmt vet
+lint:
+	./script/linters/license-linter.sh
+	./script/linters/yaml-linter.sh
+	./script/linters/golang-linter.sh
+
+.PHONY: default all test-all test test-dashboard fmt vet lint install-tools

--- a/script/linters/golang-linter.sh
+++ b/script/linters/golang-linter.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+command -v golangci-lint > /dev/null 2>&1 || { echo "golangci-lint must be installed -> https://github.com/golangci/golangci-lint"; exit 1; }
+
+PROJECT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null && pwd)
+TIMEOUT="10m"
+
+golangci-lint run --timeout=${TIMEOUT} "${PROJECT_DIR}/cmd/..."
+golangci-lint run --timeout=${TIMEOUT} "${PROJECT_DIR}/pkg/..."

--- a/script/linters/license-linter.sh
+++ b/script/linters/license-linter.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+command -v license-eye > /dev/null 2>&1 || { echo "license-eye must be installed -> https://github.com/apache/skywalking-eyes"; exit 1; }
+
+PROJECT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null && pwd)
+
+license-eye -c "${PROJECT_DIR}/.licenserc.yaml" header check

--- a/script/linters/yaml-linter.sh
+++ b/script/linters/yaml-linter.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+command -v yamllint > /dev/null 2>&1 || { echo "yamllint must be installed -> https://yamllint.readthedocs.io/en/stable/quickstart.html#installing-yamllint"; exit 1; }
+
+PROJECT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null && pwd)
+
+[ -f "${PROJECT_DIR}/.yamllint.yml" ] || exit 1;
+
+yamllint -c "${PROJECT_DIR}/.yamllint.yml" "${PROJECT_DIR}"


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Currently, we have several linters running in our GHA pipeline, but we do not have an easy way of running those linters locally. This PR adds a new target to the makefile that allows executing those linters locally, so we can easily run them as git hooks or whatever.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

We are able to execute the linters locally.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
None
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #5628 

