### PR TITLE
Restructure to enable multiple providers. Add basic command options.

### DIFF
--- a/cmd/oci-catalog/Cargo.lock
+++ b/cmd/oci-catalog/Cargo.lock
@@ -3,6 +3,64 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +165,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "401a4694d2bf92537b6867d94de48c4842089645fdcdf6c71865b175d836e9c2"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +241,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -334,6 +453,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +552,18 @@ name = "ipnet"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "itertools"
@@ -547,7 +684,10 @@ dependencies = [
 name = "oci-catalog"
 version = "0.1.0"
 dependencies = [
+ "clap",
+ "env_logger",
  "futures-core",
+ "log",
  "prost",
  "reqwest",
  "tokio",
@@ -793,6 +933,8 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -946,6 +1088,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,6 +1132,15 @@ dependencies = [
  "redox_syscall",
  "rustix",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1218,6 +1375,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,6 +1504,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/cmd/oci-catalog/Cargo.toml
+++ b/cmd/oci-catalog/Cargo.toml
@@ -7,11 +7,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tonic = "0.9"
+clap = { version = "4.3", features = ["derive", "env"] }
+env_logger = "0.10"
+futures-core = "0.3"
+log = "0.4"
 prost = "0.11"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1"
-futures-core = "0.3"
+tonic = "0.9"
 reqwest = "0.11"
 
 [build-dependencies]

--- a/cmd/oci-catalog/build.rs
+++ b/cmd/oci-catalog/build.rs
@@ -1,7 +1,17 @@
 // Copyright 2023 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::env;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("proto/ocicatalog.proto")?;
+
+    // If the binary is built with the ENV var "OCI_CATALOG_VERSION",
+    // the value will be available at buildime. Otherwise, it becomes "devel"
+    // We use this ENV var to display a custom version when passing the "-- version"
+    // flag
+    let version = env::var("OCI_CATALOG_VERSION").unwrap_or("devel".to_string());
+    println!("cargo:rustc-env=OCI_CATALOG_VERSION={}", version);
+
     Ok(())
 }

--- a/cmd/oci-catalog/src/cli.rs
+++ b/cmd/oci-catalog/src/cli.rs
@@ -1,0 +1,34 @@
+// Copyright 2023 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap;
+
+#[derive(clap::Parser, Debug)]
+#[command(version = env!("OCI_CATALOG_VERSION"))]
+/// A service that returns catalog information for an OCI repository.
+///
+/// The OCI Catalog service uses a strategy pattern to enable listing catalog
+/// information for different OCI provider registries, until a standard is set
+/// for requesting namespaced repositories of a registry in the OCI Distribution
+/// specification.
+pub struct Options {
+    #[arg(
+        short = 'p',
+        long = "port",
+        env = "OCI_CATALOG_PORT",
+        default_value = "50001",
+        help = "Specify the port on which oci-catalog gRPC service listens."
+    )]
+    pub port: u16,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cli() {
+        use clap::CommandFactory;
+        Options::command().debug_assert();
+    }
+}

--- a/cmd/oci-catalog/src/main.rs
+++ b/cmd/oci-catalog/src/main.rs
@@ -1,8 +1,11 @@
 // Copyright 2023 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
-use tokio_stream::wrappers::ReceiverStream;
+use self::providers::OCICatalogSender;
+use clap::Parser;
+use log;
 use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 use tonic::{transport::Server, Request, Response, Status};
 
 // Ensure that the compiled proto API is available within a module
