### PR TITLE
Fix version for Github CLI

### DIFF
--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -38,7 +38,7 @@ env:
   GOLANG_VERSION: "1.19.8"
   HELM_VERSION_MIN: "v3.2.0"
   HELM_VERSION_STABLE: "v3.11.0"
-  GITHUB_VERSION: "2.27.2"
+  GITHUB_VERSION: "2.27.0"
   IMAGES_TO_PUSH: "apprepository-controller dashboard asset-syncer pinniped-proxy kubeapps-apis"
   # IMG_DEV_TAG is the tags used for the Kubeapps docker images. Ideally there should be an IMG_PROD_TAG
   # but its value is dynamic and GitHub actions doesn't support it in the `env` block, so it is generated


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

In the previous PR I changed the minor version of the GH CLI correctly, but failed to change the patch version, resulting in a release that does not exist:

https://github.com/vmware-tanzu/kubeapps/pull/6209/files#diff-5b6cd7ed775959abb6c5484c9dabb475d5bb5c55850de016832356722ec3f7f8R40-R41

### Benefits

Full-integration pipeline can download the GH CLI.
