### PR TITLE
At some point between the 0.2 release and the 0.7 the linux binary

### DIFF
--- a/.github/actions/srp-source-provenance/action.yml
+++ b/.github/actions/srp-source-provenance/action.yml
@@ -32,7 +32,7 @@ runs:
           curl https://srp-cli.s3.amazonaws.com/srp-cli-latest.tgz -o /tmp/srp-cli/srp-cli-latest.tgz
           tar xvzf /tmp/srp-cli/srp-cli-latest.tgz -C /tmp/srp-cli/
         else
-          wget "https://vmwaresaas.jfrog.io/artifactory/srp-tools/srpcli/${SRP_CLI_VERSION}/linux/srp" -O /tmp/srp-cli/srp
+          wget "https://vmwaresaas.jfrog.io/artifactory/srp-tools/srpcli/${SRP_CLI_VERSION}/linux-386/srp" -O /tmp/srp-cli/srp
         fi
         chmod +x /tmp/srp-cli/srp
         sudo mv /tmp/srp-cli/srp /usr/local/bin/.

--- a/.github/actions/srp-source-provenance/action.yml
+++ b/.github/actions/srp-source-provenance/action.yml
@@ -32,7 +32,7 @@ runs:
           curl https://srp-cli.s3.amazonaws.com/srp-cli-latest.tgz -o /tmp/srp-cli/srp-cli-latest.tgz
           tar xvzf /tmp/srp-cli/srp-cli-latest.tgz -C /tmp/srp-cli/
         else
-          wget "https://vmwaresaas.jfrog.io/artifactory/srp-tools/srpcli/${SRP_CLI_VERSION}/linux-386/srp" -O /tmp/srp-cli/srp
+          wget "https://vmwaresaas.jfrog.io/artifactory/srp-tools/srpcli/${SRP_CLI_VERSION}/linux-amd64/srp" -O /tmp/srp-cli/srp
         fi
         chmod +x /tmp/srp-cli/srp
         sudo mv /tmp/srp-cli/srp /usr/local/bin/.


### PR DESCRIPTION
has moved from /linux/ to /linux-amd64/


### Description of the change

Not clear to me why we were on the old 0.2 version, but the [0.2 version has a `/linux/` directory](https://vmwaresaas.jfrog.io/ui/native/srp-tools/srpcli/0.2.20220825211752-571e676-57/) while the [0.7 version has arch-specific directories](https://vmwaresaas.jfrog.io/ui/native/srp-tools/srpcli/0.7.2-20230418081227-67dbd9c-113).
