### PR TITLE
Ensure user client with service account backup when fetching namespaces.

### DIFF
--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -196,8 +196,6 @@ func newClientGetter(configGetter core.KubernetesConfigGetter, useServiceAccount
 	return clientProvider, nil
 }
 
-// Why does this function even exist? It appears to do nothing if
-// useServiceAccount is false - so why call it.
 func setupRestConfigForCluster(restConfig *rest.Config, cluster string, clustersConfig kube.ClustersConfig) error {
 	// Override client config with the service token for additional cluster
 	// Added from #5034 after deprecation of "kubeops"

--- a/pkg/kube/cluster_config.go
+++ b/pkg/kube/cluster_config.go
@@ -7,10 +7,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"k8s.io/client-go/rest"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -85,8 +86,8 @@ type ClustersConfig struct {
 	Clusters                 map[string]ClusterConfig
 }
 
-// NewClusterConfig returns a copy of an in-cluster config with a user token (leave blank for
-// when configuring a service account). and/or custom cluster host
+// NewClusterConfig returns a copy of an in-cluster config with a user token
+// and/or custom cluster host
 func NewClusterConfig(inClusterConfig *rest.Config, userToken string, cluster string, clustersConfig ClustersConfig) (*rest.Config, error) {
 	config := rest.CopyConfig(inClusterConfig)
 	config.BearerToken = userToken

--- a/site/content/docs/latest/reference/manifests/kubeapps-local-dev-users-rbac.yaml
+++ b/site/content/docs/latest/reference/manifests/kubeapps-local-dev-users-rbac.yaml
@@ -51,6 +51,13 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: oidc:kubeapps-users
+  # pinniped doesn't use a prefix, unlike the cluster oidc config:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: kubeapps-user@example.com
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: kubeapps-users
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -68,6 +75,13 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: oidc:kubeapps-users
+  # pinniped doesn't use a prefix, unlike the cluster oidc config:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: kubeapps-user@example.com
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: kubeapps-users
 ---
 # Currently unnecessary (when kubeapps operators are already cluster-admin) but
 # included to be explicit and plan to replace cluster-admin for kubeapps


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

The main change here is to ensure that the request for namespaces uses the *user* client first, then the service account client. For a detailed analysis of the issue it is fixing, see my [comment on 5755](https://github.com/vmware-tanzu/kubeapps/issues/5755#issuecomment-1406172791)

While there, I have tried to clarify the code a little, so that it is clearer when the user client is being used (it now matches the comments again).

I also fixed an RBAC issue in the dev environment (so that `kubeapps-user@example.com` is permitted to access, in addition to `oidc:kubeapps-user@example.com`, since the former is what pinniped uses).

### Benefits

<!-- What benefits will be realized by the code change? -->
Back to expected behavior when authenticated as a non-privileged user with or without a service account token configured in Kubeapps' clusters configuration.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #5755 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

I've tested this pretty thoroughly locally with multiple clusters using both unprivileged and privileged users (with additional log lines showing exactly what token is being used when), but only in the namespaces call-site.
