### PR TITLE
GetAvailablePackageVersions returns non-semver versions unchanged

### DIFF
--- a/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go
@@ -363,6 +363,18 @@ func TestPackageAppVersionsSummary(t *testing.T) {
 			},
 			input_versions_in_summary: GetDefaultVersionsInSummary(),
 		},
+		{
+			name: "it just returns versions that are not semver without any filtering or ordering",
+			chart_versions: []models.ChartVersion{
+				{Version: "v12-main", AppVersion: DefaultAppVersion},
+				{Version: "v11-main", AppVersion: DefaultAppVersion},
+			},
+			version_summary: []*corev1.PackageAppVersion{
+				{PkgVersion: "v12-main", AppVersion: DefaultAppVersion},
+				{PkgVersion: "v11-main", AppVersion: DefaultAppVersion},
+			},
+			input_versions_in_summary: GetDefaultVersionsInSummary(),
+		},
 	}
 
 	opts := cmpopts.IgnoreUnexported(corev1.PackageAppVersion{})

--- a/script/makefiles/deploy-dev.mk
+++ b/script/makefiles/deploy-dev.mk
@@ -35,7 +35,7 @@ deploy-dependencies: deploy-dex deploy-openldap devel/localhost-cert.pem
 		--from-literal=password=dev-only-fake-password
 
 deploy-dev-kubeapps:
-	helm --kubeconfig=${CLUSTER_CONFIG} upgrade --install kubeapps bitnami/kubeapps --namespace kubeapps --create-namespace \
+	helm --kubeconfig=${CLUSTER_CONFIG} upgrade --install kubeapps ./chart/kubeapps --namespace kubeapps --create-namespace \
 		--values ./site/content/docs/latest/reference/manifests/kubeapps-local-dev-values.yaml \
 		--values ./site/content/docs/latest/reference/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
 		--values ./site/content/docs/latest/reference/manifests/kubeapps-local-dev-additional-kind-cluster.yaml \


### PR DESCRIPTION
### Description of the change

When Kubeapps was encountering Helm charts with non-semver versions, rather than just returning the versions as they are, we were implicitly converting them to the closest semver. This resulted in Kubeapps then not being able to upgrade to a different version once an app with a non-semver version was installed.

See #6099 for more detail.

### Benefits

If people choose to use non-semver versions, we don't block them from upgrading.

### Possible drawbacks

We were previously ignoring errors when creating semver versions whereas with this PR we now simply return all the versions as they were provided. This may change some untested behavior, though unlikely.

### Applicable issues

- fixes #6099 

### Additional information

Also fixes an accidental change to our dev environment Makefile (I'd accidentally committed a change in #6209 that had our dev environment installing the upstream bitnami chart rather than the dev kubeapps one).
