### PR TITLE
Fix wrong regex for testing the release in GHA

### DIFF
--- a/.github/workflows/kubeapps-release.yml
+++ b/.github/workflows/kubeapps-release.yml
@@ -9,7 +9,7 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       # TODO(bjesus) Remove the following line once we have tested the release process
-      - 'test-.*'
+      - 'test-v[0-9]+.[0-9]+.[0-9]+'
 
 concurrency:
   group: ${{ github.head_ref || github.ref_name }}_release


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This commit fixes the regex that triggers the release pipeline for "testing releases" (tags following the pattern `test-vX.Y.Z`).
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
We can test the release pipeline without triggering a real release.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
None.
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- related to #4436 
