### PR TITLE
Initial Dockerfile for OCI catalog.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ IMG_MODIFIER ?=
 GO_PACKAGES = ./...
 # GO_FILES := $(shell find $(shell $(GO) list -f '{{.Dir}}' $(GO_PACKAGES)) -name \*.go)
 
-all: kubeapps/dashboard kubeapps/apprepository-controller kubeapps/asset-syncer kubeapps/pinniped-proxy kubeapps/kubeapps-apis
+all: kubeapps/dashboard kubeapps/apprepository-controller kubeapps/asset-syncer kubeapps/pinniped-proxy kubeapps/kubeapps-apis kubeapps/oci-catalog
 
 # TODO(miguel) Create Makefiles per component
 # TODO(mnelson) Or at least don't send the whole repo as the context for each project.

--- a/cmd/oci-catalog/Cargo.toml
+++ b/cmd/oci-catalog/Cargo.toml
@@ -12,6 +12,11 @@ prost = "0.11"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1"
 futures-core = "0.3"
+# To build a statically linked version, will need to use the rusttls rather than
+# OS-native, then compile for the linux-musl conditionally with something like
+# https://stackoverflow.com/a/75350455 in the Dockerfile to set a target
+# linux-musl target specific for the arch.
+# reqwest = { version ="0.11", default_features=false, features = ["rustls-tls"] }
 reqwest = "0.11"
 
 [build-dependencies]

--- a/cmd/oci-catalog/Cargo.toml
+++ b/cmd/oci-catalog/Cargo.toml
@@ -12,11 +12,6 @@ prost = "0.11"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1"
 futures-core = "0.3"
-# To build a statically linked version, will need to use the rusttls rather than
-# OS-native, then compile for the linux-musl conditionally with something like
-# https://stackoverflow.com/a/75350455 in the Dockerfile to set a target
-# linux-musl target specific for the arch.
-# reqwest = { version ="0.11", default_features=false, features = ["rustls-tls"] }
 reqwest = "0.11"
 
 [build-dependencies]

--- a/cmd/oci-catalog/Dockerfile
+++ b/cmd/oci-catalog/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2023 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+# syntax = docker/dockerfile:1
+
+FROM rust:1.68.2 as builder
+
+WORKDIR /oci-catalog
+ARG VERSION
+
+# Ensure protoc is available for the build.rs step.
+RUN apt-get update && apt-get -y install --no-install-recommends protobuf-compiler && rm -rf /var/lib/apt/lists/*
+
+# Create a release build of oci-catalog itself.
+COPY ./cmd/oci-catalog ./
+ENV OCI_CATALOG_VERSION=$VERSION
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/oci-catalog/target \
+    cargo build --release
+RUN --mount=type=cache,target=/oci-catalog/target \
+    cp /oci-catalog/target/release/oci-catalog /oci-catalog/oci-catalog
+
+FROM bitnami/minideb:bullseye
+RUN apt-get update && apt-get install -y ca-certificates libssl1.1 && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /oci-catalog/oci-catalog /oci-catalog
+USER 1001
+EXPOSE 50051
+CMD [ "/oci-catalog"]

--- a/cmd/oci-catalog/Dockerfile
+++ b/cmd/oci-catalog/Dockerfile
@@ -12,6 +12,12 @@ ARG VERSION
 RUN apt-get update && apt-get -y install --no-install-recommends protobuf-compiler && rm -rf /var/lib/apt/lists/*
 
 # Create a release build of oci-catalog itself.
+# To build a statically linked version, will need to use the rusttls rather than
+# OS-native,
+# reqwest = { version ="0.11", default_features=false, features = ["rustls-tls"] }
+# then build for the linux-musl conditionally with something like
+# https://stackoverflow.com/a/75350455 in the Dockerfile to set a target
+# linux-musl target specific for the arch.
 COPY ./cmd/oci-catalog ./
 ENV OCI_CATALOG_VERSION=$VERSION
 RUN --mount=type=cache,target=/usr/local/cargo/registry \

--- a/cmd/oci-catalog/src/main.rs
+++ b/cmd/oci-catalog/src/main.rs
@@ -103,7 +103,7 @@ impl OciCatalog for KubeappsOCICatalog {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let addr = "[::1]:50051".parse()?;
+    let addr = "0.0.0.0:50051".parse()?;
     let kubeapps_oci_catalog = KubeappsOCICatalog::default();
 
     Server::builder()


### PR DESCRIPTION
### Description of the change

Creating the Dockerfile for the stubbed service now so that we can start the process for getting an official image in the bitnami pipeline.

I'll have another attempt at a static build for a scratch image before making the request.

### Benefits

We can communicate a working Dockerfile for the official Bitnami image to be based on.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #6263

### Additional information

```
$ IMAGE_TAG=dev1 make kubeapps/oci-catalog
...
$ docker run -p 50051:50051 docker.io/kubeapps/oci-catalog:dev1 
```

then in a separate terminal
```
$  grpcurl -proto ./proto/ocicatalog.proto -d '{"repository": {"registry": "registry-1.docker.io"}}' -plaintext "127.0.0.1:50051" ocicatalog.OCICatalog.ListTagsForRepository
{
  "name": "tag-0"
}
{
  "name": "tag-1"
}
{
  "name": "tag-2"
}
{
  "name": "tag-3"
}
{
  "name": "tag-4"
}
{
  "name": "tag-5"
}
{
  "name": "tag-6"
}
{
  "name": "tag-7"
}
{
  "name": "tag-8"
}
{
  "name": "tag-9"
}
```
