### PR TITLE
Leave slash in chart name encoded. Fixes #5897

### DIFF
--- a/cmd/asset-syncer/server/utils.go
+++ b/cmd/asset-syncer/server/utils.go
@@ -197,6 +197,13 @@ func unescapeChartsData(charts []models.Chart) []models.Chart {
 
 // Unescape string or return value itself if error
 func unescapeOrDefaultValue(value string) string {
+	// Ensure any escaped `/` (%2F) in a chart name will remain escaped.
+	// Kubeapps splits the chart ID, such as "repo-name/harbor-project%2Fchart-name", on the slash.
+	// See PR comment at
+	// https://github.com/vmware-tanzu/kubeapps/pull/3863#pullrequestreview-819141298
+	// and instance of the issue cropping up via Harbor at
+	// https://github.com/vmware-tanzu/kubeapps/issues/5897
+	value = strings.Replace(value, "%2F", "%252F", -1)
 	unescapedValue, err := url.PathUnescape(value)
 	if err != nil {
 		return value

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -1376,6 +1376,21 @@ func TestUnescapeChartsData(t *testing.T) {
 				{Name: "foo#bar.bar"},
 			},
 		},
+		{
+			"slashes in the chart name are not unescaped",
+			[]models.Chart{
+				{
+					ID:   "repo-name/project1%2Ffoo%20bar",
+					Name: "project1%2Ffoo%20bar",
+				},
+			},
+			[]models.Chart{
+				{
+					ID:   "repo-name/project1%2Ffoo bar",
+					Name: "project1%2Ffoo bar",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {

--- a/pkg/helm/index.go
+++ b/pkg/helm/index.go
@@ -48,11 +48,9 @@ func newChart(entry repo.ChartVersions, r *models.Repo, shallow bool) models.Cha
 	return c
 }
 
-//
 // ChartsFromIndex receives an array of bytes containing the contents of index.yaml from a helm repo and returns
 // all Chart models from that index. The shallow flag controls whether only the latest version of the charts is returned
 // or all versions
-//
 func ChartsFromIndex(contents []byte, r *models.Repo, shallow bool) ([]models.Chart, error) {
 	var charts []models.Chart
 	index, err := parseRepoIndex(contents)

--- a/pkg/helm/index_test.go
+++ b/pkg/helm/index_test.go
@@ -14,6 +14,9 @@ import (
 var validRepoIndexYAMLBytes, _ = os.ReadFile("testdata/valid-index.yaml")
 var validRepoIndexYAML = string(validRepoIndexYAMLBytes)
 
+var validRepoIndexHarborUnifiedYAMLBytes, _ = os.ReadFile("testdata/valid-index-harbor-unified.yaml")
+var validRepoIndexHarborUnifiedYAML = string(validRepoIndexHarborUnifiedYAMLBytes)
+
 func Test_parseRepoIndex(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -50,6 +53,16 @@ func Test_chartsFromIndex(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(charts), 2, "number of charts")
 	assert.Equal(t, len(charts[1].ChartVersions), 2, "number of versions")
+}
+
+func Test_chartsFromIndexHarborUnified(t *testing.T) {
+	r := &models.Repo{Name: "test", URL: "http://testrepo.com"}
+	charts, err := ChartsFromIndex([]byte(validRepoIndexHarborUnifiedYAML), r, false)
+	assert.NoError(t, err)
+	assert.Equal(t, len(charts), 2, "number of charts")
+
+	assert.Equal(t, charts[0].Name, "project1%2Facs-engine-autoscaler")
+	assert.Equal(t, charts[1].Name, "project2%2Fwordpress")
 }
 
 func Test_shallowChartsFromIndex(t *testing.T) {

--- a/pkg/helm/testdata/valid-index-harbor-unified.yaml
+++ b/pkg/helm/testdata/valid-index-harbor-unified.yaml
@@ -1,0 +1,73 @@
+# Copyright 2021-2022 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+entries:
+  project1/acs-engine-autoscaler:
+    - apiVersion: v1
+      appVersion: 2.1.1
+      created: 2017-12-06T18:48:59.568323124Z
+      description: Scales worker nodes within agent pools
+      digest: 39e66eb53c310529bd9dd19776f8ba662e063a4ebd51fc5ec9f2267e2e073e3e
+      icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
+      maintainers:
+        - email: ritazh@microsoft.com
+          name: ritazh
+        - email: wibuch@microsoft.com
+          name: wbuchwalter
+      name: project1/acs-engine-autoscaler
+      sources:
+        - https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
+      urls:
+        - https://kubernetes-charts.storage.googleapis.com/acs-engine-autoscaler-2.1.1.tgz
+      version: 2.1.1
+  project2/wordpress:
+    - appVersion: 4.9.1
+      created: 2017-12-06T18:48:59.644981487Z
+      description: new description!
+      digest: 74889e60a35dcffa4686f88bb23de863fed2b6e63a69b1f4858dde37c301885c
+      engine: gotpl
+      home: http://www.wordpress.com/
+      icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
+      keywords:
+        - wordpress
+        - cms
+        - blog
+        - http
+        - web
+        - application
+        - php
+      maintainers:
+        - email: containers@bitnami.com
+          name: bitnami-bot
+      name: project2/wordpress
+      sources:
+        - https://github.com/bitnami/bitnami-docker-wordpress
+      urls:
+        - https://kubernetes-charts.storage.googleapis.com/wordpress-0.7.5.tgz
+      version: 0.7.5
+    - appVersion: 4.9.0
+      created: 2017-12-01T11:49:00.136950565Z
+      description: Web publishing platform for building blogs and websites.
+      digest: a69139ef3008eeb11ca60261ec2ded61e84ce7db32bb3626056e84bcff7ec270
+      engine: gotpl
+      home: http://www.wordpress.com/
+      icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
+      keywords:
+        - wordpress
+        - cms
+        - cms
+        - blog
+        - http
+        - web
+        - application
+        - php
+      maintainers:
+        - email: containers@bitnami.com
+          name: bitnami-bot
+      name: wordpress
+      sources:
+        - https://github.com/bitnami/bitnami-docker-wordpress
+      urls:
+        - https://kubernetes-charts.storage.googleapis.com/wordpress-0.7.4.tgz
+      version: 0.7.4


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

In #3863 a change was made to ensure that we unescape spaces in the chart name before syncing data to the database, which unintentionally stopped Kubeapps from being able to retrieve charts that include a slash `/` in the chart name (as is the case when using a unified repository with Harbor). It was [noted on the PR as a possibility](https://github.com/vmware-tanzu/kubeapps/pull/3863#pullrequestreview-819141298), but at the time, we didn't have non-OCI helm chart names with slashes that we were aware of, so we didn't follow it up.

### Benefits

<!-- What benefits will be realized by the code change? -->
A unified Harbor Helm repo can be used with Kubeapps.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
Haven't checked if the chart will display with the escaped slash or not, but still better to be able to display it rather than error.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #5897 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
