### PR TITLE
Ensure that clusters' apiServiceURL is honored for kubeapps cluster.

### DIFF
--- a/pkg/kube/cluster_config.go
+++ b/pkg/kube/cluster_config.go
@@ -137,7 +137,10 @@ func NewClusterConfig(inClusterConfig *rest.Config, userToken string, cluster st
 		return config, nil
 	}
 
-	if cluster == clustersConfig.KubeappsClusterName {
+	// We cannot assume that if the cluster is the kubeapps cluster that we simply return
+	// the incluster config, because some users set proxies in front of their clusters in
+	// which case the incluster kubernetes.default will skip the proxy.
+	if cluster == clustersConfig.KubeappsClusterName && clusterConfig.APIServiceURL == "" {
 		return config, nil
 	}
 

--- a/pkg/kube/cluster_config_test.go
+++ b/pkg/kube/cluster_config_test.go
@@ -45,6 +45,39 @@ func TestNewClusterConfig(t *testing.T) {
 			},
 		},
 		{
+			name:      "returns a cluster config with explicit apiServiceURL and cert even for the kubeapps default cluster, when specified",
+			userToken: "token-1",
+			cluster:   "default",
+			clustersConfig: ClustersConfig{
+				KubeappsClusterName: "default",
+				Clusters: map[string]ClusterConfig{
+					"default": {
+						APIServiceURL:                   "https://proxy.example.com:7890",
+						CertificateAuthorityData:        "Y2EtZmlsZS1kYXRhCg==",
+						CertificateAuthorityDataDecoded: "ca-file-data",
+						CAFile:                          "/tmp/ca-file-data",
+					},
+				},
+			},
+			inClusterConfig: &rest.Config{
+				Host:            "https://something-else.example.com:6443",
+				BearerToken:     "something-else",
+				BearerTokenFile: "/foo/bar",
+				TLSClientConfig: rest.TLSClientConfig{
+					CAFile: "/var/run/whatever/ca.crt",
+				},
+			},
+			expectedConfig: &rest.Config{
+				Host:            "https://proxy.example.com:7890",
+				BearerToken:     "token-1",
+				BearerTokenFile: "",
+				TLSClientConfig: rest.TLSClientConfig{
+					CAData: []byte("ca-file-data"),
+					CAFile: "/tmp/ca-file-data",
+				},
+			},
+		},
+		{
 			name:      "returns an in-cluster config when the global packaging cluster token is specified",
 			userToken: "token-1",
 			cluster:   KUBEAPPS_GLOBAL_PACKAGING_CLUSTER_TOKEN,


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
After some testing of the previous PR, we found the issue is actually that kubeapps assumes the cluster on which Kubeapps is installed will never have an APIServiceURL set in the configuration (since it can be accessed via the in-cluster configuration at https://kubernetes.default).

As it turns out, some users need to set the APIServiceURL of the cluster on which Kubeapps is installed because they use a proxy in front of the API server for authentication purposes, so it's important that Kubeapps also use this.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #5999 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
