### PR TITLE
Simplify release-related logic in GHA's kubeapps general pipeline

### DIFF
--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -740,6 +740,8 @@ jobs:
       - # Assuming there is a personal access token created in GitHub granted with the scopes
         # "repo:status", "public_repo" and "read:org"
         name: Run the create_release script
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eu
           ./script/create_release.sh "${GITHUB_REF_NAME}" "${KUBEAPPS_REPO}"

--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -13,6 +13,10 @@ on:
         type: boolean
         required: false
         default: true
+      trigger_release:
+        type: boolean
+        required: false
+        default: false
 
 env:
   CHARTMUSEUM_VERSION: "3.9.1"
@@ -86,7 +90,6 @@ jobs:
       postgresql_version: ${{ steps.set-outputs.outputs.postgresql_version }}
       rust_version: ${{ steps.set-outputs.outputs.rust_version }}
       running_on_main: ${{ steps.set-outputs.outputs.running_on_main }}
-      running_on_tag: ${{ steps.set-outputs.outputs.running_on_tag }}
       ssh_key_kubeapps_deploy_filename: ${{ steps.set-outputs.outputs.ssh_key_kubeapps_deploy_filename }}
       ssh_key_forked_charts_deploy_filename: ${{ steps.set-outputs.outputs.ssh_key_forked_charts_deploy_filename }}
       triggered_from_fork: ${{ steps.set-outputs.outputs.triggered_from_fork }}
@@ -134,12 +137,6 @@ jobs:
             echo "running_on_main=false" >> $GITHUB_OUTPUT
           fi
 
-          if [[ ${GITHUB_REF_TYPE} == "tag" ]]; then
-            echo "running_on_tag=true" >> $GITHUB_OUTPUT
-          else
-            echo "running_on_tag=false" >> $GITHUB_OUTPUT
-          fi
-
           # TODO(bjesus) Once we've properly tested the release job, we can/should remove this hack, just leave the content from the else branch
           if [[ ${GITHUB_REF_TYPE} == "tag" &&  ${GITHUB_REF_NAME} == 'test-'* ]]; then
             echo "dev_mode=true" >> $GITHUB_OUTPUT
@@ -165,7 +162,6 @@ jobs:
           echo "POSTGRESQL_VERSION: ${{steps.set-outputs.outputs.postgresql_version}}"
           echo "RUST_VERSION: ${{steps.set-outputs.outputs.rust_version}}"
           echo "RUNNING_ON_MAIN: ${{steps.set-outputs.outputs.running_on_main}}"
-          echo "RUNNING_ON_TAG: ${{steps.set-outputs.outputs.running_on_tag}}"
           echo "SSH_KEY_KUBEAPPS_DEPLOY_FILENAME: ${{steps.set-outputs.outputs.ssh_key_kubeapps_deploy_filename}}"
           echo "SSH_KEY_FORKED_CHARTS_DEPLOY_FILENAME: ${{steps.set-outputs.outputs.ssh_key_forked_charts_deploy_filename}}"
           echo "TRIGGERED_FROM_FORK: ${{steps.set-outputs.outputs.triggered_from_fork}}"
@@ -554,7 +550,7 @@ jobs:
         run: exit 1
 
   push_images:
-    if: needs.setup.outputs.running_on_main == 'true' || needs.setup.outputs.running_on_tag == 'true'
+    if: needs.setup.outputs.running_on_main == 'true' || inputs.trigger_release
     runs-on: ubuntu-latest
     needs:
       - setup
@@ -617,7 +613,7 @@ jobs:
   sync_chart_from_bitnami:
     needs:
       - setup
-    if: needs.setup.outputs.running_on_main == 'true' || needs.setup.outputs.running_on_tag == 'true'
+    if: needs.setup.outputs.running_on_main == 'true' || inputs.trigger_release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -676,7 +672,7 @@ jobs:
       - local_e2e_tests
       - GKE_REGULAR_VERSION
       - GKE_STABLE_VERSION
-    if: needs.setup.outputs.running_on_tag == 'true'
+    if: inputs.trigger_release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -727,7 +723,7 @@ jobs:
               ${DEV_MODE}
 
   release:
-    if: needs.setup.outputs.running_on_tag == 'true'
+    if: inputs.trigger_release
     needs:
       - setup
       - sync_chart_to_bitnami
@@ -749,7 +745,7 @@ jobs:
           ./script/create_release.sh "${GITHUB_REF_NAME}" "${KUBEAPPS_REPO}"
 
   gke_setup:
-    if: needs.setup.outputs.running_on_tag == 'true' || inputs.run_gke_tests
+    if: inputs.run_gke_tests
     needs:
       - setup
       - test_go

--- a/.github/workflows/kubeapps-release.yml
+++ b/.github/workflows/kubeapps-release.yml
@@ -22,3 +22,4 @@ jobs:
     with:
       run_gke_tests: true
       run_linters: false
+      trigger_release: true

--- a/script/create_release.sh
+++ b/script/create_release.sh
@@ -12,6 +12,7 @@ source $(dirname "$0")/chart_sync_utils.sh
 TAG=${1:?Missing tag}
 KUBEAPPS_REPO=${2:?Missing kubeapps repo}
 DEV_MODE=${DEV_MODE:-false}
+GH_TOKEN=${GH_TOKEN:?Missing GitHub token}
 
 if [[ -z "${TAG}" ]]; then
   echo "A git tag is required for creating a release"


### PR DESCRIPTION
Signed-off-by: Jesús Benito Calzada <bjesus@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This commit aims to simplify the logic in the GHA's Kubeapps General workflow. Currently, we have some logic that checks if the pipeline has been triggered by a tag pushed to the repo, and if it is, we run some jobs: push_images, sync_charts, release, etc. As we already have a top-level workflow `kubeapps-release.yml` that internally uses the general workflow, and only runs when a tag following the release pattern is pushed to the repo, we can just introduce an input parameter in the general workflow that controls whether those jobs should be run or not, instead of relying on the logic residing in the general pipeline.

### Benefits

GHA's workflows `kubeapps-general.yaml` and `kubeapps-release.yml` are simpler to understand and maintain.

### Possible drawbacks

None.

### Applicable issues

- related to #4436 