### PR TITLE
Replace stub request with real (non-authed) dockerhub request.

### DIFF
--- a/cmd/oci-catalog/Cargo.lock
+++ b/cmd/oci-catalog/Cargo.lock
@@ -315,11 +315,26 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -329,6 +344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -336,6 +352,34 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
 
 [[package]]
 name = "futures-sink"
@@ -350,15 +394,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -509,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -690,10 +746,14 @@ dependencies = [
  "log",
  "prost",
  "reqwest",
+ "rstest",
+ "serde",
+ "serde_json",
  "tokio",
  "tokio-stream",
  "tonic",
  "tonic-build",
+ "url",
 ]
 
 [[package]]
@@ -748,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
@@ -982,6 +1042,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,10 +1135,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+
+[[package]]
 name = "serde"
 version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.162"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
 
 [[package]]
 name = "serde_json"
@@ -1365,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/cmd/oci-catalog/Cargo.toml
+++ b/cmd/oci-catalog/Cargo.toml
@@ -12,10 +12,16 @@ env_logger = "0.10"
 futures-core = "0.3"
 log = "0.4"
 prost = "0.11"
+reqwest = "0.11"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1"
 tonic = "0.9"
-reqwest = "0.11"
+url = "2.4"
 
 [build-dependencies]
 tonic-build = "0.9"
+
+[dev-dependencies]
+rstest = "0.17.0"

--- a/cmd/oci-catalog/proto/ocicatalog.proto
+++ b/cmd/oci-catalog/proto/ocicatalog.proto
@@ -21,9 +21,12 @@ message ListRepositoriesRequest {
     // An optional namespace within which to list repositories.
     string namespace = 2;
 
+    // An optional list of content types to filter.
+    repeated string content_types = 3;
+
     // Perhaps switch to be a one-of, so when testing, can pass a token
     // directly? Though wouldn't want this to be used or available in prod.
-    string kubernetes_secret = 3;
+    string kubernetes_secret = 4;
     // Possibly send hint or specific API to use (ie. a custom harbor install
     // may not be recognisable from the URL, so the request will need to
     // specify that the harbor API should be used?).
@@ -34,7 +37,8 @@ message ListRepositoriesRequest {
 // Uniquely identifies an OCI repository.
 message Repository {
     string registry = 1;
-    string name = 2;
+    string namespace = 2;
+    string name = 3;
 }
 
 // ListTagsRequest


### PR DESCRIPTION
### Description of the change

Adds implementation of send_repositories for the dockerhub implementation, replacing the stub.

### Benefits

Actual results (see below).

### Applicable issues

- ref #6263 

### Additional information

Logs for request show two separate requests to hub.docker:
```
RUST_LOG=debug cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.52s
     Running `target/debug/oci-catalog`
[2023-06-13T01:54:29Z INFO  oci_catalog] listening for gRPC requests at 0.0.0.0:50001
[2023-06-13T01:54:33Z DEBUG oci_catalog::providers::dockerhub] requesting: https://hub.docker.com/v2/namespaces/bitnamicharts/repositories/?page_size=100&ordering=name&content_types=helm
[2023-06-13T01:54:33Z DEBUG reqwest::connect] starting new connection: https://hub.docker.com/
[2023-06-13T01:54:35Z DEBUG oci_catalog::providers::dockerhub] requesting: https://hub.docker.com/v2/namespaces/bitnamicharts/repositories/?content_types=helm&ordering=name&page=2&page_size=100

```

Request shows grpc streaming the full result.
```
grpcurl -proto ./proto/ocicatalog.proto -d '{"registry": "registry-1.docker.io", "namespace": "bitnamicharts", "content_types":["helm"]}' -plaintext "0.0.0.0:50001" ocicatalog.OCICatalog.ListRepositoriesForRegistry
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "airflow"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "apache"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "apisix"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "appsmith"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "argo-cd"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "argo-workflows"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "aspnet-core"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "cassandra"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "cert-manager"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "clickhouse"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "common"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "concourse"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "consul"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "contour"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "contour-operator"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "discourse"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "dokuwiki"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "drupal"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "ejbca"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "elasticsearch"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "etcd"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "external-dns"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "flink"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "fluent-bit"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "fluentd"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "flux"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "ghost"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "gitea"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "grafana"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "grafana-loki"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "grafana-mimir"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "grafana-operator"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "grafana-tempo"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "haproxy"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "harbor"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "influxdb"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "jaeger"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "jasperreports"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "jenkins"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "joomla"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "jupyterhub"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "kafka"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "keycloak"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "kiam"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "kibana"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "kong"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "kubeapps"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "kube-prometheus"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "kubernetes-event-exporter"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "kube-state-metrics"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "logstash"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "magento"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "mariadb"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "mariadb-galera"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "mastodon"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "matomo"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "mediawiki"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "memcached"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "metallb"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "metrics-server"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "minio"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "mongodb"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "mongodb-sharded"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "moodle"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "multus-cni"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "mxnet"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "mysql"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "nats"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "nginx"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "nginx-ingress-controller"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "node-exporter"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "oauth2-proxy"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "odoo"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "opencart"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "osclass"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "parse"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "phpbb"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "phpmyadmin"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "pinniped"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "postgresql"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "postgresql-ha"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "prestashop"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "prometheus"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "pytorch"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "rabbitmq"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "rabbitmq-cluster-operator"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "redis"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "redis-cluster"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "redmine"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "schema-registry"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "sealed-secrets"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "solr"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "sonarqube"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "spark"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "spring-cloud-dataflow"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "suitecrm"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "supabase"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "tensorflow-resnet"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "thanos"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "tomcat"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "vault"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "wavefront"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "wavefront-hpa-adapter"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "wavefront-prometheus-storage-adapter"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "whereabouts"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "wildfly"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "wordpress"
}
{
  "registry": "registry-1.docker.io",
  "namespace": "bitnamicharts",
  "name": "zookeeper"
}
```
