### PR TITLE
Use existing secret for OAUTH2_PROXY_CLIENT_ID, OAUTH2_PROXY_CLIENT_SECRET and OAUTH2_PROXY_COOKIE_SECRET variables

### DIFF
--- a/chart/kubeapps/templates/frontend/deployment.yaml
+++ b/chart/kubeapps/templates/frontend/deployment.yaml
@@ -185,6 +185,7 @@ spec:
             {{- end }}
           {{- end }}
           env:
+            {{- if not .Values.authProxy.existingSecret.enabled }}
             - name: OAUTH2_PROXY_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -200,6 +201,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "kubeapps.oauth2_proxy-secret.name" . }}
                   key: cookieSecret
+            {{- end }}
             {{- if .Values.authProxy.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.authProxy.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
@@ -211,6 +213,10 @@ spec:
             {{- if .Values.authProxy.extraEnvVarsSecret }}
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.authProxy.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+            {{- if .Values.authProxy.existingSecret.enabled }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.authProxy.existingSecret.name "context" $) }}
             {{- end }}
           ports:
             - name: proxy

--- a/chart/kubeapps/templates/frontend/oauth2-secret.yaml
+++ b/chart/kubeapps/templates/frontend/oauth2-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.authProxy.enabled (not .Values.authProxy.external) }}
+{{- if and .Values.authProxy.enabled (not .Values.authProxy.external) (not .Values.authProxy.existingSecret.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1186,6 +1186,11 @@ authProxy:
   ## @param authProxy.cookieRefresh Duration after which to refresh the cookie
   ##
   cookieRefresh: 2m
+  ## @param authProxy.existingSecret Secret used by oauth2-proxy to get clientID, clientSecret and cookieSecret parameters from existing secret
+  ##
+  existingSecret:
+    enabled: false
+    name: ""
   ## @param authProxy.scope OAuth scope specification
   ##
   scope: "openid email groups"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This change introduce possibility to use existing secret where you can put `OAUTH2_PROXY_CLIENT_ID`, `OAUTH2_PROXY_CLIENT_SECRET` and `OAUTH2_PROXY_COOKIE_SECRET` variables.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

`OAUTH2_PROXY_CLIENT_SECRET` value is something that should not be push to git repo as plaintext so it is better to use some existing secret where this value is provided.
You can also use some secret operator like `external-secrets` to fetch those values from some secure secret store.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

N/A
<!-- Describe any known limitations with your change -->

### Applicable issues

N/A
<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

I tested this change on my local k8s cluster without any issues.
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
