### PR TITLE
Call chekout action before using srp-source-provenance

### DIFF
--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -609,6 +609,7 @@ jobs:
       - push_images
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/srp-source-provenance
         with:
           SRP_CLI_VERSION: ${SRP_CLI_VERSION}


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

We have a bug in the recently added `report_srp` job in the GHA pipeline. In this job, we are using a custom action defined in the Kubeapps repository without calling the `checkout` action before, so the runner is not able to find the custom action.

### Benefits

GHA's `srp_report` job works as expected.

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #4436 
