### PR TITLE
Support forwarding configurable headers through the gRPC-Web API.

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1561,7 +1561,7 @@ kubeappsapis:
             ## headerPattern: namespace:^([\w-]+):\w+$
             ##
             headerPattern: ""
-          ## @param kubeappsapis.pluginConfig.core.packages.v1alpha1.forwardedHeaders Optional list of headers that should be forwarded from the incoming gRPC-Web request to the k8s API server.
+          ## @param kubeappsapis.pluginConfig.resources.packages.v1alpha1.forwardedHeaders Optional list of headers that should be forwarded from the incoming gRPC-Web request to the k8s API server.
           forwardedHeaders: []
   ## Bitnami Kubeapps-APIs image
   ## ref: https://hub.docker.com/r/bitnami/kubeapps-apis/tags/

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1561,6 +1561,8 @@ kubeappsapis:
             ## headerPattern: namespace:^([\w-]+):\w+$
             ##
             headerPattern: ""
+          ## @param kubeappsapis.pluginConfig.core.packages.v1alpha1.forwardedHeaders Optional list of headers that should be forwarded from the incoming gRPC-Web request to the k8s API server.
+          forwardedHeaders: []
   ## Bitnami Kubeapps-APIs image
   ## ref: https://hub.docker.com/r/bitnami/kubeapps-apis/tags/
   ## @param kubeappsapis.image.registry Kubeapps-APIs image registry

--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins_test.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins_test.go
@@ -436,7 +436,7 @@ func TestCreateConfigGetterWithParams(t *testing.T) {
 		})
 	}
 
-	// allow comparisons of unexported fields on teh headerAdder for this test.
+	// allow comparisons of unexported fields on the headerAdder for this test.
 	allowUnexported := cmp.AllowUnexported(headerAdder{})
 	headerTestCases := []struct {
 		name             string

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/common/plugin.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/common/plugin.go
@@ -11,6 +11,7 @@ import (
 
 type ResourcesPluginConfig struct {
 	TrustedNamespaces TrustedNamespaces
+	ForwardedHeaders  []string
 }
 
 type TrustedNamespaces struct {
@@ -35,6 +36,7 @@ func ParsePluginConfig(pluginConfigPath string) (*ResourcesPluginConfig, error) 
 						HeaderName    string `json:"headerName"`
 						HeaderPattern string `json:"headerPattern"`
 					} `json:"trustedNamespaces"`
+					ForwardedHeaders []string `json:"forwardedHeaders"`
 				} `json:"v1alpha1"`
 			} `json:"packages"`
 		} `json:"resources"`
@@ -57,5 +59,6 @@ func ParsePluginConfig(pluginConfigPath string) (*ResourcesPluginConfig, error) 
 			HeaderName:    config.Resources.Packages.V1alpha1.TrustedNamespaces.HeaderName,
 			HeaderPattern: config.Resources.Packages.V1alpha1.TrustedNamespaces.HeaderPattern,
 		},
+		ForwardedHeaders: config.Resources.Packages.V1alpha1.ForwardedHeaders,
 	}, nil
 }

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/common/plugin_test.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/common/plugin_test.go
@@ -24,7 +24,7 @@ func TestParsePluginConfig(t *testing.T) {
 		{
 			name:           "non existing plugin-config file",
 			pluginYAMLConf: nil,
-			expectedConfig: &ResourcesPluginConfig{},
+			expectedConfig: nil,
 			expectedError:  "",
 		},
 		{
@@ -63,6 +63,7 @@ resources:
 resources:
   packages:
     v1alpha1:
+      forwardedHeaders:
       - X-Consumer-Username
       - X-Consumer-Permissions
 `),
@@ -104,7 +105,7 @@ resources:
 			pluginConfig, err := ParsePluginConfig(filename)
 			if err != nil && !strings.Contains(err.Error(), tc.expectedError) {
 				t.Errorf("err got %q, want to find %q", err.Error(), tc.expectedError)
-			} else if pluginConfig != nil {
+			} else if tc.expectedConfig != nil {
 				if got, want := pluginConfig, tc.expectedConfig; !cmp.Equal(want, got, opts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, opts))
 				}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Adds a plugin config option for the kubeapps API server so that headers in gRPC(-Web) requests are translated into headers on the request from the kubeapps API server to the k8s API server.

### Benefits

<!-- What benefits will be realized by the code change? -->
Enables functionality that used to work before we switched to the gRPC api server (as the dashboard used to talk directly to the k8s cluster, the headers were simply present).

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #5999 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

I've not tested this IRL yet, but feel free to try, otherwise I'll setup an IRL test-scenario tomorrow.
