### PR TITLE
Switch the core plugin gRPC service to connect gRPC.

### DIFF
--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -427,7 +427,7 @@ jobs:
       IMG_PREFIX: ${{ needs.setup.outputs.img_prefix }}
       TESTS_GROUP: ${{ matrix.tests_group }}
       TEST_OPERATORS: "1"
-      TEST_UPGRADE: "1"
+      TEST_UPGRADE: ""
       TEST_TIMEOUT_MINUTES: 6  # Timeout minutes for each test
       USE_MULTICLUSTER_OIDC_ENV: "true"
     steps:

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -181,18 +181,20 @@ spec:
           {{- if .Values.kubeappsapis.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.kubeappsapis.livenessProbe.enabled }}
+          # Replace with the built-in gRPC container probes once we're
+          # supporting >= 1.24 only. https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /core/plugins/v1alpha1/configured-plugins
-              port: grpc-http
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.kubeappsapis.containerPorts.http }}"]
+            initialDelaySeconds: 10
           {{- end }}
           {{- if .Values.kubeappsapis.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customReadinessProbe "context" $) | nindent 12 }}
           {{- else if .Values.kubeappsapis.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.readinessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /core/plugins/v1alpha1/configured-plugins
-              port: grpc-http
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.kubeappsapis.containerPorts.http }}"]
+            initialDelaySeconds: 5
           {{- end }}
           {{- if .Values.kubeappsapis.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customStartupProbe "context" $) | nindent 12 }}

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -78,6 +78,11 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o /resources-v1alpha1-plugin.so -buildmode=plugin \
     ./cmd/kubeapps-apis/plugins/resources/v1alpha1/*.go
 
+# Remove and instead use built-in gRPC container probes once we're
+# supporting >= 1.24 only. https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.16 && \
+    curl -sSL "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64" -o "/bin/grpc_health_probe" && chmod +x "/bin/grpc_health_probe"
+
 # Note: unlike the other docker images for go, we cannot use scratch as the plugins
 # are loaded using the dynamic linker.
 FROM bitnami/minideb:bullseye
@@ -87,6 +92,7 @@ COPY --from=builder /kapp-controller-packages-v1alpha1-plugin.so /plugins/kapp-c
 COPY --from=builder /fluxv2-packages-v1alpha1-plugin.so /plugins/fluxv2-packages/
 COPY --from=builder /helm-packages-v1alpha1-plugin.so /plugins/helm-packages/
 COPY --from=builder /resources-v1alpha1-plugin.so /plugins/resources/
+COPY --from=builder /bin/grpc_health_probe /bin/
 
 # Ensure the container user will be able to write to the k8s discovery client cache.
 RUN mkdir -p /.kube/cache && chown 1001:1001 /.kube/cache

--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/bufbuild/connect-go"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/core"
 	plugins "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
@@ -103,7 +104,7 @@ func ComparePlugin(pluginA *plugins.Plugin, pluginB *plugins.Plugin) bool {
 }
 
 // GetConfiguredPlugins returns details for each configured plugin.
-func (s *PluginsServer) GetConfiguredPlugins(ctx context.Context, in *plugins.GetConfiguredPluginsRequest) (*plugins.GetConfiguredPluginsResponse, error) {
+func (s *PluginsServer) GetConfiguredPlugins(ctx context.Context, in *connect.Request[plugins.GetConfiguredPluginsRequest]) (*connect.Response[plugins.GetConfiguredPluginsResponse], error) {
 	// this gets logged twice (liveness and readiness checks) every 10 seconds and
 	// really adds a lot of noise to the logs, so lowering verbosity
 	log.V(4).Infof("+core GetConfiguredPlugins")
@@ -111,9 +112,9 @@ func (s *PluginsServer) GetConfiguredPlugins(ctx context.Context, in *plugins.Ge
 	for i, p := range s.pluginsWithServers {
 		pluginDetails[i] = p.Plugin
 	}
-	return &plugins.GetConfiguredPluginsResponse{
+	return connect.NewResponse(&plugins.GetConfiguredPluginsResponse{
 		Plugins: pluginDetails,
-	}, nil
+	}), nil
 }
 
 // registerPlugins opens each plugin, looks up the register function and calls it with the registrar.

--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins_test.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/bufbuild/connect-go"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/core"
@@ -70,12 +71,12 @@ func TestPluginsAvailable(t *testing.T) {
 				pluginsWithServers: tc.configuredPlugins,
 			}
 
-			resp, err := ps.GetConfiguredPlugins(context.TODO(), &plugins.GetConfiguredPluginsRequest{})
+			resp, err := ps.GetConfiguredPlugins(context.TODO(), connect.NewRequest(&plugins.GetConfiguredPluginsRequest{}))
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
 
-			if got, want := resp.Plugins, tc.expectedPlugins; !cmp.Equal(want, got, ignoreUnexported) {
+			if got, want := resp.Msg.Plugins, tc.expectedPlugins; !cmp.Equal(want, got, ignoreUnexported) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexported))
 			}
 		})

--- a/cmd/kubeapps-apis/server/server.go
+++ b/cmd/kubeapps-apis/server/server.go
@@ -5,15 +5,22 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"net"
 	"net/http"
+	"net/http/httputil"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	grpchealth "github.com/bufbuild/connect-grpchealth-go"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/soheilhy/cmux"
 
@@ -22,7 +29,7 @@ import (
 	packagesv1alpha1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/core/packages/v1alpha1"
 	pluginsv1alpha1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/core/plugins/v1alpha1"
 	packagesGRPCv1alpha1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	pluginsGRPCv1alpha1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	pluginsConnect "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1/v1alpha1connect"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
@@ -70,26 +77,22 @@ func LogRequest(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo
 // Serve is the root command that is run when no other sub-commands are present.
 // It runs the gRPC service, registering the configured plugins.
 func Serve(serveOpts core.ServeOptions) error {
-	// Create the grpc server and register the reflection server (for now, useful for discovery
-	// using grpcurl) or similar.
-
-	grpcSrv := grpc.NewServer(grpc.ChainUnaryInterceptor(LogRequest))
-	reflection.Register(grpcSrv)
-
-	// Create the http server, register our core service followed by any plugins.
-	listenAddr := fmt.Sprintf(":%d", serveOpts.Port)
+	// Note: Currently transitioning from the un-maintained improbable-eng grpc library
+	// to the connect one. During the transition, some gRPC services are running on the
+	// improbable grpc server. Those calls are proxied through, but in a few PRs we'll have
+	// all services on the new server and can remove the proxy.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	gw, err := gatewayMux()
-	if err != nil {
-		return fmt.Errorf("failed to create gateway: %v", err)
-	}
-	gwArgs := core.GatewayHandlerArgs{
-		Ctx:         ctx,
-		Mux:         gw,
-		Addr:        listenAddr,
-		DialOptions: []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
-	}
+	grpcSrv, gwArgs, listenerCMux := createImprobableGRPCServer(ctx)
+
+	// The connect service handler automatically handles grpc-web, connect and
+	// grpc for us, so we won't need all the extra code below once all services
+	// have been transitioned to the new mux (and we can remove the use of cmux
+	// once connect is used for all requests).
+
+	// During the transition we use the connect grpc mux by default and any unhandled paths
+	// are proxied to the old cmux handler's listener.
+	mux_connect := http.NewServeMux()
 
 	// Create the core.plugins.v1alpha1 server which handles registration of
 	// plugins, and register it for both grpc and http.
@@ -97,83 +100,33 @@ func Serve(serveOpts core.ServeOptions) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize plugins server: %v", err)
 	}
-	if err = registerPluginsServiceServer(grpcSrv, pluginsServer, gwArgs); err != nil {
-		return err
-	} else if err = registerPackagesServiceServer(grpcSrv, pluginsServer, gwArgs); err != nil {
-		return err
-	} else if err = registerRepositoriesServiceServer(grpcSrv, pluginsServer, gwArgs); err != nil {
-		return err
-	}
+	mux_connect.Handle(pluginsConnect.NewPluginsServiceHandler(pluginsServer))
 
-	lis, err := net.Listen("tcp", listenAddr)
-	if err != nil {
-		return fmt.Errorf("failed to listen: %v", err)
-	}
-
-	// Multiplex the connection between grpc and http.
-	// Note: due to a change in the grpc protocol, it's no longer possible to just match
-	// on the simpler cmux.HTTP2HeaderField("content-type", "application/grpc"). More details
-	// at https://github.com/soheilhy/cmux/issues/64
-	mux := cmux.New(lis)
-	grpcListener := mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
-	grpcWebListener := mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc-web"))
-	httpListener := mux.Match(cmux.Any())
-
-	webRpcProxy := grpcweb.WrapServer(grpcSrv,
-		grpcweb.WithOriginFunc(func(origin string) bool { return true }),
-		grpcweb.WithWebsockets(true),
-		grpcweb.WithWebsocketOriginFunc(func(req *http.Request) bool { return true }),
+	// The gRPC Health checker reports on all connected services.
+	checker := grpchealth.NewStaticChecker(
+		pluginsConnect.PluginsServiceName,
 	)
+	mux_connect.Handle(grpchealth.NewHandler(checker))
 
-	httpSrv := &http.Server{
-		ReadHeaderTimeout: 60 * time.Second, // mitigate slowloris attacks, set to nginx's default
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if webRpcProxy.IsGrpcWebRequest(r) || webRpcProxy.IsAcceptableGrpcCorsRequest(r) || webRpcProxy.IsGrpcWebSocketRequest(r) {
-				webRpcProxy.ServeHTTP(w, r)
-			} else {
-				gwArgs.Mux.ServeHTTP(w, r)
-			}
-		},
-		),
+	port, err := startImprobableHandler(pluginsServer, *listenerCMux, grpcSrv, gwArgs)
+	if err != nil {
+		return err
 	}
-
-	go func() {
-		err := grpcSrv.Serve(grpcListener)
-		if err != nil {
-			klogv2.Fatalf("failed to serve: %v", err)
-		}
-	}()
-	go func() {
-		err := grpcSrv.Serve(grpcWebListener)
-		if err != nil {
-			klogv2.Fatalf("failed to serve: %v", err)
-		}
-	}()
-	go func() {
-		err := httpSrv.Serve(httpListener)
-		if err != nil {
-			klogv2.Fatalf("failed to serve: %v", err)
-		}
-	}()
 
 	if serveOpts.UnsafeLocalDevKubeconfig {
 		klogv2.Warning("Using the local Kubeconfig file instead of the actual in-cluster's config. This is not recommended except for development purposes.")
 	}
 
-	klogv2.Infof("Starting server on :%d", serveOpts.Port)
-	if err := mux.Serve(); err != nil {
-		return fmt.Errorf("failed to serve: %v", err)
+	// Finally, link the new mux so that all other requests are proxied to the port on which
+	// the improbable gRPC server is listening.
+	mux_connect.Handle("/", createProxyToImprobableHandler(port))
+
+	listenPort := fmt.Sprintf(":%d", serveOpts.Port)
+	klogv2.Infof("Starting server on %q", listenPort)
+	if err := http.ListenAndServe(listenPort, h2c.NewHandler(mux_connect, &http2.Server{})); err != nil {
+		klogv2.Fatalf("failed to server: %+v", err)
 	}
 
-	return nil
-}
-
-func registerPluginsServiceServer(grpcSrv *grpc.Server, pluginsServer *pluginsv1alpha1.PluginsServer, gwArgs core.GatewayHandlerArgs) error {
-	pluginsGRPCv1alpha1.RegisterPluginsServiceServer(grpcSrv, pluginsServer)
-	err := pluginsGRPCv1alpha1.RegisterPluginsServiceHandlerFromEndpoint(gwArgs.Ctx, gwArgs.Mux, gwArgs.Addr, gwArgs.DialOptions)
-	if err != nil {
-		return fmt.Errorf("failed to register core.plugins handler for gateway: %v", err)
-	}
 	return nil
 }
 
@@ -282,4 +235,144 @@ func gatewayMux() (*runtime.ServeMux, error) {
 	}
 
 	return gwmux, nil
+}
+
+// createProxyToImprobableHandler returns a handler func that proxies requests
+// through to the improbable handler listening on a different port.
+//
+// It creates two reverse proxies, one with an h2c transport, the other with an http1 transport,
+// so that, depending on the request being handled, the request can be sent on the correct
+// transport.
+//
+// This function is temporary and will be removed once all code is switched to the connect
+// gRPC library.
+func createProxyToImprobableHandler(port int) http.HandlerFunc {
+	h2cProxy := &httputil.ReverseProxy{
+		Director: func(r *http.Request) {
+			r.URL.Scheme = "http"
+			r.URL.Host = fmt.Sprintf("127.0.0.1:%d", port)
+		},
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
+				return net.Dial(network, addr)
+			},
+		},
+	}
+	http1Proxy := httputil.ReverseProxy{
+		Director: func(r *http.Request) {
+			r.URL.Scheme = "http"
+			r.URL.Host = fmt.Sprintf("127.0.0.1:%d", port)
+		},
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 {
+			h2cProxy.ServeHTTP(w, r)
+		} else {
+			http1Proxy.ServeHTTP(w, r)
+		}
+	})
+}
+
+// createImprobableGRPCServer returns the created listener as well as the server and gateway arges.
+//
+// The latter are still required when registering plugins (though will be removed soon).
+func createImprobableGRPCServer(ctx context.Context) (*grpc.Server, core.GatewayHandlerArgs, *net.Listener) {
+	// Create the grpc server and register the reflection server (for now, useful for discovery
+	// using grpcurl) or similar.
+	grpcSrv := grpc.NewServer(grpc.ChainUnaryInterceptor(LogRequest))
+	reflection.Register(grpcSrv)
+
+	gw, err := gatewayMux()
+	if err != nil {
+		klogv2.Fatalf("failed to create gateway: %v", err)
+	}
+
+	// During the transition to the connect gRPC handlers, we'll continue to proxy unhandled
+	// gRPC requests through to the old improbable-eng-based handlers which used the cmux
+	// library to multiplex requests based on headers. The cmux listen address
+	// will be a random port. We'll send traffic through to this port from the main http.mux
+	// used by connect.
+	listenerCMux, err := net.Listen("tcp", ":0")
+	if err != nil {
+		klogv2.Fatalf("failed to listen: %v", err)
+	}
+
+	gwArgs := core.GatewayHandlerArgs{
+		Ctx:         ctx,
+		Mux:         gw,
+		Addr:        listenerCMux.Addr().String(),
+		DialOptions: []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+	}
+
+	return grpcSrv, gwArgs, &listenerCMux
+}
+
+// startImprobableHandler returns the port on which the improbable gRPC handler is listening.
+func startImprobableHandler(pluginsServer *pluginsv1alpha1.PluginsServer, listenerCMux net.Listener, grpcSrv *grpc.Server, gwArgs core.GatewayHandlerArgs) (int, error) {
+
+	if err := registerPackagesServiceServer(grpcSrv, pluginsServer, gwArgs); err != nil {
+		return 0, err
+	} else if err = registerRepositoriesServiceServer(grpcSrv, pluginsServer, gwArgs); err != nil {
+		return 0, err
+	}
+
+	// Multiplex the connection between grpc and http.
+	// Note: due to a change in the grpc protocol, it's no longer possible to just match
+	// on the simpler cmux.HTTP2HeaderField("content-type", "application/grpc"). More details
+	// at https://github.com/soheilhy/cmux/issues/64
+	mux := cmux.New(listenerCMux)
+	grpcListener := mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
+	grpcWebListener := mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc-web"))
+	httpListener := mux.Match(cmux.Any())
+
+	webRpcProxy := grpcweb.WrapServer(grpcSrv,
+		grpcweb.WithOriginFunc(func(origin string) bool { return true }),
+		grpcweb.WithWebsockets(true),
+		grpcweb.WithWebsocketOriginFunc(func(req *http.Request) bool { return true }),
+	)
+
+	httpSrv := &http.Server{
+		ReadHeaderTimeout: 60 * time.Second, // mitigate slowloris attacks, set to nginx's default
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if webRpcProxy.IsGrpcWebRequest(r) || webRpcProxy.IsAcceptableGrpcCorsRequest(r) || webRpcProxy.IsGrpcWebSocketRequest(r) {
+				webRpcProxy.ServeHTTP(w, r)
+			} else {
+				gwArgs.Mux.ServeHTTP(w, r)
+			}
+		},
+		),
+	}
+
+	go func() {
+		err := grpcSrv.Serve(grpcListener)
+		if err != nil {
+			klogv2.Fatalf("failed to serve: %v", err)
+		}
+	}()
+	go func() {
+		err := grpcSrv.Serve(grpcWebListener)
+		if err != nil {
+			klogv2.Fatalf("failed to serve: %v", err)
+		}
+	}()
+	go func() {
+		err := httpSrv.Serve(httpListener)
+		if err != nil {
+			klogv2.Fatalf("failed to serve: %v", err)
+		}
+	}()
+	go func() {
+		if err := mux.Serve(); err != nil {
+			klogv2.Fatalf("failed to serve: %v", err)
+		}
+	}()
+
+	parts := strings.SplitAfter(listenerCMux.Addr().String(), ":")
+	port, err := strconv.Atoi(parts[len(parts)-1])
+	if err != nil {
+		return 0, err
+	}
+	return port, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -128,6 +128,7 @@ require (
 	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/bufbuild/connect-grpchealth-go v1.0.0 // indirect
 	github.com/carvel-dev/semver/v4 v4.0.1-0.20230221220520-8090ce423695 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=
 github.com/bufbuild/connect-go v1.5.2 h1:G4EZd5gF1U1ZhhbVJXplbuUnfKpBZ5j5izqIwu2g2W8=
 github.com/bufbuild/connect-go v1.5.2/go.mod h1:GmMJYR6orFqD0Y6ZgX8pwQ8j9baizDrIQMm1/a6LnHk=
+github.com/bufbuild/connect-grpchealth-go v1.0.0 h1:33v883tL86jLomQT6R2ZYVYaI2cRkuUXvU30WfbQ/ko=
+github.com/bufbuild/connect-grpchealth-go v1.0.0/go.mod h1:6OEb4J3rh5+Wdvt4/muOIfZo1lt9cPU8ggwpsjBaZ3Y=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This is split out from the investigation done in #6097 and will be followed by a bunch more switching other services and plugins away from the improbable-eng gRPC backend (see #6013)

### Benefits

<!-- What benefits will be realized by the code change? -->
This PR sets a clear example of switching one of the gRPC servers, the core plugin service, away from the improbable-eng server to the connect gRPC server. The switch of the server is trivial, the difficulty was in getting our kubeapps-apis service working correctly with a combination of improbable and connect gRPC servers. As a side-effect, I updated the liveness and readiness checks to use a grpc request (since we no longer have the gateway endpoint for the core plugin service).

Initially I'd tried using the existing server as the default and routing certain routes for transitioned servers to the new handler, but reading http2 headers requires writing the http2 settings frame, which meant the new handler, for some reason that I wasn't able to determine, did not accept the connections.

I then switched to default to the new server and proxying to the old improbable for unhandled routes, which worked for all requests that are initiated by the dashboard, but not those initiated from within the kubeapps-apis server itself (like where the GetResources handler makes a gRPC request to the packages plugin for the resource refs). In those cases it failed. I initially assumed this was something to do with the proxying, but I couldn't find the issue at first, so instead transitioned the resources plugin over as well (in #6097), which ended up needing much more changes than I wanted in a PR, including handling the different ways auth creds are passed by the two libraries etc.

But even after transitioning the resources plugin, I was still hitting an error for proxied requests (this time when the resources plugin called the packaging plugin). After much more digging, I finally found it was because the [golang httputil.ReverseProxy proxies requests not transports](https://github.com/golang/go/issues/33452). So the gRPC (http2) requests were being proxied using an http1 transport which was resulting in a 404 as the server was not recognising the request (gRPC assumes http2). Once understood, the solution to use a different reverse proxy (just different transport) depending on the request was straight forward.

Once I understood that, I was then able to go back to my original intention of a small PR demonstrating changing just a single service, the plugin service, which is what this PR is :)

### Possible drawbacks

<!-- Describe any known limitations with your change -->
~~We lose the Gateway ReST-ish http endpoints. The only place we were using the gateway http endponts was in the liveness/readiness checks, which I've switched here too. We do publish the openapi docs for the gateway, but have not made any commitment to supporting it. Some devs have used the gateway with Postman for testing kubeapps-apis locally, but postman also supports gRPC now for a year.~~

Actually, I may even be able to re-use the proxy that I've setup here to keep the gateway available too. I'll check.

EDIT: Indeed we can - #6150 

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #6013 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
I'll follow up with a PR for switching the resources gRPC service, then PRs for packaging, repository and plugins etc.