### PR TITLE
Add more explicit error logging when fetching detail.

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -318,6 +318,7 @@ func (s *Server) GetAvailablePackageDetail(ctx context.Context, request *corev1.
 		chart, err = s.manager.GetChartVersion(namespace, unescapedChartID, version)
 	}
 	if err != nil {
+		log.Errorf("Failed to request chart '%s' in ns '%s': %v", unescapedChartID, namespace, err)
 		return nil, status.Errorf(codes.Internal, "Unable to retrieve chart: %v", err)
 	}
 


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
A user is getting an error in the UX showing "Unable to retrieve chart: sql: no rows in result set" but no corresponding error in the backend. Checking, I found that we don't actually log the error, other than the request log showing the internal error without details:

```
I0119 19:05:27.529184       1 server.go:314] Requesting chart 'repo/kubeapps%2Fnginx' (latest version) in ns 'default'
I0119 19:05:27.530935       1 server.go:375] Requesting chart 'repo/kubeapps%2Fnginx' (latest version) in ns 'default'
I0119 19:05:27.535286       1 server.go:62] Internal 88.857512ms /kubeappsapis.core.packages.v1alpha1.PackagesService/GetAvailablePackageDetail
I0119 19:05:27.536622       1 server.go:62] Internal 90.361477ms /kubeappsapis.core.packages.v1alpha1.PackagesService/GetAvailablePackageVersions

```
With this change we'll have details about the actual error in the backend logs.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
