### PR TITLE
Refactor OCI file extraction to use existing tarutils.

### DIFF
--- a/cmd/asset-syncer/server/utils.go
+++ b/cmd/asset-syncer/server/utils.go
@@ -402,10 +402,7 @@ func pullAndExtract(repoURL *url.URL, appName, tag string, puller helm.ChartPull
 		return nil, err
 	}
 
-	// OCI tarballs do not have a root directory with files under that, but rather
-	// have the files at the top-level.
-	tarballRootDir := ""
-	files, err := tarutil.FetchChartDetailFromTarball(chartBuffer, tarballRootDir)
+	files, err := tarutil.FetchChartDetailFromTarball(chartBuffer)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart.go
@@ -112,7 +112,7 @@ func (s *Server) availableChartDetail(ctx context.Context, packageRef *corev1.Av
 		}
 	}
 
-	chartDetail, err := tarutil.FetchChartDetailFromTarball(bytes.NewReader(byteArray), chartID)
+	chartDetail, err := tarutil.FetchChartDetailFromTarball(bytes.NewReader(byteArray), chartName)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart.go
@@ -293,7 +293,7 @@ func availablePackageDetailFromChartDetail(chartID string, chartDetail map[strin
 		ShortDescription: chartMetadata.Description,
 		Categories:       categories,
 		Readme:           chartDetail[models.ReadmeKey],
-		DefaultValues:    chartDetail[models.ValuesKey],
+		DefaultValues:    chartDetail[models.DefaultValuesKey],
 		ValuesSchema:     chartDetail[models.SchemaKey],
 		SourceUrls:       chartMetadata.Sources,
 		Maintainers:      maintainers,

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart.go
@@ -112,7 +112,7 @@ func (s *Server) availableChartDetail(ctx context.Context, packageRef *corev1.Av
 		}
 	}
 
-	chartDetail, err := tarutil.FetchChartDetailFromTarball(bytes.NewReader(byteArray), chartName)
+	chartDetail, err := tarutil.FetchChartDetailFromTarball(bytes.NewReader(byteArray))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/oci_repo.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/oci_repo.go
@@ -844,7 +844,7 @@ func getOCIChartMetadata(ociRepo *OCIChartRepository, chartID string, chartVersi
 	}
 
 	// not sure yet why flux untars into a temp directory
-	files, err := tarutil.FetchChartDetailFromTarball(bytes.NewReader(chartTarball), chartID)
+	files, err := tarutil.FetchChartDetailFromTarball(bytes.NewReader(chartTarball))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "%v", err)
 	}

