### PR TITLE
Fix GHA release workflow

### DIFF
--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -134,7 +134,7 @@ jobs:
             echo "running_on_main=false" >> $GITHUB_OUTPUT
           fi
 
-          if [[ ${GITHUB_REF_TYPE} == "tag" && ${GITHUB_REF_NAME} =~ ^v[0-9]+ ]]; then
+          if [[ ${GITHUB_REF_TYPE} == "tag" ]]; then
             echo "running_on_tag=true" >> $GITHUB_OUTPUT
           else
             echo "running_on_tag=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This commit aims to fix the `Release Pipeline` of the GHA workflows (better said, to make it support testing releases, those triggered by tags following the pattern `test-vX.Y.Z`). Currently, it is failing because in the `Kubeapps General` workflow, we are setting the `running_on_tag` output variable of the `setup` job based on whether the Git ref type is `tag` and it matches the pattern `vX.Y.Z`. Given that we are controlling what tag patterns can trigger a release in the `Release Pipeline` workflow, it doesn't make sense to have this condition, as we need to make sure that it's in sync with what there is in the workflow conditions, and it's error-prone.

### Benefits

The `Release Pipeline` works as expected and supports testing releases.

### Possible drawbacks

None.

### Applicable issues

- related to #4436 
