### PR TITLE
Update deprecated parameter in the call to srp tool

### DIFF
--- a/.github/actions/srp-source-provenance/action.yml
+++ b/.github/actions/srp-source-provenance/action.yml
@@ -75,7 +75,9 @@ runs:
         export COMP_UID=${COMP_UID//\//\%2f}
         export SRP_UID="uid.mtd.provenance_2_5.fragment(obj_uid=$COMP_UID,revision='')"
         echo "SRP_UID: ${SRP_UID}"
+        echo "SOURCE PROVENANCE FILE CONTENT:"
         cat /tmp/provenance/source.json
+        echo ""
         srp uid validate ${SRP_UID}
         srp metadata submit \
         --verbose \

--- a/.github/actions/srp-source-provenance/action.yml
+++ b/.github/actions/srp-source-provenance/action.yml
@@ -79,7 +79,7 @@ runs:
         srp uid validate ${SRP_UID}
         srp metadata submit \
         --verbose \
-        --url https://apigw.vmware.com/v1/s1/api/helix-beta \
+        --srp-endpoint https://apigw.vmware.com/v1/s1/api/helix-beta \
         --uid "${SRP_UID}" \
         --path /tmp/provenance/source.json
     - name: Upload SRP file as a build artifact


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Even though the `report_srp` job of the GHA's pipeline is working properly, it's showing a warning due to the use of a deprecated argument in the call to the `srp` tool. Here we replace that argument by the new recommended one.

### Benefits

We get rid of a deprecated argument in the call to the `srp` CLI tool and remove the risk of a future failure when updating to a new version that no longer supports the deprecated argument.

### Possible drawbacks

None

### Applicable issues

- related to #4436 

### Additional information

* https://github.com/vmware-tanzu/kubeapps/actions/runs/3485334417/jobs/5830985505#step:3:701