### PR TITLE
Fix typo in srp command

### DIFF
--- a/.github/actions/srp-source-provenance/action.yml
+++ b/.github/actions/srp-source-provenance/action.yml
@@ -58,7 +58,7 @@ runs:
         echo "COMP_UID=$COMP_UID"
         mkdir -p /tmp/provenance
         sudo srp provenance source \
-        --verbose\
+        --verbose \
         --scm-type git \
         --name "kubeapps" \
         --path ./ \


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This PR fixes a typo in the call to `srp provenance source` command in the GHA's `srp-source-provenance` action.

### Benefits

A typo in the call to a command is removed, so it should work as expected now.

### Possible drawbacks

None.
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #4436 
