### PR TITLE
Default to a custom default values if exactly one provided.

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -7,6 +7,7 @@ ignore: |
   #  Ignore folders
   **/chart/kubeapps/
   **/integration/charts/simplechart/
+  **/integration/charts/simplechart-customvalues/
   **/dashboard/node_modules/
   **/devel/
   #  Ignore files

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -21,7 +21,7 @@ import * as ReactRouter from "react-router";
 import { MemoryRouter, Route, Router } from "react-router-dom";
 import { Kube } from "shared/Kube";
 import { getStore, mountWrapper } from "shared/specs/mountWrapper";
-import { FetchError, IStoreState, IPackageState, PluginNames } from "shared/types";
+import { FetchError, IStoreState, PluginNames } from "shared/types";
 import DeploymentForm from "./DeploymentForm";
 import DeploymentFormBody from "./DeploymentFormBody";
 
@@ -47,7 +47,7 @@ const defaultSelectedPkg = {
     defaultValues: "package: defaults",
   } as AvailablePackageDetail,
   pkgVersion: "1.2.4",
-  values: "not: used",
+  values: "package: defaults",
 };
 
 const routePathParam = `/c/${defaultProps.cluster}/ns/${defaultProps.namespace}/apps/new/${defaultProps.plugin.name}/${defaultProps.plugin.version}/${defaultProps.packageCluster}/${defaultProps.packageNamespace}/${defaultProps.pkgName}/versions/${defaultProps.version}`;
