### PR TITLE
Transition core plugin and grpc health status as example.

### DIFF
--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -182,17 +182,17 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.kubeappsapis.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /core/plugins/v1alpha1/configured-plugins
-              port: grpc-http
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.kubeappsapis.containerPorts.http }}"]
+            initialDelaySeconds: 10
           {{- end }}
           {{- if .Values.kubeappsapis.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customReadinessProbe "context" $) | nindent 12 }}
           {{- else if .Values.kubeappsapis.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.readinessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /core/plugins/v1alpha1/configured-plugins
-              port: grpc-http
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.kubeappsapis.containerPorts.http }}"]
+            initialDelaySeconds: 5
           {{- end }}
           {{- if .Values.kubeappsapis.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customStartupProbe "context" $) | nindent 12 }}

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -181,6 +181,8 @@ spec:
           {{- if .Values.kubeappsapis.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.kubeappsapis.livenessProbe.enabled }}
+          # Replace with the built-in gRPC container probes once we're
+          # supporting >= 1.24 only. https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.kubeappsapis.containerPorts.http }}"]

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -78,6 +78,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o /resources-v1alpha1-plugin.so -buildmode=plugin \
     ./cmd/kubeapps-apis/plugins/resources/v1alpha1/*.go
 
+# Remove and instead use built-in gRPC container probes once we're
+# supporting >= 1.24 only. https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/
 RUN GRPC_HEALTH_PROBE_VERSION=v0.4.13 && \
     curl -sSL "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64" -o "/bin/grpc_health_probe" && chmod +x "/bin/grpc_health_probe"
 

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -80,7 +80,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 # Remove and instead use built-in gRPC container probes once we're
 # supporting >= 1.24 only. https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.13 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.16 && \
     curl -sSL "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64" -o "/bin/grpc_health_probe" && chmod +x "/bin/grpc_health_probe"
 
 # Note: unlike the other docker images for go, we cannot use scratch as the plugins

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -78,6 +78,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o /resources-v1alpha1-plugin.so -buildmode=plugin \
     ./cmd/kubeapps-apis/plugins/resources/v1alpha1/*.go
 
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.13 && \
+    curl -sSL "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64" -o "/bin/grpc_health_probe" && chmod +x "/bin/grpc_health_probe"
+
 # Note: unlike the other docker images for go, we cannot use scratch as the plugins
 # are loaded using the dynamic linker.
 FROM bitnami/minideb:bullseye
@@ -87,6 +90,7 @@ COPY --from=builder /kapp-controller-packages-v1alpha1-plugin.so /plugins/kapp-c
 COPY --from=builder /fluxv2-packages-v1alpha1-plugin.so /plugins/fluxv2-packages/
 COPY --from=builder /helm-packages-v1alpha1-plugin.so /plugins/helm-packages/
 COPY --from=builder /resources-v1alpha1-plugin.so /plugins/resources/
+COPY --from=builder /bin/grpc_health_probe /bin/
 
 # Ensure the container user will be able to write to the k8s discovery client cache.
 RUN mkdir -p /.kube/cache && chown 1001:1001 /.kube/cache

--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
@@ -336,6 +336,10 @@ func createConfigGetterWithParams(inClusterConfig *rest.Config, serveOpts core.S
 			if err != nil {
 				return nil, status.Errorf(codes.Unauthenticated, "invalid authorization metadata: %v", err)
 			}
+		} else if strings.HasPrefix(token, "Bearer ") {
+			// The token via header still includes the "Bearer " prefix,
+			// unlike the token in the context from improbable-eng.
+			token = token[7:]
 		}
 
 		var config *rest.Config

--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
@@ -329,6 +329,7 @@ func createConfigGetterWithParams(inClusterConfig *rest.Config, serveOpts core.S
 	return func(ctx context.Context, hdrs http.Header, cluster string) (*rest.Config, error) {
 		log.V(4).Infof("+clientGetter.GetClient")
 
+		// TODO: Move this into a unified extractToken
 		token := hdrs.Get("Authorization")
 		var err error
 		if token == "" {

--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/bufbuild/connect-go"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/core"
 	plugins "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
@@ -103,7 +104,7 @@ func ComparePlugin(pluginA *plugins.Plugin, pluginB *plugins.Plugin) bool {
 }
 
 // GetConfiguredPlugins returns details for each configured plugin.
-func (s *PluginsServer) GetConfiguredPlugins(ctx context.Context, in *plugins.GetConfiguredPluginsRequest) (*plugins.GetConfiguredPluginsResponse, error) {
+func (s *PluginsServer) GetConfiguredPlugins(ctx context.Context, in *connect.Request[plugins.GetConfiguredPluginsRequest]) (*connect.Response[plugins.GetConfiguredPluginsResponse], error) {
 	// this gets logged twice (liveness and readiness checks) every 10 seconds and
 	// really adds a lot of noise to the logs, so lowering verbosity
 	log.V(4).Infof("+core GetConfiguredPlugins")
@@ -111,9 +112,9 @@ func (s *PluginsServer) GetConfiguredPlugins(ctx context.Context, in *plugins.Ge
 	for i, p := range s.pluginsWithServers {
 		pluginDetails[i] = p.Plugin
 	}
-	return &plugins.GetConfiguredPluginsResponse{
+	return connect.NewResponse(&plugins.GetConfiguredPluginsResponse{
 		Plugins: pluginDetails,
-	}, nil
+	}), nil
 }
 
 // registerPlugins opens each plugin, looks up the register function and calls it with the registrar.

--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins_test.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins_test.go
@@ -401,7 +401,7 @@ func TestCreateConfigGetterWithParams(t *testing.T) {
 		},
 		{
 			name:            "it creates the config for the default cluster when passing a valid value for the authorization headers",
-			headers:         http.Header{"Authorization": []string{"token-value"}},
+			headers:         http.Header{"Authorization": []string{"Bearer token-value"}},
 			expectedAPIHost: DefaultK8sAPI,
 			expectedErrMsg:  nil,
 		},

--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins_test.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/bufbuild/connect-go"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/core"
@@ -70,12 +71,12 @@ func TestPluginsAvailable(t *testing.T) {
 				pluginsWithServers: tc.configuredPlugins,
 			}
 
-			resp, err := ps.GetConfiguredPlugins(context.TODO(), &plugins.GetConfiguredPluginsRequest{})
+			resp, err := ps.GetConfiguredPlugins(context.TODO(), connect.NewRequest(&plugins.GetConfiguredPluginsRequest{}))
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
 
-			if got, want := resp.Plugins, tc.expectedPlugins; !cmp.Equal(want, got, ignoreUnexported) {
+			if got, want := resp.Msg.Plugins, tc.expectedPlugins; !cmp.Equal(want, got, ignoreUnexported) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexported))
 			}
 		})

--- a/cmd/kubeapps-apis/core/serveopts.go
+++ b/cmd/kubeapps-apis/core/serveopts.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
@@ -37,4 +38,4 @@ type GatewayHandlerArgs struct {
 // KubernetesConfigGetter is a function type used throughout the apis server so
 // that call-sites don't need to know how to obtain an authenticated client, but
 // rather can just pass the request context and the cluster to get one.
-type KubernetesConfigGetter func(ctx context.Context, cluster string) (*rest.Config, error)
+type KubernetesConfigGetter func(ctx context.Context, hdr http.Header, cluster string) (*rest.Config, error)

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/watcher_cache.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/watcher_cache.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -193,7 +194,7 @@ func (c *NamespacedResourceWatcherCache) isGvrValid() error {
 	}
 	// sanity check that CRD for GVR has been registered
 	ctx := context.Background()
-	apiExt, err := c.config.ClientGetter.ApiExt(ctx)
+	apiExt, err := c.config.ClientGetter.ApiExt(ctx, http.Header{})
 	if err != nil {
 		return err
 	}
@@ -384,7 +385,7 @@ func (c *NamespacedResourceWatcherCache) resyncAndNewRetryWatcher(bootstrap bool
 func (c *NamespacedResourceWatcherCache) Watch(options metav1.ListOptions) (watch.Interface, error) {
 	ctx := context.Background()
 
-	ctrlClient, err := c.config.ClientGetter.ControllerRuntime(ctx)
+	ctrlClient, err := c.config.ClientGetter.ControllerRuntime(ctx, http.Header{})
 	if err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "unable to get client due to: %v", err)
 	}
@@ -434,7 +435,7 @@ func (c *NamespacedResourceWatcherCache) resync(bootstrap bool) (string, error) 
 	}
 
 	ctx := context.Background()
-	ctrlClient, err := c.config.ClientGetter.ControllerRuntime(ctx)
+	ctrlClient, err := c.config.ClientGetter.ControllerRuntime(ctx, http.Header{})
 	if err != nil {
 		return "", status.Errorf(codes.FailedPrecondition, "unable to get client due to: %v", err)
 	}
@@ -550,7 +551,7 @@ func (c *NamespacedResourceWatcherCache) syncHandler(key string) error {
 
 	// Get the resource with this namespace/name
 	ctx := context.Background()
-	ctrlClient, err := c.config.ClientGetter.ControllerRuntime(ctx)
+	ctrlClient, err := c.config.ClientGetter.ControllerRuntime(ctx, http.Header{})
 	if err != nil {
 		return status.Errorf(codes.FailedPrecondition, "unable to get client due to: %v", err)
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_test.go
@@ -685,7 +685,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 			}
 
 			// check expected HelmReleass CRD has been created
-			if ctrlClient, err := s.clientGetter.ControllerRuntime(context.Background(), s.kubeappsCluster); err != nil {
+			if ctrlClient, err := s.clientGetter.ControllerRuntime(context.Background(), http.Header{}, s.kubeappsCluster); err != nil {
 				t.Fatal(err)
 			} else {
 				key := types.NamespacedName{Namespace: tc.request.TargetContext.Namespace, Name: tc.request.Name}
@@ -901,7 +901,7 @@ func TestUpdateInstalledPackage(t *testing.T) {
 			}
 			ctx := context.Background()
 			var actualRel helmv2.HelmRelease
-			if ctrlClient, err := s.clientGetter.ControllerRuntime(ctx, s.kubeappsCluster); err != nil {
+			if ctrlClient, err := s.clientGetter.ControllerRuntime(ctx, http.Header{}, s.kubeappsCluster); err != nil {
 				t.Fatal(err)
 			} else if err = ctrlClient.Get(ctx, key, &actualRel); err != nil {
 				t.Fatal(err)
@@ -989,7 +989,7 @@ func TestDeleteInstalledPackage(t *testing.T) {
 			}
 			ctx := context.Background()
 			var actualRel helmv2.HelmRelease
-			if ctrlClient, err := s.clientGetter.ControllerRuntime(ctx, s.kubeappsCluster); err != nil {
+			if ctrlClient, err := s.clientGetter.ControllerRuntime(ctx, http.Header{}, s.kubeappsCluster); err != nil {
 				t.Fatal(err)
 			} else if err = ctrlClient.Get(ctx, key, &actualRel); !errors.IsNotFound(err) {
 				t.Errorf("mismatch expected, NotFound, got %+v", err)

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/gob"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -57,7 +58,7 @@ func (s *Server) listReposInNamespace(ctx context.Context, ns string) ([]sourcev
 	// kubeapps-internal-kubeappsapis service account
 	// ref https://github.com/vmware-tanzu/kubeapps/issues/4390 for explanation
 	backgroundCtx := context.Background()
-	client, err := s.serviceAccountClientGetter.ControllerRuntime(backgroundCtx)
+	client, err := s.serviceAccountClientGetter.ControllerRuntime(backgroundCtx, http.Header{})
 	if err != nil {
 		return nil, err
 	}
@@ -814,7 +815,7 @@ func (s *repoEventSink) getRepoSecret(ctx context.Context, repo sourcev1.HelmRep
 	if s == nil || s.clientGetter == nil {
 		return nil, status.Errorf(codes.Internal, "unexpected state in clientGetter instance")
 	}
-	typedClient, err := s.clientGetter.Typed(ctx)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/resources"
 
@@ -651,7 +652,7 @@ func (s *Server) GetPackageRepositoryPermissions(ctx context.Context, request *c
 	if cluster == "" && namespace != "" {
 		return nil, status.Errorf(codes.InvalidArgument, "cluster must be specified when namespace is present: %s", namespace)
 	}
-	typedClient, err := s.clientGetter.Typed(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -686,8 +687,8 @@ func (s *Server) GetPackageRepositoryPermissions(ctx context.Context, request *c
 // done explicitly, aka "in-band" interaction
 func (s *Server) newRepoEventSink() repoEventSink {
 
-	cg := &clientgetter.FixedClusterClientProvider{ClientsFunc: func(ctx context.Context) (*clientgetter.ClientGetter, error) {
-		return s.clientGetter.GetClients(ctx, s.kubeappsCluster)
+	cg := &clientgetter.FixedClusterClientProvider{ClientsFunc: func(ctx context.Context, hdrs http.Header) (*clientgetter.ClientGetter, error) {
+		return s.clientGetter.GetClients(ctx, hdrs, s.kubeappsCluster)
 	}}
 
 	// notice a bit of inconsistency here, we are using the context
@@ -706,7 +707,7 @@ func (s *Server) newRepoEventSink() repoEventSink {
 }
 
 func (s *Server) getClient(ctx context.Context, namespace string) (ctrlclient.Client, error) {
-	client, err := s.clientGetter.ControllerRuntime(ctx, s.kubeappsCluster)
+	client, err := s.clientGetter.ControllerRuntime(ctx, http.Header{}, s.kubeappsCluster)
 	if err != nil {
 		return nil, err
 	}
@@ -715,7 +716,7 @@ func (s *Server) getClient(ctx context.Context, namespace string) (ctrlclient.Cl
 
 // hasAccessToNamespace returns an error if the client does not have read access to a given namespace
 func (s *Server) hasAccessToNamespace(ctx context.Context, gvr schema.GroupVersionResource, namespace string) (bool, error) {
-	typedCli, err := s.clientGetter.Typed(ctx, s.kubeappsCluster)
+	typedCli, err := s.clientGetter.Typed(ctx, http.Header{}, s.kubeappsCluster)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/test_util_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/test_util_test.go
@@ -393,7 +393,7 @@ func newCtrlClient(repos []sourcev1.HelmRepository, charts []sourcev1.HelmChart,
 
 func ctrlClientAndWatcher(t *testing.T, s *Server) (client.WithWatch, *watch.RaceFreeFakeWatcher, error) {
 	ctx := context.Background()
-	if ctrlClient, err := s.clientGetter.ControllerRuntime(ctx, s.kubeappsCluster); err != nil {
+	if ctrlClient, err := s.clientGetter.ControllerRuntime(ctx, http.Header{}, s.kubeappsCluster); err != nil {
 		return nil, nil, err
 	} else if ww, ok := ctrlClient.(*withWatchWrapper); !ok {
 		return nil, nil, fmt.Errorf("Could not cast %T to: *withWatchWrapper", ctrlClient)

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository"
 
@@ -61,7 +62,7 @@ func (s *Server) newRepo(ctx context.Context, repo *HelmRepository) (*corev1.Pac
 	if repo.repoType == "" || !slices.Contains(ValidRepoTypes, repo.repoType) {
 		return nil, status.Errorf(codes.InvalidArgument, "repository type [%s] not supported", repo.repoType)
 	}
-	typedClient, err := s.clientGetter.Typed(ctx, repo.cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, repo.cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +311,7 @@ func (s *Server) setOwnerReferencesForRepoSecret(
 	repo *apprepov1alpha1.AppRepository) error {
 
 	if secret != nil {
-		if typedClient, err := s.clientGetter.Typed(ctx, cluster); err != nil {
+		if typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, cluster); err != nil {
 			return err
 		} else {
 			secretsInterface := typedClient.CoreV1().Secrets(repo.Namespace)
@@ -343,7 +344,7 @@ func (s *Server) updateRepo(ctx context.Context,
 	if repo.name.Name == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "repository name may not be empty")
 	}
-	typedClient, err := s.clientGetter.Typed(ctx, repo.cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, repo.cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -585,10 +586,10 @@ func (s *Server) GetPkgRepositories(ctx context.Context, cluster, namespace stri
 // getAccessiblePackageRepositories gather list of repositories to which the user has access per namespace
 func (s *Server) getAccessiblePackageRepositories(ctx context.Context, cluster string) ([]*apprepov1alpha1.AppRepository, error) {
 	clusterTypedClientFunc := func() (kubernetes.Interface, error) {
-		return s.clientGetter.Typed(ctx, cluster)
+		return s.clientGetter.Typed(ctx, http.Header{}, cluster)
 	}
 	inClusterTypedClientFunc := func() (kubernetes.Interface, error) {
-		return s.localServiceAccountClientGetter.Typed(context.Background())
+		return s.localServiceAccountClientGetter.Typed(context.Background(), http.Header{})
 	}
 
 	namespaceList, err := resources.FindAccessibleNamespaces(clusterTypedClientFunc, inClusterTypedClientFunc, s.MaxWorkers())
@@ -630,7 +631,7 @@ func (s *Server) deleteRepo(ctx context.Context, cluster string, repoRef *corev1
 	} else {
 		// Cross-namespace owner references are disallowed by design.
 		// We need to explicitly delete the repo secret from the namespace of the asset syncer.
-		typedClient, err := s.clientGetter.Typed(ctx, cluster)
+		typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, cluster)
 		if err != nil {
 			return err
 		}
@@ -650,7 +651,7 @@ func (s *Server) GetPackageRepositoryPermissions(ctx context.Context, request *c
 	if cluster == "" && namespace != "" {
 		return nil, status.Errorf(codes.InvalidArgument, "cluster must be specified when namespace is present: %s", namespace)
 	}
-	typedClient, err := s.clientGetter.Typed(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_resources.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_resources.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	apprepov1alpha1 "github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/statuserror"
@@ -18,7 +19,7 @@ import (
 )
 
 func (s *Server) getPkgRepositoryResource(ctx context.Context, cluster, namespace string) (dynamic.ResourceInterface, error) {
-	dynClient, err := s.clientGetter.Dynamic(ctx, cluster)
+	dynClient, err := s.clientGetter.Dynamic(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +49,7 @@ func (s *Server) getPkgRepository(ctx context.Context, cluster, namespace, ident
 	}
 
 	// Auth and TLS
-	typedClient, err := s.clientGetter.Typed(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
@@ -874,7 +874,7 @@ func TestAddPackageRepository(t *testing.T) {
 			}
 
 			// check expected HelmRelease CRD has been created
-			if ctrlClient, err := s.clientGetter.ControllerRuntime(ctx, s.kubeappsCluster); err != nil {
+			if ctrlClient, err := s.clientGetter.ControllerRuntime(ctx, http.Header{}, s.kubeappsCluster); err != nil {
 				t.Fatal(err)
 			} else {
 				var actualRepo appRepov1alpha1.AppRepository
@@ -2133,7 +2133,7 @@ func TestDeletePackageRepository(t *testing.T) {
 
 			if tc.expectedNonExistingSecrets != nil {
 				ctx := context.Background()
-				typedClient, err := s.clientGetter.Typed(ctx, s.kubeappsCluster)
+				typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, s.kubeappsCluster)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -2339,7 +2339,7 @@ func checkRepoSecrets(s *Server, t *testing.T, userManagedSecrets bool,
 			if actualRepo.Spec.Auth.Header == nil && actualRepo.Spec.Auth.CustomCA == nil {
 				t.Errorf("Error: Repository auth secret was expected but auth header and CA are empty")
 			}
-			typedClient, err := s.clientGetter.Typed(ctx, s.kubeappsCluster)
+			typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, s.kubeappsCluster)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2360,7 +2360,7 @@ func checkRepoSecrets(s *Server, t *testing.T, userManagedSecrets bool,
 			if len(actualRepo.Spec.DockerRegistrySecrets) == 0 {
 				t.Errorf("Error: Repository docker secret was expected but imagePullSecrets are empty")
 			}
-			typedClient, err := s.clientGetter.Typed(ctx, s.kubeappsCluster)
+			typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, s.kubeappsCluster)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2376,7 +2376,7 @@ func checkRepoSecrets(s *Server, t *testing.T, userManagedSecrets bool,
 
 func checkGlobalSecret(s *Server, t *testing.T, expectedRepo *appRepov1alpha1.AppRepository, expectedGlobalSecret *apiv1.Secret, checkNoGlobalSecret bool) {
 	ctx := context.Background()
-	typedClient, err := s.clientGetter.Typed(ctx, s.kubeappsCluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, s.kubeappsCluster)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -112,7 +113,7 @@ func TestGetClient(t *testing.T) {
 		{
 			name:    "it returns whatever error the clients getter function returns",
 			manager: manager,
-			clientGetter: &clientgetter.ClientProvider{ClientsFunc: func(ctx context.Context, cluster string) (*clientgetter.ClientGetter, error) {
+			clientGetter: &clientgetter.ClientProvider{ClientsFunc: func(ctx context.Context, hdrs http.Header, cluster string) (*clientgetter.ClientGetter, error) {
 				return nil, status.Errorf(codes.FailedPrecondition, "Bang!")
 			}},
 			statusCodeClient:  codes.FailedPrecondition,
@@ -136,7 +137,7 @@ func TestGetClient(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s := Server{clientGetter: tc.clientGetter, manager: tc.manager}
 
-			clientsProvider, errClient := s.clientGetter.GetClients(context.Background(), "")
+			clientsProvider, errClient := s.clientGetter.GetClients(context.Background(), http.Header{}, "")
 			if got, want := status.Code(errClient), tc.statusCodeClient; got != want {
 				t.Errorf("got: %+v, want: %+v", got, want)
 			}

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/cppforlife/go-cli-ui/ui"
@@ -126,7 +127,7 @@ func NewServer(configGetter core.KubernetesConfigGetter, clientQPS float32, clie
 				return ctlapp.Apps{}, ctlres.IdentifiedResources{}, nil, ctlres.ResourceFilter{}, status.Errorf(codes.Internal, "configGetter arg required")
 			}
 			// Retrieve the k8s REST client from the configGetter
-			config, err := configGetter(ctx, cluster)
+			config, err := configGetter(ctx, http.Header{}, cluster)
 			if err != nil {
 				return ctlapp.Apps{}, ctlres.IdentifiedResources{}, nil, ctlres.ResourceFilter{}, status.Errorf(codes.FailedPrecondition, "unable to get config due to: %v", err)
 			}

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -470,7 +471,7 @@ func (s *Server) GetInstalledPackageDetail(ctx context.Context, request *corev1.
 		cluster = s.globalPackagingCluster
 	}
 
-	typedClient, err := s.clientGetter.Typed(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)
 	}
@@ -589,7 +590,7 @@ func (s *Server) CreateInstalledPackage(ctx context.Context, request *corev1.Cre
 		return nil, status.Errorf(codes.InvalidArgument, "installing packages in other clusters in not supported yet")
 	}
 
-	typedClient, err := s.clientGetter.Typed(ctx, targetCluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, targetCluster)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)
 	}
@@ -695,7 +696,7 @@ func (s *Server) UpdateInstalledPackage(ctx context.Context, request *corev1.Upd
 		packageCluster = s.globalPackagingCluster
 	}
 
-	typedClient, err := s.clientGetter.Typed(ctx, packageCluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, packageCluster)
 	if err != nil {
 		return nil, err
 	}
@@ -824,7 +825,7 @@ func (s *Server) DeleteInstalledPackage(ctx context.Context, request *corev1.Del
 		cluster = s.globalPackagingCluster
 	}
 
-	typedClient, err := s.clientGetter.Typed(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_repositories.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_repositories.go
@@ -5,6 +5,8 @@ package main
 
 import (
 	"context"
+	"net/http"
+
 	packagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/resources"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -349,7 +351,7 @@ func (s *Server) GetPackageRepositoryPermissions(ctx context.Context, request *c
 	if cluster == "" && namespace != "" {
 		return nil, status.Errorf(codes.InvalidArgument, "cluster must be specified when namespace is present: %s", namespace)
 	}
-	typedClient, err := s.clientGetter.Typed(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_resources.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_resources.go
@@ -6,9 +6,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/resources"
 	"k8s.io/client-go/kubernetes"
-	"strings"
 
 	kappctrlv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	packagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
@@ -45,7 +47,7 @@ const (
 
 // See https://carvel.dev/kapp-controller/docs/latest/packaging/#package-cr
 func (s *Server) getPkgResource(ctx context.Context, cluster, namespace string) (dynamic.ResourceInterface, error) {
-	dynClient, err := s.clientGetter.Dynamic(ctx, cluster)
+	dynClient, err := s.clientGetter.Dynamic(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +61,7 @@ func (s *Server) getPkgResource(ctx context.Context, cluster, namespace string) 
 
 // See https://carvel.dev/kapp-controller/docs/latest/packaging/#package-metadata
 func (s *Server) getPkgMetadataResource(ctx context.Context, cluster, namespace string) (dynamic.ResourceInterface, error) {
-	dynClient, err := s.clientGetter.Dynamic(ctx, cluster)
+	dynClient, err := s.clientGetter.Dynamic(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +75,7 @@ func (s *Server) getPkgMetadataResource(ctx context.Context, cluster, namespace 
 
 // See https://carvel.dev/kapp-controller/docs/latest/packaging/#package-install
 func (s *Server) getPkgInstallResource(ctx context.Context, cluster, namespace string) (dynamic.ResourceInterface, error) {
-	dynClient, err := s.clientGetter.Dynamic(ctx, cluster)
+	dynClient, err := s.clientGetter.Dynamic(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +89,7 @@ func (s *Server) getPkgInstallResource(ctx context.Context, cluster, namespace s
 
 // See https://carvel.dev/kapp-controller/docs/latest/packaging/#packagerepository-cr
 func (s *Server) getPkgRepositoryResource(ctx context.Context, cluster, namespace string) (dynamic.ResourceInterface, error) {
-	dynClient, err := s.clientGetter.Dynamic(ctx, cluster)
+	dynClient, err := s.clientGetter.Dynamic(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +103,7 @@ func (s *Server) getPkgRepositoryResource(ctx context.Context, cluster, namespac
 
 // See https://carvel.dev/kapp-controller/docs/latest/app-spec/
 func (s *Server) getAppResource(ctx context.Context, cluster, namespace string) (dynamic.ResourceInterface, error) {
-	dynClient, err := s.clientGetter.Dynamic(ctx, cluster)
+	dynClient, err := s.clientGetter.Dynamic(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +211,7 @@ func (s *Server) getApp(ctx context.Context, cluster, namespace, identifier stri
 
 // get Secret
 func (s *Server) getSecret(ctx context.Context, cluster, namespace, name string) (*k8scorev1.Secret, error) {
-	typedClient, err := s.clientGetter.Typed(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -347,10 +349,10 @@ func (s *Server) getPkgRepositories(ctx context.Context, cluster, namespace stri
 // getAccessiblePackageRepositories gather list of repositories to which the user has access per namespace
 func (s *Server) getAccessiblePackageRepositories(ctx context.Context, cluster string) ([]*packagingv1alpha1.PackageRepository, error) {
 	clusterTypedClientFunc := func() (kubernetes.Interface, error) {
-		return s.clientGetter.Typed(ctx, cluster)
+		return s.clientGetter.Typed(ctx, http.Header{}, cluster)
 	}
 	inClusterTypedClientFunc := func() (kubernetes.Interface, error) {
-		return s.localServiceAccountClientGetter.Typed(context.Background())
+		return s.localServiceAccountClientGetter.Typed(context.Background(), http.Header{})
 	}
 
 	namespaceList, err := resources.FindAccessibleNamespaces(clusterTypedClientFunc, inClusterTypedClientFunc, s.MaxWorkers())
@@ -470,7 +472,7 @@ func (s *Server) createPkgRepository(ctx context.Context, cluster, namespace str
 
 // create Secret
 func (s *Server) createSecret(ctx context.Context, cluster string, secret *k8scorev1.Secret) (*k8scorev1.Secret, error) {
-	typedClient, err := s.clientGetter.Typed(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -511,7 +513,7 @@ func (s *Server) deletePkgRepository(ctx context.Context, cluster, namespace, id
 
 // create Secret
 func (s *Server) deleteSecret(ctx context.Context, cluster, namespace, name string) error {
-	typedClient, err := s.clientGetter.Typed(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, cluster)
 	if err != nil {
 		return err
 	}
@@ -667,7 +669,7 @@ func (s *Server) updatePkgRepository(ctx context.Context, cluster, namespace str
 
 // create Secret
 func (s *Server) updateSecret(ctx context.Context, cluster string, secret *k8scorev1.Secret) (*k8scorev1.Secret, error) {
-	typedClient, err := s.clientGetter.Typed(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, http.Header{}, cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/pkg/helm/helmaction_configgetter.go
+++ b/cmd/kubeapps-apis/plugins/pkg/helm/helmaction_configgetter.go
@@ -5,6 +5,8 @@ package helm
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/core"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/helm/agent"
 	"google.golang.org/grpc/codes"
@@ -22,7 +24,7 @@ func NewHelmActionConfigGetter(configGetter core.KubernetesConfigGetter, cluster
 		if configGetter == nil {
 			return nil, status.Errorf(codes.Internal, "configGetter arg required")
 		}
-		config, err := configGetter(ctx, cluster)
+		config, err := configGetter(ctx, http.Header{}, cluster)
 		if err != nil {
 			return nil, status.Errorf(codes.FailedPrecondition, "unable to get config due to: %v", err)
 		}

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
@@ -12,6 +12,7 @@ import (
 	pluginsv1alpha1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/core/plugins/v1alpha1"
 	pluginsgrpcv1alpha1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
+	resourcesConnect "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1/v1alpha1connect"
 )
 
 // Set the pluginDetail once during a module init function so the single struct
@@ -34,7 +35,10 @@ func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) 
 	if err != nil {
 		return nil, err
 	}
-	v1alpha1.RegisterResourcesServiceServer(opts.Registrar, svr)
+	// v1alpha1.RegisterResourcesServiceServer(opts.Registrar, svr)
+	// Instead, register the path and handler
+	// mux.Handle(pluginsConnect.NewPluginsServiceHandler(pluginsServer))
+	opts.Mux.Handle(resourcesConnect.NewResourcesServiceHandler(svr))
 	return svr, nil
 }
 

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces.go
@@ -28,7 +28,7 @@ func (s *Server) CheckNamespaceExists(ctx context.Context, r *connect.Request[v1
 	cluster := r.Msg.GetContext().GetCluster()
 	log.InfoS("+resources CheckNamespaceExists", "cluster", cluster, "namespace", namespace)
 
-	typedClient, err := s.clientGetter.Typed(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, r.Header(), cluster)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)
 	}
@@ -55,7 +55,7 @@ func (s *Server) CreateNamespace(ctx context.Context, r *connect.Request[v1alpha
 	cluster := r.Msg.GetContext().GetCluster()
 	log.InfoS("+resources CreateNamespace", "cluster", cluster, "namespace", namespace, "labels", r.Msg.Labels)
 
-	typedClient, err := s.clientGetter.Typed(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, r.Header(), cluster)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)
 	}
@@ -89,7 +89,7 @@ func (s *Server) GetNamespaceNames(ctx context.Context, r *connect.Request[v1alp
 		return nil, statuserror.FromK8sError("get", "Namespaces", "", err)
 	}
 
-	namespaceList, err := s.GetAccessibleNamespaces(ctx, cluster, trustedNamespaces)
+	namespaceList, err := s.GetAccessibleNamespaces(ctx, r.Header(), cluster, trustedNamespaces)
 	if err != nil {
 		return nil, statuserror.FromK8sError("list", "Namespaces", "", err)
 	}
@@ -120,9 +120,9 @@ func (s *Server) CanI(ctx context.Context, r *connect.Request[v1alpha1.CanIReque
 	var err error
 	if s.kubeappsCluster != cluster && strings.ToLower(r.Msg.GetVerb()) == "list" && strings.ToLower(r.Msg.GetResource()) == "namespaces" {
 		// Listing namespaces in additional clusters might involve using the provided service account token
-		typedClient, err = s.clusterServiceAccountClientGetter.Typed(ctx, cluster)
+		typedClient, err = s.clusterServiceAccountClientGetter.Typed(ctx, r.Header(), cluster)
 	} else {
-		typedClient, err = s.clientGetter.Typed(ctx, cluster)
+		typedClient, err = s.clientGetter.Typed(ctx, r.Header(), cluster)
 	}
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces.go
@@ -5,10 +5,12 @@ package main
 
 import (
 	"context"
-	authorizationapi "k8s.io/api/authorization/v1"
-	"k8s.io/client-go/kubernetes"
 	"strings"
 
+	authorizationapi "k8s.io/api/authorization/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/bufbuild/connect-go"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/statuserror"
 	"google.golang.org/grpc/codes"
@@ -21,9 +23,9 @@ import (
 
 // CheckNamespaceExists returns whether a namespace exists on the cluster, or
 // an error if the user does not have the required RBAC.
-func (s *Server) CheckNamespaceExists(ctx context.Context, r *v1alpha1.CheckNamespaceExistsRequest) (*v1alpha1.CheckNamespaceExistsResponse, error) {
-	namespace := r.GetContext().GetNamespace()
-	cluster := r.GetContext().GetCluster()
+func (s *Server) CheckNamespaceExists(ctx context.Context, r *connect.Request[v1alpha1.CheckNamespaceExistsRequest]) (*connect.Response[v1alpha1.CheckNamespaceExistsResponse], error) {
+	namespace := r.Msg.GetContext().GetNamespace()
+	cluster := r.Msg.GetContext().GetCluster()
 	log.InfoS("+resources CheckNamespaceExists", "cluster", cluster, "namespace", namespace)
 
 	typedClient, err := s.clientGetter.Typed(ctx, cluster)
@@ -34,24 +36,24 @@ func (s *Server) CheckNamespaceExists(ctx context.Context, r *v1alpha1.CheckName
 	_, err = typedClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return &v1alpha1.CheckNamespaceExistsResponse{
+			return connect.NewResponse(&v1alpha1.CheckNamespaceExistsResponse{
 				Exists: false,
-			}, nil
+			}), nil
 		}
 		return nil, statuserror.FromK8sError("get", "Namespace", namespace, err)
 	}
 
-	return &v1alpha1.CheckNamespaceExistsResponse{
+	return connect.NewResponse(&v1alpha1.CheckNamespaceExistsResponse{
 		Exists: true,
-	}, nil
+	}), nil
 }
 
 // CreateNamespace create the namespace for the given context
 // if the user has the required RBAC
-func (s *Server) CreateNamespace(ctx context.Context, r *v1alpha1.CreateNamespaceRequest) (*v1alpha1.CreateNamespaceResponse, error) {
-	namespace := r.GetContext().GetNamespace()
-	cluster := r.GetContext().GetCluster()
-	log.InfoS("+resources CreateNamespace", "cluster", cluster, "namespace", namespace, "labels", r.Labels)
+func (s *Server) CreateNamespace(ctx context.Context, r *connect.Request[v1alpha1.CreateNamespaceRequest]) (*connect.Response[v1alpha1.CreateNamespaceResponse], error) {
+	namespace := r.Msg.GetContext().GetNamespace()
+	cluster := r.Msg.GetContext().GetCluster()
+	log.InfoS("+resources CreateNamespace", "cluster", cluster, "namespace", namespace, "labels", r.Msg.Labels)
 
 	typedClient, err := s.clientGetter.Typed(ctx, cluster)
 	if err != nil {
@@ -65,20 +67,20 @@ func (s *Server) CreateNamespace(ctx context.Context, r *v1alpha1.CreateNamespac
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   namespace,
-			Labels: r.Labels,
+			Labels: r.Msg.Labels,
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {
 		return nil, statuserror.FromK8sError("get", "Namespace", namespace, err)
 	}
 
-	return &v1alpha1.CreateNamespaceResponse{}, nil
+	return connect.NewResponse(&v1alpha1.CreateNamespaceResponse{}), nil
 }
 
 // GetNamespaceNames returns the list of namespace names from either the cluster or the incoming trusted namespaces.
 // In any case, only if the user has the required RBAC.
-func (s *Server) GetNamespaceNames(ctx context.Context, r *v1alpha1.GetNamespaceNamesRequest) (*v1alpha1.GetNamespaceNamesResponse, error) {
-	cluster := r.GetCluster()
+func (s *Server) GetNamespaceNames(ctx context.Context, r *connect.Request[v1alpha1.GetNamespaceNamesRequest]) (*connect.Response[v1alpha1.GetNamespaceNamesResponse], error) {
+	cluster := r.Msg.GetCluster()
 	log.InfoS("+resources GetNamespaceNames ", "cluster", cluster)
 
 	// Check if there are trusted namespaces in the request
@@ -97,26 +99,26 @@ func (s *Server) GetNamespaceNames(ctx context.Context, r *v1alpha1.GetNamespace
 		namespaces[i] = ns.Name
 	}
 
-	return &v1alpha1.GetNamespaceNamesResponse{
+	return connect.NewResponse(&v1alpha1.GetNamespaceNamesResponse{
 		NamespaceNames: namespaces,
-	}, nil
+	}), nil
 }
 
 // CanI Checks if the operation can be performed according to incoming auth rbac
-func (s *Server) CanI(ctx context.Context, r *v1alpha1.CanIRequest) (*v1alpha1.CanIResponse, error) {
-	if r.GetContext() == nil {
+func (s *Server) CanI(ctx context.Context, r *connect.Request[v1alpha1.CanIRequest]) (*connect.Response[v1alpha1.CanIResponse], error) {
+	if r.Msg.GetContext() == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "context parameter is required")
 	}
-	namespace := r.GetContext().GetNamespace()
-	cluster := r.GetContext().GetCluster()
+	namespace := r.Msg.GetContext().GetNamespace()
+	cluster := r.Msg.GetContext().GetCluster()
 	if cluster == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "cluster parameter is required")
 	}
-	log.InfoS("+resources CanI", "cluster", cluster, "namespace", namespace, "group", r.GetGroup(), "resource", r.GetResource(), "verb", r.GetVerb())
+	log.InfoS("+resources CanI", "cluster", cluster, "namespace", namespace, "group", r.Msg.GetGroup(), "resource", r.Msg.GetResource(), "verb", r.Msg.GetVerb())
 
 	var typedClient kubernetes.Interface
 	var err error
-	if s.kubeappsCluster != cluster && strings.ToLower(r.GetVerb()) == "list" && strings.ToLower(r.GetResource()) == "namespaces" {
+	if s.kubeappsCluster != cluster && strings.ToLower(r.Msg.GetVerb()) == "list" && strings.ToLower(r.Msg.GetResource()) == "namespaces" {
 		// Listing namespaces in additional clusters might involve using the provided service account token
 		typedClient, err = s.clusterServiceAccountClientGetter.Typed(ctx, cluster)
 	} else {
@@ -129,9 +131,9 @@ func (s *Server) CanI(ctx context.Context, r *v1alpha1.CanIRequest) (*v1alpha1.C
 	reviewResult, err := typedClient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, &authorizationapi.SelfSubjectAccessReview{
 		Spec: authorizationapi.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &authorizationapi.ResourceAttributes{
-				Group:     r.Group,
-				Resource:  r.Resource,
-				Verb:      r.Verb,
+				Group:     r.Msg.Group,
+				Resource:  r.Msg.Resource,
+				Verb:      r.Msg.Verb,
 				Namespace: namespace,
 			},
 		},
@@ -140,7 +142,7 @@ func (s *Server) CanI(ctx context.Context, r *v1alpha1.CanIRequest) (*v1alpha1.C
 		return nil, err
 	}
 
-	return &v1alpha1.CanIResponse{
+	return connect.NewResponse(&v1alpha1.CanIResponse{
 		Allowed: reviewResult.Status.Allowed,
-	}, nil
+	}), nil
 }

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/secrets.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/secrets.go
@@ -23,7 +23,7 @@ func (s *Server) CreateSecret(ctx context.Context, r *connect.Request[v1alpha1.C
 	cluster := r.Msg.GetContext().GetCluster()
 	log.InfoS("+resources CreateSecret ", "cluster", cluster, "namespace", namespace)
 
-	typedClient, err := s.clientGetter.Typed(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, r.Header(), cluster)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)
 	}
@@ -98,7 +98,7 @@ func (s *Server) GetSecretNames(ctx context.Context, r *connect.Request[v1alpha1
 	namespace := r.Msg.GetContext().GetNamespace()
 	log.InfoS("+resources GetSecretNames ", "cluster", cluster, "namespace", namespace)
 
-	typedClient, err := s.clientGetter.Typed(ctx, cluster)
+	typedClient, err := s.clientGetter.Typed(ctx, r.Header(), cluster)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)
 	}

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/secrets.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/secrets.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 
+	"github.com/bufbuild/connect-go"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/statuserror"
 	"google.golang.org/grpc/codes"
@@ -17,9 +18,9 @@ import (
 
 // CreateSecret creates the secret in the given context if the user has the
 // required RBAC
-func (s *Server) CreateSecret(ctx context.Context, r *v1alpha1.CreateSecretRequest) (*v1alpha1.CreateSecretResponse, error) {
-	namespace := r.GetContext().GetNamespace()
-	cluster := r.GetContext().GetCluster()
+func (s *Server) CreateSecret(ctx context.Context, r *connect.Request[v1alpha1.CreateSecretRequest]) (*connect.Response[v1alpha1.CreateSecretResponse], error) {
+	namespace := r.Msg.GetContext().GetNamespace()
+	cluster := r.Msg.GetContext().GetCluster()
 	log.InfoS("+resources CreateSecret ", "cluster", cluster, "namespace", namespace)
 
 	typedClient, err := s.clientGetter.Typed(ctx, cluster)
@@ -34,16 +35,16 @@ func (s *Server) CreateSecret(ctx context.Context, r *v1alpha1.CreateSecretReque
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      r.GetName(),
+			Name:      r.Msg.GetName(),
 		},
-		Type:       k8sTypeForProtoType(r.GetType()),
-		StringData: r.GetStringData(),
+		Type:       k8sTypeForProtoType(r.Msg.GetType()),
+		StringData: r.Msg.GetStringData(),
 	}, metav1.CreateOptions{})
 	if err != nil {
 		return nil, statuserror.FromK8sError("get", "Namespace", namespace, err)
 	}
 
-	return &v1alpha1.CreateSecretResponse{}, nil
+	return connect.NewResponse(&v1alpha1.CreateSecretResponse{}), nil
 }
 
 func k8sTypeForProtoType(secretType v1alpha1.SecretType) core.SecretType {
@@ -92,9 +93,9 @@ func protoTypeForK8sType(secretType core.SecretType) v1alpha1.SecretType {
 
 // GetSecretNames returns a map of secret names with their types for the given
 // context if the user has the required RBAC.
-func (s *Server) GetSecretNames(ctx context.Context, r *v1alpha1.GetSecretNamesRequest) (*v1alpha1.GetSecretNamesResponse, error) {
-	cluster := r.GetContext().GetCluster()
-	namespace := r.GetContext().GetNamespace()
+func (s *Server) GetSecretNames(ctx context.Context, r *connect.Request[v1alpha1.GetSecretNamesRequest]) (*connect.Response[v1alpha1.GetSecretNamesResponse], error) {
+	cluster := r.Msg.GetContext().GetCluster()
+	namespace := r.Msg.GetContext().GetNamespace()
 	log.InfoS("+resources GetSecretNames ", "cluster", cluster, "namespace", namespace)
 
 	typedClient, err := s.clientGetter.Typed(ctx, cluster)
@@ -112,7 +113,7 @@ func (s *Server) GetSecretNames(ctx context.Context, r *v1alpha1.GetSecretNamesR
 		secrets[s.Name] = protoTypeForK8sType(s.Type)
 	}
 
-	return &v1alpha1.GetSecretNamesResponse{
+	return connect.NewResponse(&v1alpha1.GetSecretNamesResponse{
 		SecretNames: secrets,
-	}, nil
+	}), nil
 }

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server_test.go
@@ -5,39 +5,25 @@ package main
 
 import (
 	"context"
-	"errors"
-	"io"
-	"net"
 	"reflect"
 	"testing"
-	"time"
 
+	"github.com/bufbuild/connect-go"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/clientgetter"
 	"github.com/vmware-tanzu/kubeapps/pkg/kube"
 	"k8s.io/client-go/rest"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"google.golang.org/grpc/test/bufconn"
-	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
-	rbac "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	dynfake "k8s.io/client-go/dynamic/fake"
 	typfake "k8s.io/client-go/kubernetes/fake"
 
 	pkgsGRPCv1alpha1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	pluginsGRPCv1alpha1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
-	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugin_test"
 )
 
 const bufSize = 1024 * 1024
@@ -67,389 +53,412 @@ func resourceRefsForObjects(t *testing.T, objects ...runtime.Object) []*pkgsGRPC
 // and a test core packages service, but using a buf connection (ie. no need for
 // slow network port etc.). More at
 // https://stackoverflow.com/a/52080545
-func getResourcesClient(t *testing.T, objects ...runtime.Object) (v1alpha1.ResourcesServiceClient, *dynfake.FakeDynamicClient, func()) {
-	lis := bufconn.Listen(bufSize)
-	s := grpc.NewServer()
-	bufDialer := func(context.Context, string) (net.Conn, error) {
-		return lis.Dial()
-	}
-	ctx := context.Background()
-	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("Failed to dial bufnet: %v", err)
-	}
-
-	// Create and register a fake packages plugin returning resourcerefs for objects.
-	fakePkgsPluginServer := &plugin_test.TestPackagingPluginServer{
-		Plugin:       fakePkgsPlugin,
-		ResourceRefs: resourceRefsForObjects(t, objects...),
-	}
-	pkgsGRPCv1alpha1.RegisterPackagesServiceServer(s, fakePkgsPluginServer)
-
-	scheme := runtime.NewScheme()
-	t.Logf("loading fake client with objects: %+v", objects)
-	fakeDynamicClient := dynfake.NewSimpleDynamicClient(
-		scheme,
-		objects...,
-	)
-	// Create the resources service server.
-	v1alpha1.RegisterResourcesServiceServer(s, &Server{
-		// Use a client getter that returns a dynamic client prepped with the
-		// specified objects.
-		clientGetter: clientgetter.NewBuilder().
-			WithDynamic(fakeDynamicClient).
-			Build(),
-		// Use a corePackagesClientGetter that returns a client connected to our
-		// running test service.
-		corePackagesClientGetter: func() (pkgsGRPCv1alpha1.PackagesServiceClient, error) {
-			return pkgsGRPCv1alpha1.NewPackagesServiceClient(conn), nil
-		},
-		// For testing, define a kindToResource converter that doesn't require
-		// a rest mapper.
-		kindToResource: func(mapper meta.RESTMapper, gvk schema.GroupVersionKind) (schema.GroupVersionResource, meta.RESTScopeName, error) {
-			gvr, _ := meta.UnsafeGuessKindToResource(gvk)
-			return gvr, meta.RESTScopeNameNamespace, nil
-		},
-	})
-
-	go func() {
-		if err := s.Serve(lis); err != nil {
-			// Only valid error should be when the listener is closed.
-			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) {
-				return
-			}
-		}
-	}()
-
-	return v1alpha1.NewResourcesServiceClient(conn), fakeDynamicClient, func() {
-		conn.Close()
-		lis.Close()
-	}
-}
-
-func TestGetResources(t *testing.T) {
-	testCases := []struct {
-		name              string
-		request           *v1alpha1.GetResourcesRequest
-		withoutAuthz      bool
-		clusterObjects    []runtime.Object
-		expectedErrorCode codes.Code
-		expectedResources []*v1alpha1.GetResourcesResponse
-	}{
-		{
-			name: "it returns permission denied for a request without auth",
-			request: &v1alpha1.GetResourcesRequest{
-				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
-					Context: &pkgsGRPCv1alpha1.Context{
-						Cluster:   "default",
-						Namespace: "default",
-					},
-					Identifier: "some-package",
-					Plugin:     fakePkgsPlugin,
-				},
-			},
-			withoutAuthz:      true,
-			expectedErrorCode: codes.PermissionDenied,
-		},
-		{
-			name: "it gets all resources for an installed app when the filter is empty",
-			request: &v1alpha1.GetResourcesRequest{
-				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
-					Context: &pkgsGRPCv1alpha1.Context{
-						Cluster:   "default",
-						Namespace: "default",
-					},
-					Identifier: "some-package",
-					Plugin:     fakePkgsPlugin,
-				},
-			},
-			clusterObjects: []runtime.Object{
-				&apps.Deployment{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "Deployment",
-						APIVersion: "apps/v1",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "some-deployment",
-						Namespace: "default",
-					},
-				},
-				&core.Service{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "Service",
-						APIVersion: "core/v1",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "some-service",
-						Namespace: "default",
-					},
-				},
-			},
-			expectedErrorCode: codes.OK,
-			expectedResources: []*v1alpha1.GetResourcesResponse{
-				{
-					ResourceRef: &pkgsGRPCv1alpha1.ResourceRef{
-						ApiVersion: "apps/v1",
-						Kind:       "Deployment",
-						Name:       "some-deployment",
-						Namespace:  "default",
-					},
-				},
-				{
-					ResourceRef: &pkgsGRPCv1alpha1.ResourceRef{
-						ApiVersion: "core/v1",
-						Kind:       "Service",
-						Name:       "some-service",
-						Namespace:  "default",
-					},
-				},
-			},
-		},
-		{
-			name: "it gets only requested resources for an installed app when the filter is specified",
-			request: &v1alpha1.GetResourcesRequest{
-				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
-					Context: &pkgsGRPCv1alpha1.Context{
-						Cluster:   "default",
-						Namespace: "default",
-					},
-					Identifier: "some-package",
-					Plugin:     fakePkgsPlugin,
-				},
-				ResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
-					{
-						ApiVersion: "core/v1",
-						Kind:       "Service",
-						Name:       "some-service",
-						Namespace:  "default",
-					},
-				},
-			},
-			clusterObjects: []runtime.Object{
-				&apps.Deployment{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "Deployment",
-						APIVersion: "apps/v1",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "some-deployment",
-						Namespace: "default",
-					},
-				},
-				&core.Service{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "Service",
-						APIVersion: "core/v1",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "some-service",
-						Namespace: "default",
-					},
-				},
-			},
-			expectedErrorCode: codes.OK,
-			expectedResources: []*v1alpha1.GetResourcesResponse{
-				{
-					ResourceRef: &pkgsGRPCv1alpha1.ResourceRef{
-						ApiVersion: "core/v1",
-						Kind:       "Service",
-						Name:       "some-service",
-						Namespace:  "default",
-					},
-				},
-			},
-		},
-		{
-			name: "it returns invalid argument if a requested resource isn't part of the installed package",
-			request: &v1alpha1.GetResourcesRequest{
-				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
-					Context: &pkgsGRPCv1alpha1.Context{
-						Cluster:   "default",
-						Namespace: "default",
-					},
-					Identifier: "some-package",
-					Plugin:     fakePkgsPlugin,
-				},
-				ResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
-					{
-						ApiVersion: "core/v1",
-						Kind:       "Secret",
-						Name:       "some-secret",
-					},
-				},
-			},
-			clusterObjects: []runtime.Object{
-				&apps.Deployment{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "Deployment",
-						APIVersion: "apps/v1",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "some-deployment",
-						Namespace: "default",
-					},
-				},
-			},
-			expectedErrorCode: codes.InvalidArgument,
-		},
-		{
-			name: "it returns invalid argument if request is to watch all packages implicitly (ie. empty resource refs filter in request)",
-			request: &v1alpha1.GetResourcesRequest{
-				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
-					Context: &pkgsGRPCv1alpha1.Context{
-						Cluster:   "default",
-						Namespace: "default",
-					},
-					Identifier: "some-package",
-					Plugin:     fakePkgsPlugin,
-				},
-				Watch: true,
-			},
-			expectedErrorCode: codes.InvalidArgument,
-		},
-		{
-			name: "it gets requested resources from different namespaces when they belong to the installed package",
-			request: &v1alpha1.GetResourcesRequest{
-				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
-					Context: &pkgsGRPCv1alpha1.Context{
-						Cluster:   "default",
-						Namespace: "default",
-					},
-					Identifier: "some-package",
-					Plugin:     fakePkgsPlugin,
-				},
-				ResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
-					{
-						ApiVersion: "core/v1",
-						Kind:       "Service",
-						Name:       "some-service",
-						Namespace:  "other-namespace",
-					},
-				},
-			},
-			clusterObjects: []runtime.Object{
-				&core.Service{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "Service",
-						APIVersion: "core/v1",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "some-service",
-						Namespace: "other-namespace",
-					},
-				},
-			},
-			expectedErrorCode: codes.OK,
-			expectedResources: []*v1alpha1.GetResourcesResponse{
-				{
-					ResourceRef: &pkgsGRPCv1alpha1.ResourceRef{
-						ApiVersion: "core/v1",
-						Kind:       "Service",
-						Name:       "some-service",
-						Namespace:  "other-namespace",
-					},
-				},
-			},
-		},
-		{
-			name: "it gets non-namespaced requested resources when they belong to the installed package",
-			request: &v1alpha1.GetResourcesRequest{
-				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
-					Context: &pkgsGRPCv1alpha1.Context{
-						Cluster:   "default",
-						Namespace: "default",
-					},
-					Identifier: "some-package",
-					Plugin:     fakePkgsPlugin,
-				},
-				ResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
-					{
-						ApiVersion: "rbac/v1",
-						Kind:       "ClusterRole",
-						Name:       "some-cluster-role",
-					},
-				},
-			},
-			clusterObjects: []runtime.Object{
-				&rbac.ClusterRole{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "ClusterRole",
-						APIVersion: "rbac/v1",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "some-cluster-role",
-					},
-				},
-			},
-			expectedErrorCode: codes.OK,
-			expectedResources: []*v1alpha1.GetResourcesResponse{
-				{
-					ResourceRef: &pkgsGRPCv1alpha1.ResourceRef{
-						ApiVersion: "rbac/v1",
-						Kind:       "ClusterRole",
-						Name:       "some-cluster-role",
-					},
-				},
-			},
-		},
-		// TODO(minelson): test a watch request also. I've spent quite a bit of
-		// time trying to do so by putting the call to `GetResources` in a go
-		// routine (and passing the results out via response and error channels)
-		// and then deleting the resources via the fake k8s client's object
-		// tracker. From the source code, this should trigger the watch event,
-		// but I didn't succeed (yet).
-	}
-
-	ignoredUnexported := cmpopts.IgnoreUnexported(
-		v1alpha1.GetResourcesResponse{},
-		pkgsGRPCv1alpha1.ResourceRef{},
-	)
-	ignoreManifest := cmpopts.IgnoreFields(v1alpha1.GetResourcesResponse{}, "Manifest")
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			client, _, cleanup := getResourcesClient(t, tc.clusterObjects...)
-			defer cleanup()
-
-			// Use a context with a timeout to ensure that if a test unexpectedly
-			// waits beyond expectations, we'll see the failure.
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-			defer cancel()
-			if !tc.withoutAuthz {
-				ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "some-auth-token")
-			}
-
-			responseStream, err := client.GetResources(ctx, tc.request)
-			if err != nil {
-				t.Fatalf("%+v", err)
-			}
-
-			var resources []*v1alpha1.GetResourcesResponse
-			for numResponses := 0; numResponses < len(tc.expectedResources); numResponses++ {
-				resource, err := responseStream.Recv()
-				if err == io.EOF {
-					break
-				}
-				if err != nil {
-					if got, want := status.Code(err), tc.expectedErrorCode; got != want {
-						t.Fatalf("got: %s, want: %s, err: %+v", got, want, err)
-					}
-					// If it was an expected error, we continue to the next test.
-					return
-				}
-				resources = append(resources, resource)
-			}
-			err = responseStream.CloseSend()
-			if err != nil {
-				t.Fatalf("%+v", err)
-			}
-
-			if got, want := resources, tc.expectedResources; !cmp.Equal(got, want, ignoredUnexported, ignoreManifest) {
-				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoredUnexported, ignoreManifest))
-			}
-		})
-	}
-}
+// func getResourcesClient(t *testing.T, objects ...runtime.Object) (v1alpha1.ResourcesServiceClient, *dynfake.FakeDynamicClient, func()) {
+// 	lis := bufconn.Listen(bufSize)
+// 	s := grpc.NewServer()
+// 	bufDialer := func(context.Context, string) (net.Conn, error) {
+// 		return lis.Dial()
+// 	}
+// 	ctx := context.Background()
+// 	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
+// 	if err != nil {
+// 		t.Fatalf("Failed to dial bufnet: %v", err)
+// 	}
+//
+// 	// Create and register a fake packages plugin returning resourcerefs for objects.
+// 	fakePkgsPluginServer := &plugin_test.TestPackagingPluginServer{
+// 		Plugin:       fakePkgsPlugin,
+// 		ResourceRefs: resourceRefsForObjects(t, objects...),
+// 	}
+// 	pkgsGRPCv1alpha1.RegisterPackagesServiceServer(s, fakePkgsPluginServer)
+//
+// 	scheme := runtime.NewScheme()
+// 	t.Logf("loading fake client with objects: %+v", objects)
+// 	fakeDynamicClient := dynfake.NewSimpleDynamicClient(
+// 		scheme,
+// 		objects...,
+// 	)
+// 	// Create the resources service server.
+// 	resourcesServer := &Server{
+// 		// Use a client getter that returns a dynamic client prepped with the
+// 		// specified objects.
+// 		clientGetter: clientgetter.NewBuilder().
+// 			WithDynamic(fakeDynamicClient).
+// 			Build(),
+// 		// Use a corePackagesClientGetter that returns a client connected to our
+// 		// running test service.
+// 		corePackagesClientGetter: func() (pkgsGRPCv1alpha1.PackagesServiceClient, error) {
+// 			return pkgsGRPCv1alpha1.NewPackagesServiceClient(conn), nil
+// 		},
+// 		// For testing, define a kindToResource converter that doesn't require
+// 		// a rest mapper.
+// 		kindToResource: func(mapper meta.RESTMapper, gvk schema.GroupVersionKind) (schema.GroupVersionResource, meta.RESTScopeName, error) {
+// 			gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+// 			return gvr, meta.RESTScopeNameNamespace, nil
+// 		},
+// 	}
+// 	mux := http.NewServeMux()
+// 	mux.Handle(resourcesConnect.NewResourcesServiceHandler(resourcesServer))
+//
+// 	lisConnect := bufconn.Listen(bufSize)
+// 	bufConnectDialer := func(context.Context, string) (net.Conn, error) {
+// 		return lisConnect.Dial()
+// 	}
+// 	connConnect, err := grpc.DialContext(context.Background(), "bufnet", grpc.WithContextDialer(bufConnectDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
+// 	if err != nil {
+// 		t.Fatalf("Failed to dial bufnet: %v", err)
+// 	}
+// 	go func() {
+// 		if err := http.Serve(lisConnect, h2c.NewHandler(mux, &http2.Server{})); err != nil {
+// 			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) {
+// 				return
+// 			}
+// 			log.Errorf("Error in test go routine: %+v", err)
+// 		}
+// 	}()
+// 	go func() {
+// 		if err := s.Serve(lis); err != nil {
+// 			// Only valid error should be when the listener is closed.
+// 			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) {
+// 				return
+// 			}
+// 			log.Errorf("Error in test go routine: %+v", err)
+// 		}
+// 	}()
+//
+// 	// Need to work out how to create a fake server for the connect stuff.
+// 	return v1alpha1connect.NewResourcesServiceClient(), fakeDynamicClient, func() {
+// 		conn.Close()
+// 		connConnect.Close()
+// 		lis.Close()
+// 		lisConnect.Close()
+// 	}
+// }
+//
+// func TestGetResources(t *testing.T) {
+// 	testCases := []struct {
+// 		name              string
+// 		request           *v1alpha1.GetResourcesRequest
+// 		withoutAuthz      bool
+// 		clusterObjects    []runtime.Object
+// 		expectedErrorCode codes.Code
+// 		expectedResources []*v1alpha1.GetResourcesResponse
+// 	}{
+// 		{
+// 			name: "it returns permission denied for a request without auth",
+// 			request: &v1alpha1.GetResourcesRequest{
+// 				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+// 					Context: &pkgsGRPCv1alpha1.Context{
+// 						Cluster:   "default",
+// 						Namespace: "default",
+// 					},
+// 					Identifier: "some-package",
+// 					Plugin:     fakePkgsPlugin,
+// 				},
+// 			},
+// 			withoutAuthz:      true,
+// 			expectedErrorCode: codes.PermissionDenied,
+// 		},
+// 		{
+// 			name: "it gets all resources for an installed app when the filter is empty",
+// 			request: &v1alpha1.GetResourcesRequest{
+// 				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+// 					Context: &pkgsGRPCv1alpha1.Context{
+// 						Cluster:   "default",
+// 						Namespace: "default",
+// 					},
+// 					Identifier: "some-package",
+// 					Plugin:     fakePkgsPlugin,
+// 				},
+// 			},
+// 			clusterObjects: []runtime.Object{
+// 				&apps.Deployment{
+// 					TypeMeta: metav1.TypeMeta{
+// 						Kind:       "Deployment",
+// 						APIVersion: "apps/v1",
+// 					},
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "some-deployment",
+// 						Namespace: "default",
+// 					},
+// 				},
+// 				&core.Service{
+// 					TypeMeta: metav1.TypeMeta{
+// 						Kind:       "Service",
+// 						APIVersion: "core/v1",
+// 					},
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "some-service",
+// 						Namespace: "default",
+// 					},
+// 				},
+// 			},
+// 			expectedErrorCode: codes.OK,
+// 			expectedResources: []*v1alpha1.GetResourcesResponse{
+// 				{
+// 					ResourceRef: &pkgsGRPCv1alpha1.ResourceRef{
+// 						ApiVersion: "apps/v1",
+// 						Kind:       "Deployment",
+// 						Name:       "some-deployment",
+// 						Namespace:  "default",
+// 					},
+// 				},
+// 				{
+// 					ResourceRef: &pkgsGRPCv1alpha1.ResourceRef{
+// 						ApiVersion: "core/v1",
+// 						Kind:       "Service",
+// 						Name:       "some-service",
+// 						Namespace:  "default",
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name: "it gets only requested resources for an installed app when the filter is specified",
+// 			request: &v1alpha1.GetResourcesRequest{
+// 				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+// 					Context: &pkgsGRPCv1alpha1.Context{
+// 						Cluster:   "default",
+// 						Namespace: "default",
+// 					},
+// 					Identifier: "some-package",
+// 					Plugin:     fakePkgsPlugin,
+// 				},
+// 				ResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
+// 					{
+// 						ApiVersion: "core/v1",
+// 						Kind:       "Service",
+// 						Name:       "some-service",
+// 						Namespace:  "default",
+// 					},
+// 				},
+// 			},
+// 			clusterObjects: []runtime.Object{
+// 				&apps.Deployment{
+// 					TypeMeta: metav1.TypeMeta{
+// 						Kind:       "Deployment",
+// 						APIVersion: "apps/v1",
+// 					},
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "some-deployment",
+// 						Namespace: "default",
+// 					},
+// 				},
+// 				&core.Service{
+// 					TypeMeta: metav1.TypeMeta{
+// 						Kind:       "Service",
+// 						APIVersion: "core/v1",
+// 					},
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "some-service",
+// 						Namespace: "default",
+// 					},
+// 				},
+// 			},
+// 			expectedErrorCode: codes.OK,
+// 			expectedResources: []*v1alpha1.GetResourcesResponse{
+// 				{
+// 					ResourceRef: &pkgsGRPCv1alpha1.ResourceRef{
+// 						ApiVersion: "core/v1",
+// 						Kind:       "Service",
+// 						Name:       "some-service",
+// 						Namespace:  "default",
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name: "it returns invalid argument if a requested resource isn't part of the installed package",
+// 			request: &v1alpha1.GetResourcesRequest{
+// 				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+// 					Context: &pkgsGRPCv1alpha1.Context{
+// 						Cluster:   "default",
+// 						Namespace: "default",
+// 					},
+// 					Identifier: "some-package",
+// 					Plugin:     fakePkgsPlugin,
+// 				},
+// 				ResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
+// 					{
+// 						ApiVersion: "core/v1",
+// 						Kind:       "Secret",
+// 						Name:       "some-secret",
+// 					},
+// 				},
+// 			},
+// 			clusterObjects: []runtime.Object{
+// 				&apps.Deployment{
+// 					TypeMeta: metav1.TypeMeta{
+// 						Kind:       "Deployment",
+// 						APIVersion: "apps/v1",
+// 					},
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "some-deployment",
+// 						Namespace: "default",
+// 					},
+// 				},
+// 			},
+// 			expectedErrorCode: codes.InvalidArgument,
+// 		},
+// 		{
+// 			name: "it returns invalid argument if request is to watch all packages implicitly (ie. empty resource refs filter in request)",
+// 			request: &v1alpha1.GetResourcesRequest{
+// 				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+// 					Context: &pkgsGRPCv1alpha1.Context{
+// 						Cluster:   "default",
+// 						Namespace: "default",
+// 					},
+// 					Identifier: "some-package",
+// 					Plugin:     fakePkgsPlugin,
+// 				},
+// 				Watch: true,
+// 			},
+// 			expectedErrorCode: codes.InvalidArgument,
+// 		},
+// 		{
+// 			name: "it gets requested resources from different namespaces when they belong to the installed package",
+// 			request: &v1alpha1.GetResourcesRequest{
+// 				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+// 					Context: &pkgsGRPCv1alpha1.Context{
+// 						Cluster:   "default",
+// 						Namespace: "default",
+// 					},
+// 					Identifier: "some-package",
+// 					Plugin:     fakePkgsPlugin,
+// 				},
+// 				ResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
+// 					{
+// 						ApiVersion: "core/v1",
+// 						Kind:       "Service",
+// 						Name:       "some-service",
+// 						Namespace:  "other-namespace",
+// 					},
+// 				},
+// 			},
+// 			clusterObjects: []runtime.Object{
+// 				&core.Service{
+// 					TypeMeta: metav1.TypeMeta{
+// 						Kind:       "Service",
+// 						APIVersion: "core/v1",
+// 					},
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "some-service",
+// 						Namespace: "other-namespace",
+// 					},
+// 				},
+// 			},
+// 			expectedErrorCode: codes.OK,
+// 			expectedResources: []*v1alpha1.GetResourcesResponse{
+// 				{
+// 					ResourceRef: &pkgsGRPCv1alpha1.ResourceRef{
+// 						ApiVersion: "core/v1",
+// 						Kind:       "Service",
+// 						Name:       "some-service",
+// 						Namespace:  "other-namespace",
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name: "it gets non-namespaced requested resources when they belong to the installed package",
+// 			request: &v1alpha1.GetResourcesRequest{
+// 				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+// 					Context: &pkgsGRPCv1alpha1.Context{
+// 						Cluster:   "default",
+// 						Namespace: "default",
+// 					},
+// 					Identifier: "some-package",
+// 					Plugin:     fakePkgsPlugin,
+// 				},
+// 				ResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
+// 					{
+// 						ApiVersion: "rbac/v1",
+// 						Kind:       "ClusterRole",
+// 						Name:       "some-cluster-role",
+// 					},
+// 				},
+// 			},
+// 			clusterObjects: []runtime.Object{
+// 				&rbac.ClusterRole{
+// 					TypeMeta: metav1.TypeMeta{
+// 						Kind:       "ClusterRole",
+// 						APIVersion: "rbac/v1",
+// 					},
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name: "some-cluster-role",
+// 					},
+// 				},
+// 			},
+// 			expectedErrorCode: codes.OK,
+// 			expectedResources: []*v1alpha1.GetResourcesResponse{
+// 				{
+// 					ResourceRef: &pkgsGRPCv1alpha1.ResourceRef{
+// 						ApiVersion: "rbac/v1",
+// 						Kind:       "ClusterRole",
+// 						Name:       "some-cluster-role",
+// 					},
+// 				},
+// 			},
+// 		},
+// 		// TODO(minelson): test a watch request also. I've spent quite a bit of
+// 		// time trying to do so by putting the call to `GetResources` in a go
+// 		// routine (and passing the results out via response and error channels)
+// 		// and then deleting the resources via the fake k8s client's object
+// 		// tracker. From the source code, this should trigger the watch event,
+// 		// but I didn't succeed (yet).
+// 	}
+//
+// 	ignoredUnexported := cmpopts.IgnoreUnexported(
+// 		v1alpha1.GetResourcesResponse{},
+// 		pkgsGRPCv1alpha1.ResourceRef{},
+// 	)
+// 	ignoreManifest := cmpopts.IgnoreFields(v1alpha1.GetResourcesResponse{}, "Manifest")
+//
+// 	for _, tc := range testCases {
+// 		t.Run(tc.name, func(t *testing.T) {
+// 			client, _, cleanup := getResourcesClient(t, tc.clusterObjects...)
+// 			defer cleanup()
+//
+// 			// Use a context with a timeout to ensure that if a test unexpectedly
+// 			// waits beyond expectations, we'll see the failure.
+// 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+// 			defer cancel()
+// 			if !tc.withoutAuthz {
+// 				log.Errorf("Appending authz token")
+// 				ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "some-auth-token")
+// 			}
+//
+// 			responseStream, err := client.GetResources(ctx, tc.request)
+// 			if err != nil {
+// 				t.Fatalf("%+v", err)
+// 			}
+//
+// 			var resources []*v1alpha1.GetResourcesResponse
+// 			for numResponses := 0; numResponses < len(tc.expectedResources); numResponses++ {
+// 				resource, err := responseStream.Recv()
+// 				if err == io.EOF {
+// 					break
+// 				}
+// 				if err != nil {
+// 					if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+// 						t.Fatalf("got: %s, want: %s, err: %+v", got, want, err)
+// 					}
+// 					// If it was an expected error, we continue to the next test.
+// 					return
+// 				}
+// 				resources = append(resources, resource)
+// 			}
+// 			err = responseStream.CloseSend()
+// 			if err != nil {
+// 				t.Fatalf("%+v", err)
+// 			}
+//
+// 			if got, want := resources, tc.expectedResources; !cmp.Equal(got, want, ignoredUnexported, ignoreManifest) {
+// 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoredUnexported, ignoreManifest))
+// 			}
+// 		})
+// 	}
+// }
 
 func TestGetServiceAccountNames(t *testing.T) {
 	testCases := []struct {
@@ -512,7 +521,7 @@ func TestGetServiceAccountNames(t *testing.T) {
 					Build(),
 			}
 
-			GetServiceAccountNamesResponse, err := s.GetServiceAccountNames(context.Background(), tc.request)
+			GetServiceAccountNamesResponse, err := s.GetServiceAccountNames(context.Background(), connect.NewRequest(tc.request))
 
 			if got, want := status.Code(err), tc.expectedStatusCode; got != want {
 				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
@@ -523,7 +532,7 @@ func TestGetServiceAccountNames(t *testing.T) {
 				if GetServiceAccountNamesResponse == nil {
 					t.Fatalf("got: nil, want: response")
 				} else {
-					if got, want := GetServiceAccountNamesResponse.ServiceaccountNames, tc.expectedResponse; !cmp.Equal(got, want, nil) {
+					if got, want := GetServiceAccountNamesResponse.Msg.ServiceaccountNames, tc.expectedResponse; !cmp.Equal(got, want, nil) {
 						t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, nil))
 					}
 				}

--- a/cmd/kubeapps-apis/server/server.go
+++ b/cmd/kubeapps-apis/server/server.go
@@ -333,6 +333,11 @@ func gatewayMux() (*runtime.ServeMux, error) {
 	return gwmux, nil
 }
 
+// UPTOHERE:
+// Seeing:
+// E0316 06:04:26.037244       1 server.go:351] Found :path="/grpc.health.v1.Health/Check"
+// E0316 06:04:26.037253       1 server.go:355] Matched a transitioned path
+// 2023/03/16 06:04:26 http2: server connection error from 127.0.0.1:39674: connection error: PROTOCOL_ERROR
 func match_transitioned_paths(paths []string) cmux.MatchWriter {
 	return func(w io.Writer, r io.Reader) bool {
 		if !hasHTTP2Preface(r) {

--- a/go.mod
+++ b/go.mod
@@ -128,6 +128,8 @@ require (
 	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/bufbuild/connect-go v1.5.2 // indirect
+	github.com/bufbuild/connect-grpchealth-go v1.0.0 // indirect
 	github.com/carvel-dev/semver/v4 v4.0.1-0.20230221220520-8090ce423695 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=
 github.com/bufbuild/connect-go v1.5.2 h1:G4EZd5gF1U1ZhhbVJXplbuUnfKpBZ5j5izqIwu2g2W8=
 github.com/bufbuild/connect-go v1.5.2/go.mod h1:GmMJYR6orFqD0Y6ZgX8pwQ8j9baizDrIQMm1/a6LnHk=
+github.com/bufbuild/connect-grpchealth-go v1.0.0 h1:33v883tL86jLomQT6R2ZYVYaI2cRkuUXvU30WfbQ/ko=
+github.com/bufbuild/connect-grpchealth-go v1.0.0/go.mod h1:6OEb4J3rh5+Wdvt4/muOIfZo1lt9cPU8ggwpsjBaZ3Y=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=

--- a/site/content/docs/latest/reference/manifests/kubeapps-local-dev-values.yaml
+++ b/site/content/docs/latest/reference/manifests/kubeapps-local-dev-values.yaml
@@ -10,8 +10,6 @@ frontend:
       http: 30000
 dashboard:
   replicaCount: 1
-  image:
-    tag: dev6
 postgresql:
   architecture: standalone
   auth:
@@ -21,8 +19,6 @@ postgresql:
       enabled: false
 kubeappsapis:
   replicaCount: 1
-  image:
-    tag: dev5
 ingress:
   enabled: true
   hostname: localhost

--- a/site/content/docs/latest/reference/manifests/kubeapps-local-dev-values.yaml
+++ b/site/content/docs/latest/reference/manifests/kubeapps-local-dev-values.yaml
@@ -22,7 +22,7 @@ postgresql:
 kubeappsapis:
   replicaCount: 1
   image:
-    tag: dev2
+    tag: dev5
 ingress:
   enabled: true
   hostname: localhost

--- a/site/content/docs/latest/reference/manifests/kubeapps-local-dev-values.yaml
+++ b/site/content/docs/latest/reference/manifests/kubeapps-local-dev-values.yaml
@@ -10,6 +10,8 @@ frontend:
       http: 30000
 dashboard:
   replicaCount: 1
+  image:
+    tag: dev6
 postgresql:
   architecture: standalone
   auth:
@@ -19,6 +21,8 @@ postgresql:
       enabled: false
 kubeappsapis:
   replicaCount: 1
+  image:
+    tag: dev2
 ingress:
   enabled: true
   hostname: localhost


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Transitions the core plugins gRPC service to use connect's grpc implementation. This does so in a way that I can transition services one by one without breaking main.

### Benefits

<!-- What benefits will be realized by the code change? -->

Enables transitioning gRPC services (and their gRPC-Web support) to the new library, given that the improbable one is no longer maintained.

### Possible drawbacks

This doesn't work with the grpc-gateway which provided a ReSTish version of the API which was useful for testing, but we don't actually use anywhere except for the readiness/liveness checks (and we provide no API guarantees for kubeapps-apis).

I've updated the readiness/liveness checks to use the standard grpc-health check instead (we can't yet use the built-in beta grpc health check, as it's only available for 1.23+).
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
