### PR TITLE
Ensure discovery cache can be written by client-go in the kubeappsapis service

### DIFF
--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -88,6 +88,9 @@ COPY --from=builder /fluxv2-packages-v1alpha1-plugin.so /plugins/fluxv2-packages
 COPY --from=builder /helm-packages-v1alpha1-plugin.so /plugins/helm-packages/
 COPY --from=builder /resources-v1alpha1-plugin.so /plugins/resources/
 
+# Ensure the container user will be able to write to the k8s discovery client cache.
+RUN mkdir -p /.kube/cache && chown 1001:1001 /.kube/cache
+
 EXPOSE 50051
 USER 1001
 ENTRYPOINT [ "/kubeapps-apis" ]


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Gives permission for the running process to write the k8s discovery cache when kubeapps-apis first communicates with the k8s api server.

This doesn't appear to affect users, but may be contributing to memory usage and potentially restarts.

Before this change, after deploying an app, the following would appear in the kubeapps-apis logs:

```
I0322 23:20:57.965475       1 cached_discovery.go:93] failed to write cache to /.kube/cache/discovery/10.96.0.1_443/batch/v1/serverresources.json due to mkdir /.kube: permission denied
I0322 23:20:57.965483       1 cached_discovery.go:93] failed to write cache to /.kube/cache/discovery/10.96.0.1_443/autoscaling/v2/serverresources.json due to mkdir /.kube: permission denied
I0322 23:20:57.965485       1 cached_discovery.go:93] failed to write cache to /.kube/cache/discovery/10.96.0.1_443/apiregistration.k8s.io/v1/serverresources.json due to mkdir /.kube: permission denied
I0322 23:20:57.965495       1 cached_discovery.go:93] failed to write cache to /.kube/cache/discovery/10.96.0.1_443/batch/v1beta1/serverresources.json due to mkdir /.kube: permission denied
I0322 23:20:57.965501       1 cached_discovery.go:93] failed to write cache to /.kube/cache/discovery/10.96.0.1_443/node.k8s.io/v1/serverresources.json due to mkdir /.kube: permission denied
I0322 23:20:57.965505       1 cached_discovery.go:93] failed to write cache to /.kube/cache/discovery/10.96.0.1_443/autoscaling/v1/serverresources.json due to mkdir /.kube: permission denied
I0322 23:20:57.965505       1 cached_discovery.go:93] failed to write cache to /.kube/cache/discovery/10.96.0.1_443/coordination.k8s.io/v1/serverresources.json due to mkdir /.kube: permission denied
I0322 23:20:57.965513       1 cached_discovery.go:93] failed to write cache to /.kube/cache/discovery/10.96.0.1_443/events.k8s.io/v1beta1/serverresources.json due to mkdir /.kube: permission denied
```

The client appears to work fine without a cache, but will be doing unnecessary work with each deploy (and we did in the past investigate an issue where memory was being consumed on each deploy resulting in kubeapps-apis restarts).

With this change, the above errors are no longer seen, and the cache can be verified with:

```
k -n kubeapps exec kubeapps-internal-kubeappsapis-545486f55f-8zj9h -- ls -al /.kube/cache/
total 20
drwxr-xr-x 1 1001 1001 4096 Mar 23 00:09 .
drwxr-xr-x 1 root root 4096 Mar 23 00:02 ..
drwxr-x--- 3 1001 root 4096 Mar 23 00:09 discovery
drwxr-x--- 3 1001 root 4096 Mar 23 00:10 http
```

### Benefits

<!-- What benefits will be realized by the code change? -->
Better resource usage and possibly less memory and restarts in some environments.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
