### PR TITLE
Revert and fix so that latest tag is used in dev chart PRs.

### DIFF
--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -123,7 +123,7 @@ replaceImage_latestToProduction() {
 
     # Replace image and tag from the values.yaml
     sed -i.bk -e '1h;2,$H;$!d;g' -re \
-    's/repository: '${currentImageEscaped}'\n    tag: latest/repository: '${targetImageEscaped}'\n    tag: '${tag}'/g' \
+    's/repository: '${currentImageEscaped}'\n    tag: latest/repository: '${targetImageEscaped}'\n/g' \
     "${FILE}"
     rm "${FILE}.bk"
 }
@@ -160,7 +160,7 @@ replaceImage_productionToLatest() {
 
     # Replace image and tag from the values.yaml
     sed -i.bk -e '1h;2,$H;$!d;g' -re \
-    's/repository: '${currentImageEscaped}'\n/repository: '${targetImageEscaped}'\n/g' \
+    's/repository: '${currentImageEscaped}'\n    tag: \S*/repository: '${targetImageEscaped}'\n    tag: latest/g' \
     "${FILE}"
     rm "${FILE}.bk"
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

After getting a couple of dev chart auto-created PRs like #6236, which are doing nothing except setting our development images from `latest` (which they should be in the dev chart) to a fixed version, I realised that in #6221 I'd actually updated the incorrect part of the script.

This PR fixes that, by ensuring that we don't refer to `tag` in `replaceImage_latestToProduction` since we don't have the production values of the tag currently (until we update to use the dockerhub API as per #6220) - this was the intended change of the previous PR - and reverts the unintended change that updated `replaceImage_productionToLatest` so that we again expect `latest` for our own images in the dev chart.

### Benefits

<!-- What benefits will be realized by the code change? -->
We're no longer bothered by noop PRs such as #6236 .

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
