### PR TITLE
Fix GHA's release workflow

### DIFF
--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -617,7 +617,7 @@ jobs:
   sync_chart_from_bitnami:
     needs:
       - setup
-    if: needs.setup.outputs.running_on_main == 'true'
+    if: needs.setup.outputs.running_on_main == 'true' || needs.setup.outputs.running_on_tag == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This commit fixes the GHA's Release Pipeline. Currently, the workflow is not working properly because the `sync_chart_from_bitnami` only runs when the pipeline is triggered from the main branch, and it should run when it's triggered from a version tag also.

### Benefits

The GHA's Release Pipeline works as expected.

### Possible drawbacks

None

### Applicable issues
- related to #4436 