--- a/pkg/chart/models/chart.go
+++ b/pkg/chart/models/chart.go
@@ -77,13 +77,13 @@ type ChartVersion struct {
 
 // ChartFiles holds the README and default values for a given chart version
 type ChartFiles struct {
-	ID                  string `bson:"file_id"`
-	Readme              string
-	DefaultValues       string
-	CustomDefaultValues map[string]string
-	Schema              string
-	Repo                *Repo
-	Digest              string
+	ID                      string `bson:"file_id"`
+	Readme                  string
+	DefaultValues           string
+	AdditionalDefaultValues map[string]string
+	Schema                  string
+	Repo                    *Repo
+	Digest                  string
 }
 
 // Allow to convert ChartFiles to a sql JSON
@@ -94,8 +94,8 @@ func (a ChartFiles) Value() (driver.Value, error) {
 // some constant strings used as keys in maps in several modules
 const (
 	ReadmeKey                  = "readme"
-	ValuesKey                  = "values"
-	AdditionalDefaultValuesKey = "additionalDefaultValues"
+	DefaultValuesKey           = "values"
+	AdditionalDefaultValuesKey = "additional-values"
 	SchemaKey                  = "schema"
 	ChartYamlKey               = "chartYaml"
 )

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -41,25 +41,6 @@ func FetchChartDetailFromTarballUrl(name string, chartTarballURL string, userAge
 		return nil, err
 	}
 
-	return FetchChartDetailFromTarball(reader, name)
-}
-
-//
-// Fetches helm chart details from a gzipped tarball
-//
-// name is expected in format "foo/bar" or "foo%2Fbar" if url-escaped
-//
-func FetchChartDetailFromTarball(reader io.Reader, name string) (map[string]string, error) {
-	// We read the whole chart into memory, this should be okay since the chart
-	// tarball needs to be small enough to fit into a GRPC call
-	gzf, err := gzip.NewReader(reader)
-	if err != nil {
-		return nil, err
-	}
-	defer gzf.Close()
-
-	tarf := tar.NewReader(gzf)
-
 	// decode escaped characters
 	// ie., "foo%2Fbar" should return "foo/bar"
 	decodedName, err := url.PathUnescape(name)
@@ -70,21 +51,46 @@ func FetchChartDetailFromTarball(reader io.Reader, name string) (map[string]stri
 	// get last part of the name
 	// ie., "foo/bar" should return "bar"
 	fixedName := path.Base(decodedName)
-	readmeFileName := fixedName + "/README.md"
-	valuesFileName := fixedName + "/values.yaml"
-	schemaFileName := fixedName + "/values.schema.json"
-	chartYamlFileName := fixedName + "/Chart.yaml"
+
+	return FetchChartDetailFromTarball(reader, fixedName)
+}
+
+//
+// Fetches helm chart details from a gzipped tarball
+//
+// name is expected in format "foo/bar" or "foo%2Fbar" if url-escaped
+//
+func FetchChartDetailFromTarball(reader io.Reader, tarballRootDir string) (map[string]string, error) {
+	// We read the whole chart into memory, this should be okay since the chart
+	// tarball needs to be small enough to fit into a GRPC call
+	gzf, err := gzip.NewReader(reader)
+	if err != nil {
+		return nil, err
+	}
+	defer gzf.Close()
+
+	tarf := tar.NewReader(gzf)
+
+	prefix := ""
+	if tarballRootDir != "" {
+		prefix = tarballRootDir + "/"
+	}
+
+	readmeFileName := prefix + "README.md"
+	valuesFileName := prefix + "values.yaml"
+	schemaFileName := prefix + "values.schema.json"
+	chartYamlFileName := prefix + "Chart.yaml"
 	filenames := map[string]string{
-		chart.ValuesKey:    valuesFileName,
-		chart.ReadmeKey:    readmeFileName,
-		chart.SchemaKey:    schemaFileName,
-		chart.ChartYamlKey: chartYamlFileName,
+		chart.DefaultValuesKey: valuesFileName,
+		chart.ReadmeKey:        readmeFileName,
+		chart.SchemaKey:        schemaFileName,
+		chart.ChartYamlKey:     chartYamlFileName,
 	}
 
 	// Optionally search for files matching a regular expression, using the
 	// template to provide the key.
 	regexes := map[string]*regexp.Regexp{
-		chart.ValuesKey + "-$valuesType": regexp.MustCompile(fixedName + `/values-(?P<valuesType>\w+)\.yaml`),
+		chart.DefaultValuesKey + "-$valuesType": regexp.MustCompile(prefix + `values-(?P<valuesType>\w+)\.yaml`),
 	}
 
 	return ExtractFilesFromTarball(filenames, regexes, tarf)

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -8,10 +8,10 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
+	"path"
 	"regexp"
 	"strings"
 
-	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/pkgutils"
 	chart "github.com/vmware-tanzu/kubeapps/pkg/chart/models"
 	httpclient "github.com/vmware-tanzu/kubeapps/pkg/http-client"
 )
@@ -38,18 +38,13 @@ func FetchChartDetailFromTarballUrl(name string, chartTarballURL string, userAge
 		return nil, err
 	}
 
-	_, fixedName, err := pkgutils.SplitPackageIdentifier(name)
-	if err != nil {
-		return nil, err
-	}
-
-	return FetchChartDetailFromTarball(reader, fixedName)
+	return FetchChartDetailFromTarball(reader)
 }
 
 // Fetches helm chart details from a gzipped tarball
 //
 // name is expected in format "foo/bar" or "foo%2Fbar" if url-escaped
-func FetchChartDetailFromTarball(reader io.Reader, tarballRootDir string) (map[string]string, error) {
+func FetchChartDetailFromTarball(reader io.Reader) (map[string]string, error) {
 	// We read the whole chart into memory, this should be okay since the chart
 	// tarball needs to be small enough to fit into a GRPC call
 	gzf, err := gzip.NewReader(reader)
@@ -60,26 +55,17 @@ func FetchChartDetailFromTarball(reader io.Reader, tarballRootDir string) (map[s
 
 	tarf := tar.NewReader(gzf)
 
-	prefix := ""
-	if tarballRootDir != "" {
-		prefix = tarballRootDir + "/"
-	}
-
-	readmeFileName := prefix + "README.md"
-	valuesFileName := prefix + "values.yaml"
-	schemaFileName := prefix + "values.schema.json"
-	chartYamlFileName := prefix + "Chart.yaml"
 	filenames := map[string]string{
-		chart.DefaultValuesKey: valuesFileName,
-		chart.ReadmeKey:        readmeFileName,
-		chart.SchemaKey:        schemaFileName,
-		chart.ChartYamlKey:     chartYamlFileName,
+		chart.DefaultValuesKey: "values.yaml",
+		chart.ReadmeKey:        "README.md",
+		chart.SchemaKey:        "values.schema.json",
+		chart.ChartYamlKey:     "Chart.yaml",
 	}
 
 	// Optionally search for files matching a regular expression, using the
 	// template to provide the key.
 	regexes := map[string]*regexp.Regexp{
-		chart.DefaultValuesKey + "-$valuesType": regexp.MustCompile(prefix + `values-(?P<valuesType>\w+)\.yaml`),
+		chart.DefaultValuesKey + "-$valuesType": regexp.MustCompile(`values-(?P<valuesType>\w+)\.yaml`),
 	}
 
 	return ExtractFilesFromTarball(filenames, regexes, tarf)
@@ -102,33 +88,50 @@ func ExtractFilesFromTarball(filenames map[string]string, regexes map[string]*re
 			return ret, err
 		}
 
-		foundFile := false
-		for id, f := range filenames {
-			if strings.EqualFold(header.Name, f) {
-				if s, err := readTarFileContent(tarf); err != nil {
-					return ret, err
-				} else {
-					ret[id] = s
-				}
-				foundFile = true
-				break
-			}
-		}
-		if foundFile {
+		compressedFileName := header.Name
+		if len(strings.Split(compressedFileName, "/")) > 2 {
+			// We are only interested on files directly under the named directory
 			continue
 		}
 
-		for template, pattern := range regexes {
-			match := pattern.FindSubmatchIndex([]byte(header.Name))
-			if match != nil {
-				result := []byte{}
-				result = pattern.ExpandString(result, template, header.Name, match)
-				if s, err := readTarFileContent(tarf); err != nil {
-					return ret, err
-				} else {
-					ret[string(result)] = s
+		switch header.Typeflag {
+		case tar.TypeDir:
+			// Ignore directories
+		case tar.TypeReg:
+			foundFile := false
+			for id, f := range filenames {
+				if strings.EqualFold(path.Base(header.Name), path.Base(f)) {
+					// If the expected directory is set, we use it in the comparison.
+					if path.Dir(f) != "." && (path.Dir(f) != path.Dir(header.Name)) {
+						continue
+					}
+					if s, err := readTarFileContent(tarf); err != nil {
+						return ret, err
+					} else {
+						ret[id] = s
+					}
+					foundFile = true
+					break
 				}
 			}
+			if foundFile {
+				continue
+			}
+
+			for template, pattern := range regexes {
+				match := pattern.FindSubmatchIndex([]byte(header.Name))
+				if match != nil {
+					result := []byte{}
+					result = pattern.ExpandString(result, template, header.Name, match)
+					if s, err := readTarFileContent(tarf); err != nil {
+						return ret, err
+					} else {
+						ret[string(result)] = s
+					}
+				}
+			}
+		default:
+			// Unknown type, ignore
 		}
 	}
 	return ret, nil

--- a/pkg/tarutil/tarutil_test.go
+++ b/pkg/tarutil/tarutil_test.go
@@ -24,10 +24,42 @@ func Test_extractFilesFromTarball(t *testing.T) {
 		filename string
 		want     string
 	}{
-		{"file", []test.TarballFile{{Name: "file.txt", Body: "best file ever"}}, "file.txt", "best file ever"},
-		{"multiple file tarball", []test.TarballFile{{Name: "file.txt", Body: "best file ever"}, {Name: "file2.txt", Body: "worst file ever"}}, "file2.txt", "worst file ever"},
-		{"file in dir", []test.TarballFile{{Name: "file.txt", Body: "best file ever"}, {Name: "test/file2.txt", Body: "worst file ever"}}, "test/file2.txt", "worst file ever"},
-		{"filename ignore case", []test.TarballFile{{Name: "Readme.md", Body: "# readme for chart"}, {Name: "values.yaml", Body: "key: value"}}, "README.md", "# readme for chart"},
+		{
+			name:     "file",
+			files:    []test.TarballFile{{Name: "file.txt", Body: "best file ever"}},
+			filename: "file.txt",
+			want:     "best file ever",
+		},
+		{
+			name:     "multiple file tarball",
+			files:    []test.TarballFile{{Name: "file.txt", Body: "best file ever"}, {Name: "file2.txt", Body: "worst file ever"}},
+			filename: "file2.txt",
+			want:     "worst file ever",
+		},
+		{
+			name:     "file in dir with parent dir specified",
+			files:    []test.TarballFile{{Name: "file.txt", Body: "best file ever"}, {Name: "test/file2.txt", Body: "worst file ever"}},
+			filename: "test/file2.txt",
+			want:     "worst file ever",
+		},
+		{
+			name:     "file in dir without parent dir specified",
+			files:    []test.TarballFile{{Name: "file.txt", Body: "best file ever"}, {Name: "test/file2.txt", Body: "worst file ever"}},
+			filename: "file2.txt",
+			want:     "worst file ever",
+		},
+		{
+			name:     "filename ignore case",
+			files:    []test.TarballFile{{Name: "Readme.md", Body: "# readme for chart"}, {Name: "values.yaml", Body: "key: value"}},
+			filename: "README.md",
+			want:     "# readme for chart",
+		},
+		{
+			name:     "different paths to same base filename",
+			files:    []test.TarballFile{{Name: "test/readme.md", Body: "# readme for chart"}},
+			filename: "other/readme.md",
+			want:     "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -38,7 +70,7 @@ func Test_extractFilesFromTarball(t *testing.T) {
 			tarf := tar.NewReader(r)
 			files, err := ExtractFilesFromTarball(map[string]string{tt.filename: tt.filename}, map[string]*regexp.Regexp{}, tarf)
 			assert.NoError(t, err)
-			assert.Equal(t, files[tt.filename], tt.want, "file body")
+			assert.Equal(t, tt.want, files[tt.filename], "file body")
 		})
 	}
 
@@ -189,10 +221,10 @@ func Test_FetchChartDetailFromTarball(t *testing.T) {
 
 			r := bytes.NewReader(b.Bytes())
 
-			files, err := FetchChartDetailFromTarball(r, pkgName)
+			files, err := FetchChartDetailFromTarball(r)
 
 			assert.NoError(t, err)
-			assert.Equal(t, files, tt.want)
+			assert.Equal(t, tt.want, files)
 		})
 	}
 }

--- a/pkg/tarutil/tarutil_test.go
+++ b/pkg/tarutil/tarutil_test.go
@@ -145,7 +145,7 @@ func Test_FetchChartDetailFromTarball(t *testing.T) {
 				{Name: path.Join(pkgName, "values.yaml"), Body: "foo: bar"},
 			},
 			want: map[string]string{
-				chart.ValuesKey: "foo: bar",
+				chart.DefaultValuesKey: "foo: bar",
 			},
 		},
 		{
@@ -157,14 +157,14 @@ func Test_FetchChartDetailFromTarball(t *testing.T) {
 				{Name: path.Join(pkgName, "Chart.yaml"), Body: "Name: wordpress"},
 			},
 			want: map[string]string{
-				chart.ChartYamlKey: "Name: wordpress",
-				chart.ReadmeKey:    "readme text",
-				chart.SchemaKey:    "{}",
-				chart.ValuesKey:    "foo: bar",
+				chart.ChartYamlKey:     "Name: wordpress",
+				chart.ReadmeKey:        "readme text",
+				chart.SchemaKey:        "{}",
+				chart.DefaultValuesKey: "foo: bar",
 			},
 		},
 		{
-			name: "package with custom default values",
+			name: "package with additional default values",
 			pkg: []test.TarballFile{
 				{Name: path.Join(pkgName, "values.yaml"), Body: "foo: bar"},
 				{Name: path.Join(pkgName, "README.md"), Body: "readme text"},
@@ -173,11 +173,11 @@ func Test_FetchChartDetailFromTarball(t *testing.T) {
 				{Name: path.Join(pkgName, "values-production.yaml"), Body: "foo: prod-bar"},
 			},
 			want: map[string]string{
-				chart.ChartYamlKey:  "Name: wordpress",
-				chart.ReadmeKey:     "readme text",
-				chart.SchemaKey:     "{}",
-				chart.ValuesKey:     "foo: bar",
-				"values-production": "foo: prod-bar",
+				chart.ChartYamlKey:     "Name: wordpress",
+				chart.ReadmeKey:        "readme text",
+				chart.SchemaKey:        "{}",
+				chart.DefaultValuesKey: "foo: bar",
+				"values-production":    "foo: prod-bar",
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

While working on the next part of #5692 and noticed that the OCI code seemed to be repeating similar functionality that exists already in a re-usable lib. This PR just updates to use the existing code, which required a little refactoring as OCI tarballs don't have a root directory like the chart ones do.

### Benefits

<!-- What benefits will be realized by the code change? -->

Less code.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #5692 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
