### PR TITLE
Switch core packages to use connect.

### DIFF
--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
@@ -264,7 +264,8 @@ func (s *packagesServer) GetInstalledPackageResourceRefs(ctx context.Context, re
 	ctxForPlugin := updateContextWithAuthz(ctx, request.Header())
 	response, err := pluginWithServer.server.GetInstalledPackageResourceRefs(ctxForPlugin, request.Msg)
 	if err != nil {
-		return nil, status.Errorf(status.Convert(err).Code(), "Unable to get the resource refs for the package %q using the plugin %q: %v", request.Msg.InstalledPackageRef.Identifier, request.Msg.InstalledPackageRef.Plugin.Name, err)
+		// Plugins are still using gRPC here, not connect:
+		return nil, connect.NewError(connect.Code(status.Convert(err).Code()), fmt.Errorf("Unable to get the resource refs for the package %q using the plugin %q: %w", request.Msg.InstalledPackageRef.Identifier, request.Msg.InstalledPackageRef.Plugin.Name, err))
 	}
 
 	return connect.NewResponse(response), nil

--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
@@ -71,7 +71,7 @@ func (s packagesServer) GetAvailablePackageSummaries(ctx context.Context, reques
 	var pkgWithOffsets availableSummaryWithOffsets
 	for pkgWithOffsets = range summariesWithOffsets {
 		if pkgWithOffsets.err != nil {
-			return nil, pkgWithOffsets.err
+			return nil, connect.NewError(connect.Code(status.Convert(pkgWithOffsets.err).Code()), pkgWithOffsets.err)
 		}
 		pkgs = append(pkgs, pkgWithOffsets.availablePackageSummary)
 		categories = append(categories, pkgWithOffsets.categories...)
@@ -150,7 +150,7 @@ func (s packagesServer) GetInstalledPackageSummaries(ctx context.Context, reques
 	var pkgWithOffsets installedSummaryWithOffsets
 	for pkgWithOffsets = range summariesWithOffsets {
 		if pkgWithOffsets.err != nil {
-			return nil, pkgWithOffsets.err
+			return nil, connect.NewError(connect.Code(status.Code(pkgWithOffsets.err)), pkgWithOffsets.err)
 		}
 		pkgs = append(pkgs, pkgWithOffsets.installedPackageSummary)
 		if pageSize > 0 && len(pkgs) >= int(pageSize) {

--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages_test.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/bufbuild/connect-go"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
@@ -291,14 +292,17 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 			server := &packagesServer{
 				pluginsWithServers: tc.configuredPlugins,
 			}
-			availablePackageSummaries, err := server.GetAvailablePackageSummaries(context.Background(), tc.request)
+			availablePackageSummaries, err := server.GetAvailablePackageSummaries(context.Background(), connect.NewRequest(tc.request))
 
 			if got, want := status.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
+			if tc.statusCode != codes.OK {
+				return
+			}
 
 			if tc.statusCode == codes.OK {
-				if got, want := availablePackageSummaries, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
+				if got, want := availablePackageSummaries.Msg, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
 			}
@@ -365,14 +369,14 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 			server := &packagesServer{
 				pluginsWithServers: tc.configuredPlugins,
 			}
-			availablePackageDetail, err := server.GetAvailablePackageDetail(context.Background(), tc.request)
+			availablePackageDetail, err := server.GetAvailablePackageDetail(context.Background(), connect.NewRequest(tc.request))
 
 			if got, want := status.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
 			if tc.statusCode == codes.OK {
-				if got, want := availablePackageDetail, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
+				if got, want := availablePackageDetail.Msg, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
 			}
@@ -436,14 +440,14 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 			server := &packagesServer{
 				pluginsWithServers: tc.configuredPlugins,
 			}
-			installedPackageSummaries, err := server.GetInstalledPackageSummaries(context.Background(), tc.request)
+			installedPackageSummaries, err := server.GetInstalledPackageSummaries(context.Background(), connect.NewRequest(tc.request))
 
 			if got, want := status.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
 			if tc.statusCode == codes.OK {
-				if got, want := installedPackageSummaries, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
+				if got, want := installedPackageSummaries.Msg, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
 			}
@@ -508,14 +512,14 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 			server := &packagesServer{
 				pluginsWithServers: tc.configuredPlugins,
 			}
-			installedPackageDetail, err := server.GetInstalledPackageDetail(context.Background(), tc.request)
+			installedPackageDetail, err := server.GetInstalledPackageDetail(context.Background(), connect.NewRequest(tc.request))
 
 			if got, want := status.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
 			if tc.statusCode == codes.OK {
-				if got, want := installedPackageDetail, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
+				if got, want := installedPackageDetail.Msg, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
 			}
@@ -585,14 +589,14 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 			server := &packagesServer{
 				pluginsWithServers: tc.configuredPlugins,
 			}
-			AvailablePackageVersions, err := server.GetAvailablePackageVersions(context.Background(), tc.request)
+			AvailablePackageVersions, err := server.GetAvailablePackageVersions(context.Background(), connect.NewRequest(tc.request))
 
 			if got, want := status.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
 			if tc.statusCode == codes.OK {
-				if got, want := AvailablePackageVersions, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
+				if got, want := AvailablePackageVersions.Msg, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
 			}
@@ -680,14 +684,14 @@ func TestCreateInstalledPackage(t *testing.T) {
 				pluginsWithServers: configuredPluginServers,
 			}
 
-			installedPkgResponse, err := server.CreateInstalledPackage(context.Background(), tc.request)
+			installedPkgResponse, err := server.CreateInstalledPackage(context.Background(), connect.NewRequest(tc.request))
 
 			if got, want := status.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
 			if tc.statusCode == codes.OK {
-				if got, want := installedPkgResponse, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
+				if got, want := installedPkgResponse.Msg, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
 			}
@@ -761,14 +765,14 @@ func TestUpdateInstalledPackage(t *testing.T) {
 				pluginsWithServers: configuredPluginServers,
 			}
 
-			updatedPkgResponse, err := server.UpdateInstalledPackage(context.Background(), tc.request)
+			updatedPkgResponse, err := server.UpdateInstalledPackage(context.Background(), connect.NewRequest(tc.request))
 
 			if got, want := status.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
 			if tc.statusCode == codes.OK {
-				if got, want := updatedPkgResponse, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
+				if got, want := updatedPkgResponse.Msg, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
 			}
@@ -834,7 +838,7 @@ func TestDeleteInstalledPackage(t *testing.T) {
 				pluginsWithServers: configuredPluginServers,
 			}
 
-			_, err := server.DeleteInstalledPackage(context.Background(), tc.request)
+			_, err := server.DeleteInstalledPackage(context.Background(), connect.NewRequest(tc.request))
 
 			if got, want := status.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
@@ -918,14 +922,14 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 				},
 			}
 
-			resourceRefs, err := server.GetInstalledPackageResourceRefs(context.Background(), tc.request)
+			resourceRefs, err := server.GetInstalledPackageResourceRefs(context.Background(), connect.NewRequest(tc.request))
 
 			if got, want := status.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
 			if tc.statusCode == codes.OK {
-				if got, want := resourceRefs, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
+				if got, want := resourceRefs.Msg, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
 			}

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
@@ -35,7 +35,6 @@ func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) 
 	if err != nil {
 		return nil, err
 	}
-	// Up TO HERE
 	opts.Mux.Handle(resourcesConnect.NewResourcesServiceHandler(svr))
 	return svr, nil
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This PR switches the core packages API to be using the connect gRPC for gRPC and gRPC-Web. The authz token is then set in the context when calling the (currently untransitioned) plugin implementations.

### Benefits

<!-- What benefits will be realized by the code change? -->
Step 2 of 4 done.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #6013 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
