### PR TITLE
Update secret names for the postgresql secret.

### DIFF
--- a/script/makefiles/deploy-dev.mk
+++ b/script/makefiles/deploy-dev.mk
@@ -31,8 +31,8 @@ deploy-dependencies: deploy-dex deploy-openldap devel/localhost-cert.pem
 		--key ./devel/localhost-key.pem \
 		--cert ./devel/localhost-cert.pem
 	kubectl --kubeconfig=${CLUSTER_CONFIG} -n kubeapps create secret generic postgresql-db \
-		--from-literal=postgres-postgres-password=dev-only-fake-password \
-		--from-literal=postgres-password=dev-only-fake-password
+		--from-literal=postgres-password=dev-only-fake-password \
+		--from-literal=password=dev-only-fake-password
 
 deploy-dev-kubeapps:
 	helm --kubeconfig=${CLUSTER_CONFIG} upgrade --install kubeapps ./chart/kubeapps --namespace kubeapps --create-namespace \


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

While using the normal Makefile target to setup a dev env, I noticed it would fail because the postgresql db secret was missing the `password` data field. Not sure if the chart updated recently to include validation of the data even though we don't use it, but I've taken the opportunity to remove the `postgres-postgres-password` entry (don't remember why we ended up with that) and replace it with the missing `password` entry.

### Benefits

<!-- What benefits will be realized by the code change? -->
Dev environment setup works.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
