### PR TITLE
Switch resources plugin to use connect core packages client and other clean-ups.

### DIFF
--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
@@ -51,6 +51,8 @@ type GRPCPluginRegistrationOptions struct {
 
 	// The mux used for the connect gRPC routing
 	Mux *http.ServeMux
+
+	LocalPort int
 }
 
 // PluginWithServer keeps a record of a GRPC server and its plugin detail.
@@ -185,6 +187,7 @@ func (s *PluginsServer) registerGRPC(p *plugin.Plugin, pluginDetail *plugins.Plu
 		ClientQPS:        serveOpts.QPS,
 		ClientBurst:      serveOpts.Burst,
 		Mux:              mux,
+		LocalPort:        serveOpts.Port,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("plug-in %q failed to register due to: %v", pluginDetail, err)

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
@@ -31,7 +31,7 @@ func init() {
 //
 //nolint:deadcode
 func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) (interface{}, error) {
-	svr, err := NewServer(opts.ConfigGetter, opts.ClientQPS, opts.ClientBurst, opts.PluginConfigPath, opts.ClustersConfig)
+	svr, err := NewServer(opts.ConfigGetter, opts.ClientQPS, opts.ClientBurst, opts.PluginConfigPath, opts.ClustersConfig, opts.LocalPort)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"sync"
 
 	"github.com/bufbuild/connect-go"
@@ -16,9 +15,7 @@ import (
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/resources/v1alpha1/common"
 	"github.com/vmware-tanzu/kubeapps/pkg/kube"
 
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -34,6 +31,7 @@ import (
 	"github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned/scheme"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/core"
 	pkgsGRPCv1alpha1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	pkgsConnectV1alpha1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1/v1alpha1connect"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/statuserror"
 )
@@ -54,7 +52,7 @@ type Server struct {
 
 	// corePackagesClientGetter holds a function to obtain the core.packages.v1alpha1
 	// client. It is similarly initialised in NewServer() below.
-	corePackagesClientGetter func() (pkgsGRPCv1alpha1.PackagesServiceClient, error)
+	corePackagesClientGetter func() (pkgsConnectV1alpha1.PackagesServiceClient, error)
 
 	// We keep a restmapper to cache discovery of REST mappings from GVK->GVR.
 	restMapper meta.RESTMapper
@@ -143,13 +141,8 @@ func NewServer(configGetter core.KubernetesConfigGetter, clientQPS float32, clie
 		clusterServiceAccountClientGetter: clusterServiceAccountClientGetter,
 		// Get the "in-cluster" client getter
 		localServiceAccountClientGetter: clientgetter.NewBackgroundClientProvider(clientgetter.Options{}, clientQPS, clientBurst),
-		corePackagesClientGetter: func() (pkgsGRPCv1alpha1.PackagesServiceClient, error) {
-			port := os.Getenv("PORT")
-			conn, err := grpc.Dial("localhost:"+port, grpc.WithTransportCredentials(insecure.NewCredentials()))
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "unable to dial to localhost grpc service: %s", err.Error())
-			}
-			return pkgsGRPCv1alpha1.NewPackagesServiceClient(conn), nil
+		corePackagesClientGetter: func() (pkgsConnectV1alpha1.PackagesServiceClient, error) {
+			return pkgsConnectV1alpha1.NewPackagesServiceClient(http.DefaultClient, "http://localhost/"), nil
 		},
 		restMapper: mapper,
 		kindToResource: func(mapper meta.RESTMapper, gvk schema.GroupVersionKind) (schema.GroupVersionResource, meta.RESTScopeName, error) {
@@ -212,18 +205,10 @@ func setupRestConfigForCluster(restConfig *rest.Config, cluster string, clusters
 }
 
 // GetResources returns the resources for an installed package.
-func (s *Server) GetResources(incomingCtx context.Context, r *connect.Request[v1alpha1.GetResourcesRequest], stream *connect.ServerStream[v1alpha1.GetResourcesResponse]) error {
+func (s *Server) GetResources(ctx context.Context, r *connect.Request[v1alpha1.GetResourcesRequest], stream *connect.ServerStream[v1alpha1.GetResourcesResponse]) error {
 	namespace := r.Msg.GetInstalledPackageRef().GetContext().GetNamespace()
 	cluster := r.Msg.GetInstalledPackageRef().GetContext().GetCluster()
 	log.InfoS("+resources GetResources ", "cluster", cluster, "namespace", namespace)
-
-	// Ensure the token is available for the packages plugins which are still
-	// using the grpc with context auth.
-	token, err := getTokenFromIncoming(incomingCtx, r.Header())
-	if err != nil {
-		return err
-	}
-	ctx := metadata.AppendToOutgoingContext(incomingCtx, "authorization", token)
 
 	// First we grab the resource references for the specified installed package.
 	coreClient, err := s.corePackagesClientGetter()
@@ -231,13 +216,14 @@ func (s *Server) GetResources(incomingCtx context.Context, r *connect.Request[v1
 		log.Errorf("unable to create core packages client: %+v", err)
 		return err
 	}
-	// TODO: Add the Authorization token to the header here when switching
-	// the packaging plugins. Currently it's being encoded into the
-	// context which is still checked by the core client (? Otherwise, how
-	// is the auth working)
-	refsResponse, err := coreClient.GetInstalledPackageResourceRefs(ctx, &pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsRequest{
+
+	newRequest := connect.NewRequest(&pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsRequest{
 		InstalledPackageRef: r.Msg.InstalledPackageRef,
 	})
+	newRequest.Header().Set("Authorization", r.Header().Get("Authorization"))
+
+	refsResponse, err := coreClient.GetInstalledPackageResourceRefs(ctx, newRequest)
+
 	if err != nil {
 		log.Errorf("unable to query core packages client for installed package resource refs: %+v", err)
 		return err
@@ -250,11 +236,11 @@ func (s *Server) GetResources(incomingCtx context.Context, r *connect.Request[v1
 		if r.Msg.GetWatch() {
 			return status.Errorf(codes.InvalidArgument, "resource refs must be specified in request when watching resources")
 		}
-		resourcesToReturn = refsResponse.GetResourceRefs()
+		resourcesToReturn = refsResponse.Msg.GetResourceRefs()
 	} else {
 		for _, requestedRef := range r.Msg.GetResourceRefs() {
 			found := false
-			for _, pkgRef := range refsResponse.GetResourceRefs() {
+			for _, pkgRef := range refsResponse.Msg.GetResourceRefs() {
 				if resourceRefsEqual(pkgRef, requestedRef) {
 					found = true
 					break
@@ -290,9 +276,9 @@ func (s *Server) GetResources(incomingCtx context.Context, r *connect.Request[v1
 		if !r.Msg.GetWatch() {
 			var resource interface{}
 			if scopeName == meta.RESTScopeNameNamespace {
-				resource, err = dynamicClient.Resource(gvr).Namespace(ref.Namespace).Get(incomingCtx, ref.GetName(), metav1.GetOptions{})
+				resource, err = dynamicClient.Resource(gvr).Namespace(ref.Namespace).Get(ctx, ref.GetName(), metav1.GetOptions{})
 			} else {
-				resource, err = dynamicClient.Resource(gvr).Get(incomingCtx, ref.GetName(), metav1.GetOptions{})
+				resource, err = dynamicClient.Resource(gvr).Get(ctx, ref.GetName(), metav1.GetOptions{})
 			}
 			if err != nil {
 				return status.Errorf(codes.Internal, "unable to get resource referenced by %+v: %s", ref, err.Error())
@@ -310,9 +296,9 @@ func (s *Server) GetResources(incomingCtx context.Context, r *connect.Request[v1
 		}
 		var watcher watch.Interface
 		if scopeName == meta.RESTScopeNameNamespace {
-			watcher, err = dynamicClient.Resource(gvr).Namespace(ref.Namespace).Watch(incomingCtx, listOptions)
+			watcher, err = dynamicClient.Resource(gvr).Namespace(ref.Namespace).Watch(ctx, listOptions)
 		} else {
-			watcher, err = dynamicClient.Resource(gvr).Watch(incomingCtx, listOptions)
+			watcher, err = dynamicClient.Resource(gvr).Watch(ctx, listOptions)
 		}
 		if err != nil {
 			log.Errorf("unable to watch resource %v: %v", ref, err)

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -16,7 +16,6 @@ import (
 	"github.com/vmware-tanzu/kubeapps/pkg/kube"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -465,28 +464,6 @@ func (rw *ResourceWatcher) ResultChan() <-chan ResourceEvent {
 	}()
 
 	return rw.resultChan
-}
-
-// getTokenFromIncoming explicitly copies the authz from the
-// incoming context or headers so the caller can use it in the outgoing context
-// when making the outgoing call the core packaging API.
-func getTokenFromIncoming(ctx context.Context, hdrs http.Header) (string, error) {
-	notAllowedErr := status.Errorf(codes.PermissionDenied, "unable to get authorization from request context")
-
-	token := hdrs.Get("Authorization")
-	// Fall back to getting the token from the context metadata.
-	if token == "" {
-		md, ok := metadata.FromIncomingContext(ctx)
-		if !ok {
-			return "", notAllowedErr
-		}
-		if len(md["authorization"]) == 0 {
-			return "", notAllowedErr
-		}
-		token = md["authorization"][0]
-	}
-
-	return token, nil
 }
 
 func resourceRefsEqual(r1, r2 *pkgsGRPCv1alpha1.ResourceRef) bool {

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -102,7 +102,7 @@ func createRESTMapper(clientQPS float32, clientBurst int) (meta.RESTMapper, erro
 	return restmapper.NewDiscoveryRESTMapper(groupResources), nil
 }
 
-func NewServer(configGetter core.KubernetesConfigGetter, clientQPS float32, clientBurst int, pluginConfigPath string, clustersConfig kube.ClustersConfig) (*Server, error) {
+func NewServer(configGetter core.KubernetesConfigGetter, clientQPS float32, clientBurst int, pluginConfigPath string, clustersConfig kube.ClustersConfig, localPort int) (*Server, error) {
 	mapper, err := createRESTMapper(clientQPS, clientBurst)
 	if err != nil {
 		return nil, err
@@ -141,7 +141,7 @@ func NewServer(configGetter core.KubernetesConfigGetter, clientQPS float32, clie
 		// Get the "in-cluster" client getter
 		localServiceAccountClientGetter: clientgetter.NewBackgroundClientProvider(clientgetter.Options{}, clientQPS, clientBurst),
 		corePackagesClientGetter: func() (pkgsConnectV1alpha1.PackagesServiceClient, error) {
-			return pkgsConnectV1alpha1.NewPackagesServiceClient(http.DefaultClient, "http://localhost/"), nil
+			return pkgsConnectV1alpha1.NewPackagesServiceClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d/", localPort)), nil
 		},
 		restMapper: mapper,
 		kindToResource: func(mapper meta.RESTMapper, gvk schema.GroupVersionKind) (schema.GroupVersionResource, meta.RESTScopeName, error) {

--- a/dashboard/src/actions/installedpackages.test.tsx
+++ b/dashboard/src/actions/installedpackages.test.tsx
@@ -7,8 +7,6 @@ import {
   GetInstalledPackageSummariesResponse,
   InstalledPackageDetail,
   InstalledPackageReference,
-  InstalledPackageStatus,
-  InstalledPackageStatus_StatusReason,
   InstalledPackageSummary,
   ReconciliationOptions,
   VersionReference,
@@ -52,9 +50,9 @@ describe("fetches installed packages", () => {
   beforeEach(() => {
     requestInstalledPackageListMock = jest.fn(
       () =>
-        ({
-          installedPackageSummaries,
-        } as GetInstalledPackageSummariesResponse),
+      ({
+        installedPackageSummaries,
+      } as GetInstalledPackageSummariesResponse),
     );
     InstalledPackage.GetInstalledPackageSummaries = requestInstalledPackageListMock;
   });

--- a/dashboard/src/actions/installedpackages.test.tsx
+++ b/dashboard/src/actions/installedpackages.test.tsx
@@ -7,6 +7,8 @@ import {
   GetInstalledPackageSummariesResponse,
   InstalledPackageDetail,
   InstalledPackageReference,
+  InstalledPackageStatus,
+  InstalledPackageStatus_StatusReason,
   InstalledPackageSummary,
   ReconciliationOptions,
   VersionReference,
@@ -393,6 +395,38 @@ describe("rollbackInstalledPackage", () => {
       1,
     );
     await store.dispatch(rollbackInstalledPackageBadAction);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+describe("getInstalledPkgStatus", () => {
+  it("fetches the package and dispatches the status", async () => {
+    const installedPkgRef = {
+      context: { cluster: "default-c", namespace: "default-ns" },
+      identifier: "my-release",
+      plugin: { name: "bad-plugin", version: "0.0.1" } as Plugin,
+    } as InstalledPackageReference;
+    const status = {
+      reason: InstalledPackageStatus_StatusReason.INSTALLED,
+    } as InstalledPackageStatus;
+    const installedPackageDetail = { status } as InstalledPackageDetail;
+    InstalledPackage.GetInstalledPackageDetail = jest.fn().mockReturnValue({
+      installedPackageDetail,
+    });
+
+    const expectedActions = [
+      { type: getType(actions.installedpackages.requestInstalledPackageStatus) },
+      {
+        type: getType(actions.installedpackages.receiveInstalledPackageStatus),
+        payload: status,
+      },
+    ];
+
+    const getInstalledPkgStatusAction =
+      actions.installedpackages.getInstalledPkgStatus(installedPkgRef);
+    await store.dispatch(getInstalledPkgStatusAction);
+
+    expect(InstalledPackage.GetInstalledPackageDetail).toHaveBeenCalledWith(installedPkgRef);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/actions/installedpackages.test.tsx
+++ b/dashboard/src/actions/installedpackages.test.tsx
@@ -33,10 +33,6 @@ beforeEach(() => {
       ...initialState.config,
       namespace: "kubeapps-ns",
     },
-    kube: {
-      ...initialState.kube,
-      subscriptions: { "default-c/default-ns/my-release": {} } as any,
-    },
   } as Partial<IStoreState>);
 });
 
@@ -399,38 +395,6 @@ describe("rollbackInstalledPackage", () => {
       1,
     );
     await store.dispatch(rollbackInstalledPackageBadAction);
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-});
-
-describe("getInstalledPkgStatus", () => {
-  it("fetches the package and dispatches the status", async () => {
-    const installedPkgRef = {
-      context: { cluster: "default-c", namespace: "default-ns" },
-      identifier: "my-release",
-      plugin: { name: "bad-plugin", version: "0.0.1" } as Plugin,
-    } as InstalledPackageReference;
-    const status = {
-      reason: InstalledPackageStatus_StatusReason.INSTALLED,
-    } as InstalledPackageStatus;
-    const installedPackageDetail = { status } as InstalledPackageDetail;
-    InstalledPackage.GetInstalledPackageDetail = jest.fn().mockReturnValue({
-      installedPackageDetail,
-    });
-
-    const expectedActions = [
-      { type: getType(actions.installedpackages.requestInstalledPackageStatus) },
-      {
-        type: getType(actions.installedpackages.receiveInstalledPackageStatus),
-        payload: status,
-      },
-    ];
-
-    const getInstalledPkgStatusAction =
-      actions.installedpackages.getInstalledPkgStatus(installedPkgRef);
-    await store.dispatch(getInstalledPkgStatusAction);
-
-    expect(InstalledPackage.GetInstalledPackageDetail).toHaveBeenCalledWith(installedPkgRef);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/actions/installedpackages.test.tsx
+++ b/dashboard/src/actions/installedpackages.test.tsx
@@ -50,9 +50,9 @@ describe("fetches installed packages", () => {
   beforeEach(() => {
     requestInstalledPackageListMock = jest.fn(
       () =>
-      ({
-        installedPackageSummaries,
-      } as GetInstalledPackageSummariesResponse),
+        ({
+          installedPackageSummaries,
+        } as GetInstalledPackageSummariesResponse),
     );
     InstalledPackage.GetInstalledPackageSummaries = requestInstalledPackageListMock;
   });

--- a/dashboard/src/actions/installedpackages.ts
+++ b/dashboard/src/actions/installedpackages.ts
@@ -152,36 +152,6 @@ export function getInstalledPackage(
   };
 }
 
-export function getInstalledPkgStatus(
-  installedPackageRef?: InstalledPackageReference,
-): ThunkAction<Promise<void>, IStoreState, null, InstalledPackagesAction> {
-  return async (dispatch, getState) => {
-    const {
-      kube: { subscriptions },
-    } = getState();
-    const subscriptionId = `${installedPackageRef?.context?.cluster}/${installedPackageRef?.context?.namespace}/${installedPackageRef?.identifier}`;
-
-    // only get the status if the subscription is active, otherwise the component would have been unmounted
-    if (subscriptions[subscriptionId]) {
-      dispatch(requestInstalledPackageStatus());
-      try {
-        // Get the details of an installed package for the status.
-        const { installedPackageDetail } = await InstalledPackage.GetInstalledPackageDetail(
-          installedPackageRef,
-        );
-        dispatch(receiveInstalledPackageStatus(installedPackageDetail!.status!));
-      } catch (e: any) {
-        dispatch(
-          handleErrorAction(
-            e,
-            errorInstalledPackage(new FetchError("Unable to refresh installed package", [e])),
-          ),
-        );
-      }
-    }
-  };
-}
-
 export function deleteInstalledPackage(
   installedPackageRef: InstalledPackageReference,
 ): ThunkAction<Promise<boolean>, IStoreState, null, InstalledPackagesAction> {

--- a/dashboard/src/actions/installedpackages.ts
+++ b/dashboard/src/actions/installedpackages.ts
@@ -152,6 +152,28 @@ export function getInstalledPackage(
   };
 }
 
+export function getInstalledPkgStatus(
+  installedPackageRef?: InstalledPackageReference,
+): ThunkAction<Promise<void>, IStoreState, null, InstalledPackagesAction> {
+  return async dispatch => {
+    dispatch(requestInstalledPackageStatus());
+    try {
+      // Get the details of an installed package for the status.
+      const { installedPackageDetail } = await InstalledPackage.GetInstalledPackageDetail(
+        installedPackageRef,
+      );
+      dispatch(receiveInstalledPackageStatus(installedPackageDetail!.status!));
+    } catch (e: any) {
+      dispatch(
+        handleErrorAction(
+          e,
+          errorInstalledPackage(new FetchError("Unable to refresh installed package", [e])),
+        ),
+      );
+    }
+  };
+}
+
 export function deleteInstalledPackage(
   installedPackageRef: InstalledPackageReference,
 ): ThunkAction<Promise<boolean>, IStoreState, null, InstalledPackagesAction> {

--- a/dashboard/src/actions/kube.test.tsx
+++ b/dashboard/src/actions/kube.test.tsx
@@ -18,7 +18,6 @@ const mockStore = configureMockStore([thunk]);
 const makeStore = (operatorsEnabled: boolean) => {
   const state: IKubeState = {
     items: {},
-    subscriptions: {},
     kinds: {},
   };
   const config = operatorsEnabled ? { featureFlags: { operators: true } } : {};
@@ -85,7 +84,7 @@ describe("getResourceKinds", () => {
 });
 
 describe("getResources", () => {
-  it("dispatches a requestResources action with an onComplete that closes request when watching", () => {
+  it("dispatches a requestResources action", () => {
     const refs = [
       {
         apiVersion: "v1",
@@ -110,7 +109,6 @@ describe("getResources", () => {
           watch,
           handler: expect.any(Function),
           onError: expect.any(Function),
-          onComplete: expect.any(Function),
         },
       },
     ];
@@ -149,55 +147,6 @@ describe("getResources", () => {
     const handler = store.getActions()[0].payload.handler;
     handler(getResourcesResponse);
     expect(store.getActions()).toEqual(expectedHandlerActions);
-
-    const expectedCompletionActions = [
-      ...expectedHandlerActions,
-      {
-        type: getType(actions.kube.closeRequestResources),
-        payload: pkg,
-      },
-    ];
-    const onComplete = store.getActions()[0].payload.onComplete;
-    onComplete();
-    expect(store.getActions()).toEqual(expectedCompletionActions);
-  });
-
-  it("dispatches a requestResources action with an onComplete that does nothing when not watching", () => {
-    const refs = [
-      {
-        apiVersion: "v1",
-        kind: "Service",
-        name: "foo",
-        namespace: "default",
-      },
-    ] as APIResourceRef[];
-
-    const pkg = {
-      identifier: "test-pkg",
-    } as InstalledPackageReference;
-
-    const watch = false;
-
-    const expectedActions = [
-      {
-        type: getType(actions.kube.requestResources),
-        payload: {
-          pkg,
-          refs,
-          watch,
-          handler: expect.any(Function),
-          onError: expect.any(Function),
-          onComplete: expect.any(Function),
-        },
-      },
-    ];
-
-    store.dispatch(actions.kube.getResources(pkg, refs, watch));
-    expect(store.getActions()).toEqual(expectedActions);
-
-    const onComplete = store.getActions()[0].payload.onComplete;
-    onComplete();
-    expect(store.getActions()).toEqual(expectedActions);
   });
 });
 

--- a/dashboard/src/actions/kube.tsx
+++ b/dashboard/src/actions/kube.tsx
@@ -44,16 +44,11 @@ export const requestResources = createAction("REQUEST_RESOURCES", resolve => {
     watch: boolean,
     handler: (r: GetResourcesResponse) => void,
     onError: (e: Event) => void,
-    onComplete: () => void,
-  ) => resolve({ pkg, refs, watch, handler, onError, onComplete });
+  ) => resolve({ pkg, refs, watch, handler, onError });
 });
 
 export const receiveResourcesError = createAction("RECEIVE_RESOURCES_ERROR", resolve => {
   return (err: Error) => resolve(err);
-});
-
-export const closeRequestResources = createAction("CLOSE_REQUEST_RESOURCES", resolve => {
-  return (pkg: InstalledPackageReference) => resolve(pkg);
 });
 
 const allActions = [
@@ -61,7 +56,6 @@ const allActions = [
   receiveResourceError,
   requestResources,
   receiveResourcesError,
-  closeRequestResources,
   requestResourceKinds,
   receiveResourceKinds,
   receiveKindsError,
@@ -114,15 +108,6 @@ export function getResources(
         },
         (e: any) => {
           dispatch(receiveResourcesError(e));
-        },
-        () => {
-          // The onComplete handler should only dispatch a closeRequestResources
-          // action if this call to `getResources` is for watching. If it is not
-          // watching resources, the server will close the request automatically
-          // (and we have no book-keeping in the redux state).
-          if (watch) {
-            dispatch(closeRequestResources(pkg));
-          }
         },
       ),
     );

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -580,7 +580,6 @@ describe("AppView actions", () => {
           watch: false,
           handler: expect.any(Function),
           onError: expect.any(Function),
-          onComplete: expect.any(Function),
         },
       },
       {
@@ -591,7 +590,6 @@ describe("AppView actions", () => {
           watch: true,
           handler: expect.any(Function),
           onError: expect.any(Function),
-          onComplete: expect.any(Function),
         },
       },
     ]);
@@ -642,12 +640,7 @@ describe("AppView actions", () => {
           watch,
           handler: expect.any(Function),
           onError: expect.any(Function),
-          onComplete: expect.any(Function),
         },
-      },
-      {
-        type: getType(actions.kube.closeRequestResources),
-        payload: installedPackage.installedPackageRef,
       },
     ]);
   });

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -256,9 +256,7 @@ export default function AppView() {
     }
     if (refsToWatch.length > 0) {
       dispatch(actions.kube.getResources(installedPackageRef, refsToWatch, true));
-      return function cleanup() {
-        dispatch(actions.kube.closeRequestResources(installedPackageRef));
-      };
+      return () => {};
     }
     return () => {};
   }, [dispatch, selectedInstalledPkg?.installedPackageRef, appViewResourceRefs]);

--- a/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
+++ b/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
@@ -17,7 +17,6 @@ const makeStore = (resources: { [s: string]: IKubeItem<IResource> }) => {
   const state: IKubeState = {
     items: resources,
     kinds: initialKinds,
-    subscriptions: {},
   };
   return mockStore({ kube: state, config: { featureFlags: {} } } as Partial<IStoreState>);
 };

--- a/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
+++ b/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
@@ -17,7 +17,6 @@ const makeStore = (resources: { [s: string]: IKubeItem<IResource> }) => {
   const state: IKubeState = {
     items: resources,
     kinds: initialKinds,
-    subscriptions: {},
   };
   return mockStore({ kube: state, config: { featureFlags: {} } } as Partial<IStoreState>);
 };

--- a/dashboard/src/reducers/kube.test.ts
+++ b/dashboard/src/reducers/kube.test.ts
@@ -20,7 +20,6 @@ describe("kubeReducer", () => {
   beforeEach(() => {
     initialState = {
       items: {},
-      subscriptions: {},
       kinds: initialKinds,
     };
   });

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -393,7 +393,6 @@ export interface IKind {
 
 export interface IKubeState {
   items: { [s: string]: IKubeItem<IResource | IK8sList<IResource, {}>> };
-  subscriptions: { [s: string]: Subscription };
   // TODO(minelson): Remove kinds and kindsError once the operator support is
   // removed from the dashboard or replaced with a plugin.
   kinds: { [kind: string]: IKind };

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -26,7 +26,6 @@ import { FluxPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/flux
 import { HelmPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm_pb";
 import { KappControllerPackageRepositoryCustomDetail } from "gen/kubeappsapis/plugins/kapp_controller/packages/v1alpha1/kapp_controller_pb";
 import { IOperatorsState } from "reducers/operators";
-import { Subscription } from "rxjs";
 import { IAuthState } from "../reducers/auth";
 import { IClustersState } from "../reducers/cluster";
 import { IConfigState } from "../reducers/config";


### PR DESCRIPTION
### Description of the change

Removes the last redundant pieces of functionality after the switch to connect gRPC-Web. In particular:

- Switches the resources plugin to use the connect gRPC client rather than the non-connect one, so that the header auth can be used, which meant
- Remove the last use of auth in the go context and supporting function
-  Remove the `subscriptions` state in the dashboard, which was related to the non-connect gRPC-Web implementation that subscribed to events rather than using async/await.
- Remove redundant `closeRequestResources` action.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Completes the work for 6013

### Possible drawbacks

### Applicable issues

- fixes #6013 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