@@ -13,53 +16,11 @@ pub mod oci_catalog {
 use oci_catalog::oci_catalog_server::{OciCatalog, OciCatalogServer};
 use oci_catalog::{ListRepositoriesRequest, ListTagsRequest, Repository, Tag};
 
+mod cli;
+mod providers;
+
 #[derive(Debug, Default)]
 pub struct KubeappsOCICatalog {}
-
-// OCICatalogAPI is a trait that can be implemented by different providers.
-// Initially we'll provide a DockerHub implementation followed by Harbor and others.
-#[tonic::async_trait]
-pub trait OCICatalogAPI {
-    async fn send_repositories(tx: mpsc::Sender<Result<Repository, Status>>, request: &ListRepositoriesRequest);
-    async fn send_tags(tx: mpsc::Sender<Result<Tag, Status>>, request: &ListTagsRequest);
-}
-
-// TODO: Move to separate files once multiple implementation are available.
-#[derive(Debug, Default)]
-pub struct DockerHubAPI{}
-
-// Create trait
-#[tonic::async_trait]
-impl OCICatalogAPI for DockerHubAPI {
-    // Update to return a result so errors are handled properly.
-    async fn send_repositories(tx: mpsc::Sender<Result<Repository, Status>>, request: &ListRepositoriesRequest) {
-        // TODO: Stubbed with dockerhub API.
-        // let mut url = reqwest::Url::parse("https://hub.docker.com/v2/repositories/").unwrap();
-        // if !request.namespace.is_empty() {
-        //     url.set_path(&format!("/v2/namespace/{}/repositories/", request.namespace));
-        // }
-        // let client = reqwest::Client::builder().build().unwrap();
-        // let body = client.get(url).send().await.unwrap().text().await.unwrap();
-
-        // parse json and send.
-
-        // While still more pages, request and send.
-        for count in 0..10 {
-            tx.send(Ok(Repository {
-                registry: request.registry.clone(),
-                name: format!("repo-{}", count),
-            })).await.unwrap();
-        }
-    }
-
-    async fn send_tags(tx: mpsc::Sender<Result<Tag, Status>>, _request: &ListTagsRequest) {
-        for count in 0..10 {
-            tx.send(Ok(Tag {
-                name: format!("tag-{}", count),
-            })).await.unwrap();
-        }
-    }
-}
 
 #[tonic::async_trait]
 impl OciCatalog for KubeappsOCICatalog {
@@ -80,8 +41,9 @@ impl OciCatalog for KubeappsOCICatalog {
             // Have a trait which each registry plugin implements for matching a request.
             match request.get_ref().registry.as_str() {
                 "registry-1.docker.io" => {
-                    DockerHubAPI::send_repositories(tx, request.get_ref()).await;
-                },
+                    providers::dockerhub::DockerHubAPI::send_repositories(tx, request.get_ref())
+                        .await;
+                }
                 _ => {
                     unimplemented!()
                 }
@@ -90,12 +52,15 @@ impl OciCatalog for KubeappsOCICatalog {
         Ok(Response::new(ReceiverStream::new(rx)))
     }
 
-    async fn list_tags_for_repository(&self, request: Request<ListTagsRequest>) -> Result<Response<Self::ListTagsForRepositoryStream>, Status> {
+    async fn list_tags_for_repository(
+        &self,
+        request: Request<ListTagsRequest>,
+    ) -> Result<Response<Self::ListTagsForRepositoryStream>, Status> {
         let (tx, rx) = mpsc::channel(4);
 
         tokio::spawn(async move {
             // Possibly just use generic OCI API for listing tags.
-            DockerHubAPI::send_tags(tx, request.get_ref()).await;
+            providers::dockerhub::DockerHubAPI::send_tags(tx, request.get_ref()).await;
         });
         Ok(Response::new(ReceiverStream::new(rx)))
     }
@@ -103,13 +68,15 @@ impl OciCatalog for KubeappsOCICatalog {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let addr = "0.0.0.0:50051".parse()?;
+    env_logger::init();
+    let opt = cli::Options::parse();
+    let addr = ([0, 0, 0, 0], opt.port).into();
     let kubeapps_oci_catalog = KubeappsOCICatalog::default();
 
-    Server::builder()
+    let server = Server::builder()
         .add_service(OciCatalogServer::new(kubeapps_oci_catalog))
-        .serve(addr)
-        .await?;
-
+        .serve(addr);
+    log::info!("listening for gRPC requests at {}", addr);
+    server.await.expect("unexpected error while serving");
     Ok(())
 }

--- a/cmd/oci-catalog/src/providers/dockerhub.rs
+++ b/cmd/oci-catalog/src/providers/dockerhub.rs
@@ -1,0 +1,51 @@
+// Copyright 2023 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::OCICatalogSender;
+use super::{ListRepositoriesRequest, ListTagsRequest, Repository, Tag};
+use tokio::sync::mpsc;
+use tonic::Status;
+
+// TODO: Move to separate files once multiple implementation are available.
+#[derive(Debug, Default)]
+pub struct DockerHubAPI {}
+
+// Create trait
+#[tonic::async_trait]
+impl OCICatalogSender for DockerHubAPI {
+    // Update to return a result so errors are handled properly.
+    async fn send_repositories(
+        tx: mpsc::Sender<Result<Repository, Status>>,
+        request: &ListRepositoriesRequest,
+    ) {
+        // TODO: Stubbed with dockerhub API.
+        // let mut url = reqwest::Url::parse("https://hub.docker.com/v2/repositories/").unwrap();
+        // if !request.namespace.is_empty() {
+        //     url.set_path(&format!("/v2/namespace/{}/repositories/",
+        // request.namespace)); }
+        // let client = reqwest::Client::builder().build().unwrap();
+        // let body = client.get(url).send().await.unwrap().text().await.unwrap();
+
+        // parse json and send.
+
+        // While still more pages, request and send.
+        for count in 0..10 {
+            tx.send(Ok(Repository {
+                registry: request.registry.clone(),
+                name: format!("repo-{}", count),
+            }))
+            .await
+            .unwrap();
+        }
+    }
+
+    async fn send_tags(tx: mpsc::Sender<Result<Tag, Status>>, _request: &ListTagsRequest) {
+        for count in 0..10 {
+            tx.send(Ok(Tag {
+                name: format!("tag-{}", count),
+            }))
+            .await
+            .unwrap();
+        }
+    }
+}

--- a/cmd/oci-catalog/src/providers/mod.rs
+++ b/cmd/oci-catalog/src/providers/mod.rs
@@ -1,0 +1,21 @@
+// Copyright 2023 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{ListRepositoriesRequest, ListTagsRequest, Repository, Tag};
+use tokio::sync::mpsc;
+use tonic::Status;
+
+pub mod dockerhub;
+
+// OCICatalogSender is a trait that can be implemented by different providers.
+//
+// Initially we'll provide a DockerHub implementation followed by Harbor and
+// others.
+#[tonic::async_trait]
+pub trait OCICatalogSender {
+    async fn send_repositories(
+        tx: mpsc::Sender<Result<Repository, Status>>,
+        request: &ListRepositoriesRequest,
+    );
+    async fn send_tags(tx: mpsc::Sender<Result<Tag, Status>>, request: &ListTagsRequest);
+}


### PR DESCRIPTION
### Description of the change

Adds basic command options (`--help`, `--port`, `--version`).
Splits code out to enable multiple providers later.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #6263 

### Additional information

```
$ RUST_LOG=info cargo run -- --port 9876 
    Finished dev [unoptimized + debuginfo] target(s) in 0.37s
     Running `target/debug/oci-catalog --port 9876`
[2023-06-09T04:31:05Z INFO  oci_catalog] listening for gRPC requests at 0.0.0.0:9876
```