@@ -130,7 +130,7 @@ it("fetches the available versions", () => {
 });
 
 describe("default values", () => {
-  it("uses the available package detail default values", () => {
+  it("uses the selected package default values", () => {
     const wrapper = mountWrapper(
       getStore({ packages: { selected: defaultSelectedPkg } } as IStoreState),
       <Router history={history}>
@@ -141,31 +141,6 @@ describe("default values", () => {
     );
 
     expect(wrapper.find(DeploymentFormBody).prop("appValues")).toBe("package: defaults");
-  });
-
-  it("uses a custom default values file if there is only one", () => {
-    const wrapper = mountWrapper(
-      getStore({
-        packages: {
-          selected: {
-            ...defaultSelectedPkg,
-            availablePackageDetail: {
-              ...defaultSelectedPkg.availablePackageDetail,
-              additionalDefaultValues: {
-                "values-custom": "custom: defaults",
-              },
-            },
-          },
-        } as Partial<IPackageState>,
-      } as Partial<IStoreState>),
-      <Router history={history}>
-        <Route path={routePath}>
-          <DeploymentForm />
-        </Route>
-      </Router>,
-    );
-
-    expect(wrapper.find(DeploymentFormBody).prop("appValues")).toBe("custom: defaults");
   });
 });
 

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -14,7 +14,6 @@ import LoadingWrapper from "components/LoadingWrapper";
 import PackageHeader from "components/PackageHeader/PackageHeader";
 import { push } from "connected-react-router";
 import {
-  AvailablePackageDetail,
   AvailablePackageReference,
   ReconciliationOptions,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
@@ -40,14 +39,6 @@ interface IRouteParams {
   packageVersion?: string;
 }
 
-function defaultValues(pkg: AvailablePackageDetail) {
-  const additionalValues = Object.values(pkg.additionalDefaultValues || []);
-  if (additionalValues.length === 1) {
-    return additionalValues[0];
-  }
-  return pkg.defaultValues || "";
-}
-
 export default function DeploymentForm() {
   const dispatch: ThunkDispatch<IStoreState, null, Action> = useDispatch();
   const {
@@ -67,9 +58,7 @@ export default function DeploymentForm() {
 
   const [isDeploying, setDeploying] = useState(false);
   const [releaseName, setReleaseName] = useState("");
-  const [appValues, setAppValues] = useState(
-    defaultValues(selectedPackage.availablePackageDetail || ({} as AvailablePackageDetail)),
-  );
+  const [appValues, setAppValues] = useState(selectedPackage.values || "");
   const [valuesModified, setValuesModified] = useState(false);
   const [serviceAccountList, setServiceAccountList] = useState([] as string[]);
   const [reconciliationOptions, setReconciliationOptions] = useState({} as ReconciliationOptions);
@@ -123,12 +112,10 @@ export default function DeploymentForm() {
 
   useEffect(() => {
     if (!valuesModified) {
-      setAppValues(
-        defaultValues(selectedPackage.availablePackageDetail || ({} as AvailablePackageDetail)),
-      );
+      setAppValues(selectedPackage.values || "");
     }
     return () => {};
-  }, [selectedPackage.availablePackageDetail?.defaultValues, valuesModified]);
+  }, [selectedPackage.values, valuesModified]);
 
   const handleValuesChange = (value: string) => {
     setAppValues(value);

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -45,7 +45,7 @@ function defaultValues(pkg: AvailablePackageDetail) {
   if (additionalValues.length === 1) {
     return additionalValues[0];
   }
-  return pkg.defaultValues || ""
+  return pkg.defaultValues || "";
 }
 
 export default function DeploymentForm() {
@@ -67,7 +67,9 @@ export default function DeploymentForm() {
 
   const [isDeploying, setDeploying] = useState(false);
   const [releaseName, setReleaseName] = useState("");
-  const [appValues, setAppValues] = useState(defaultValues(selectedPackage.availablePackageDetail || {} as AvailablePackageDetail));
+  const [appValues, setAppValues] = useState(
+    defaultValues(selectedPackage.availablePackageDetail || ({} as AvailablePackageDetail)),
+  );
   const [valuesModified, setValuesModified] = useState(false);
   const [serviceAccountList, setServiceAccountList] = useState([] as string[]);
   const [reconciliationOptions, setReconciliationOptions] = useState({} as ReconciliationOptions);
@@ -103,7 +105,7 @@ export default function DeploymentForm() {
     );
     // Populate the rest of packages versions
     dispatch(actions.availablepackages.fetchAvailablePackageVersions(packageReference));
-    return () => { };
+    return () => {};
   }, [dispatch, packageReference, packageVersion]);
 
   useEffect(() => {
@@ -116,14 +118,16 @@ export default function DeploymentForm() {
           dispatch(handleErrorAction(e));
         });
     }
-    return () => { };
+    return () => {};
   }, [dispatch, targetCluster, targetNamespace, pluginObj.name]);
 
   useEffect(() => {
     if (!valuesModified) {
-      setAppValues(defaultValues(selectedPackage.availablePackageDetail || {} as AvailablePackageDetail));
+      setAppValues(
+        defaultValues(selectedPackage.availablePackageDetail || ({} as AvailablePackageDetail)),
+      );
     }
-    return () => { };
+    return () => {};
   }, [selectedPackage.availablePackageDetail?.defaultValues, valuesModified]);
 
   const handleValuesChange = (value: string) => {

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -14,6 +14,7 @@ import LoadingWrapper from "components/LoadingWrapper";
 import PackageHeader from "components/PackageHeader/PackageHeader";
 import { push } from "connected-react-router";
 import {
+  AvailablePackageDetail,
   AvailablePackageReference,
   ReconciliationOptions,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
@@ -39,6 +40,14 @@ interface IRouteParams {
   packageVersion?: string;
 }
 
+function defaultValues(pkg: AvailablePackageDetail) {
+  const additionalValues = Object.values(pkg.additionalDefaultValues || []);
+  if (additionalValues.length === 1) {
+    return additionalValues[0];
+  }
+  return pkg.defaultValues || ""
+}
+
 export default function DeploymentForm() {
   const dispatch: ThunkDispatch<IStoreState, null, Action> = useDispatch();
   const {
@@ -58,7 +67,7 @@ export default function DeploymentForm() {
 
   const [isDeploying, setDeploying] = useState(false);
   const [releaseName, setReleaseName] = useState("");
-  const [appValues, setAppValues] = useState(selectedPackage.values || "");
+  const [appValues, setAppValues] = useState(defaultValues(selectedPackage.availablePackageDetail || {} as AvailablePackageDetail));
   const [valuesModified, setValuesModified] = useState(false);
   const [serviceAccountList, setServiceAccountList] = useState([] as string[]);
   const [reconciliationOptions, setReconciliationOptions] = useState({} as ReconciliationOptions);
@@ -94,7 +103,7 @@ export default function DeploymentForm() {
     );
     // Populate the rest of packages versions
     dispatch(actions.availablepackages.fetchAvailablePackageVersions(packageReference));
-    return () => {};
+    return () => { };
   }, [dispatch, packageReference, packageVersion]);
 
   useEffect(() => {
@@ -107,15 +116,15 @@ export default function DeploymentForm() {
           dispatch(handleErrorAction(e));
         });
     }
-    return () => {};
+    return () => { };
   }, [dispatch, targetCluster, targetNamespace, pluginObj.name]);
 
   useEffect(() => {
     if (!valuesModified) {
-      setAppValues(selectedPackage.values || "");
+      setAppValues(defaultValues(selectedPackage.availablePackageDetail || {} as AvailablePackageDetail));
     }
-    return () => {};
-  }, [selectedPackage.values, valuesModified]);
+    return () => { };
+  }, [selectedPackage.availablePackageDetail?.defaultValues, valuesModified]);
 
   const handleValuesChange = (value: string) => {
     setAppValues(value);

--- a/dashboard/src/reducers/availablepackages.test.ts
+++ b/dashboard/src/reducers/availablepackages.test.ts
@@ -1,7 +1,11 @@
 // Copyright 2021-2022 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AvailablePackageSummary, Context } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
+import {
+  AvailablePackageDetail,
+  AvailablePackageSummary,
+  Context,
+} from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
 import { getType } from "typesafe-actions";
 import actions from "../actions";
@@ -496,6 +500,58 @@ describe("packageReducer", () => {
     });
     expect(state).toEqual({
       ...initialState,
+    });
+  });
+
+  describe("receiveSelectedAvailablePackageDetail", () => {
+    const packageDetail = {
+      name: "test-package",
+      defaultValues: "default: values",
+      valuesSchema: "",
+    } as AvailablePackageDetail;
+
+    it("uses the package default values by default", () => {
+      const state = packageReducer(initialState, {
+        type: getType(actions.availablepackages.receiveSelectedAvailablePackageDetail) as any,
+        payload: {
+          selectedPackage: packageDetail,
+        },
+      });
+
+      expect(state.selected.values).toEqual("default: values");
+    });
+
+    it("uses the package custom default values if only one custom default values", () => {
+      const state = packageReducer(initialState, {
+        type: getType(actions.availablepackages.receiveSelectedAvailablePackageDetail) as any,
+        payload: {
+          selectedPackage: {
+            ...packageDetail,
+            additionalDefaultValues: {
+              "values-custom": "custom: values",
+            },
+          } as AvailablePackageDetail,
+        },
+      });
+
+      expect(state.selected.values).toEqual("custom: values");
+    });
+
+    it("uses the package default values if more than one custom default values present", () => {
+      const state = packageReducer(initialState, {
+        type: getType(actions.availablepackages.receiveSelectedAvailablePackageDetail) as any,
+        payload: {
+          selectedPackage: {
+            ...packageDetail,
+            additionalDefaultValues: {
+              "values-custom": "custom: values",
+              "values-other": "more: customdefaultvalues",
+            },
+          } as AvailablePackageDetail,
+        },
+      });
+
+      expect(state.selected.values).toEqual("default: values");
     });
   });
 });

--- a/dashboard/src/reducers/availablepackages.ts
+++ b/dashboard/src/reducers/availablepackages.ts
@@ -8,6 +8,7 @@ import { getType } from "typesafe-actions";
 import actions from "../actions";
 import { PackagesAction } from "../actions/availablepackages";
 import { NamespaceAction } from "../actions/namespace";
+import { AvailablePackageDetail } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 
 export const initialState: IPackageState = {
   isFetching: false,
@@ -20,6 +21,16 @@ export const initialState: IPackageState = {
   },
   size: 20,
 };
+
+// defaultValues determines whether the package defaults or custom default
+// values should be used.
+function defaultValues(pkg: AvailablePackageDetail) {
+  const additionalValues = Object.values(pkg.additionalDefaultValues || []);
+  if (additionalValues.length === 1) {
+    return additionalValues[0];
+  }
+  return pkg.defaultValues || "";
+}
 
 const selectedPackageReducer = (
   state: IPackageState["selected"],
@@ -35,7 +46,7 @@ const selectedPackageReducer = (
         pkgVersion: action.payload.selectedPackage.version?.pkgVersion,
         appVersion: action.payload.selectedPackage.version?.appVersion,
         readme: action.payload.selectedPackage.readme,
-        values: action.payload.selectedPackage.defaultValues,
+        values: defaultValues(action.payload.selectedPackage),
         schema:
           action.payload.selectedPackage.valuesSchema !== ""
             ? (JSON.parse(action.payload.selectedPackage.valuesSchema) as JSONSchemaType<any>)

--- a/integration/charts/simplechart-customvalues/.helmignore
+++ b/integration/charts/simplechart-customvalues/.helmignore
@@ -1,0 +1,26 @@
+# Copyright 2022 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/integration/charts/simplechart-customvalues/Chart.yaml
+++ b/integration/charts/simplechart-customvalues/Chart.yaml
@@ -1,0 +1,9 @@
+# Copyright 2022 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: simplechart-customvalues
+description: A simple chart for testing custom values
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/integration/charts/simplechart-customvalues/templates/_helpers.tpl
+++ b/integration/charts/simplechart-customvalues/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/* Copyright 2022 the Kubeapps contributors. */}}
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "simplechart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "simplechart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "simplechart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "simplechart.labels" -}}
+helm.sh/chart: {{ include "simplechart.chart" . }}
+{{ include "simplechart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "simplechart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "simplechart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "simplechart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "simplechart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/integration/charts/simplechart-customvalues/templates/deployment.yaml
+++ b/integration/charts/simplechart-customvalues/templates/deployment.yaml
@@ -1,0 +1,40 @@
+# Copyright 2022 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "simplechart.fullname" . }}
+  labels:
+    {{- include "simplechart.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "simplechart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "simplechart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "simplechart.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http

--- a/integration/charts/simplechart-customvalues/templates/service.yaml
+++ b/integration/charts/simplechart-customvalues/templates/service.yaml
@@ -1,0 +1,18 @@
+# Copyright 2022 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "simplechart.fullname" . }}
+  labels:
+    {{- include "simplechart.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "simplechart.selectorLabels" . | nindent 4 }}

--- a/integration/charts/simplechart-customvalues/templates/tests/test-connection.yaml
+++ b/integration/charts/simplechart-customvalues/templates/tests/test-connection.yaml
@@ -1,0 +1,14 @@
+# Copyright 2022 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "simplechart.fullname" . }}-test-connection"
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "simplechart.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/integration/charts/simplechart-customvalues/values-custom.yaml
+++ b/integration/charts/simplechart-customvalues/values-custom.yaml
@@ -1,0 +1,7 @@
+# Copyright 2022 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+image:
+  repository: bitnami/nginx
+  tag: "1.23.3-debian-11"
+  pullPolicy: IfNotPresent

--- a/integration/charts/simplechart-customvalues/values.yaml
+++ b/integration/charts/simplechart-customvalues/values.yaml
@@ -1,0 +1,19 @@
+# Copyright 2022 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+image:
+  repository: bitnami/nginx
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: false
+  name: "default"
+
+service:
+  type: ClusterIP
+  port: 80

--- a/script/chart-museum.sh
+++ b/script/chart-museum.sh
@@ -104,7 +104,7 @@ installChartMuseum() {
     --set persistence.enabled=true \
     --set env.secret.BASIC_AUTH_USER=$CHARTMUSEUM_USER \
     --set env.secret.BASIC_AUTH_PASS=$CHARTMUSEUM_PWD
-  info "Waiting for ChartMuseum to be ready..."
+  echo "Waiting for ChartMuseum to be ready..."
   kubectl rollout status -w deployment/chartmuseum --namespace="${CHARTMUSEUM_NS}"
 
   echo "Installing Ingress for ChartMuseum with access through host ${CHARTMUSEUM_HOSTNAME}"


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This change uses the new support for custom default values files so that:
- if a single custom default values file is found in the chart, it is presented to the user so that authors can control the default values presented to users.

Note that, since it is just an overlay over the charts `values.yaml`, it can be used both to present a simpler selection of options to users, or to present a different set of default values.

### Benefits

<!-- What benefits will be realized by the code change? -->

Fulfills use-case 1 of #5692 .

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #5692 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
Using the [custom default values in the simplechart](https://github.com/vmware-tanzu/kubeapps/blob/5692-dashboard/integration/charts/simplechart-customvalues/values-custom.yaml), before the user makes any changes, they are presented with those values (only):

![5692-simplechart-no-changes](https://user-images.githubusercontent.com/497518/211962126-9e6335fd-8d55-4416-9878-445f80161bf4.png)

Any changes made are diffed against the custom default:
![5692-simplechart-smallchange](https://user-images.githubusercontent.com/497518/211962180-ceed059f-86cc-45fc-bd2e-4a7ed30cfaaf.png)
