### PR TITLE
[OCI-Catalog] Improve error handling. Add provider strategy.

### DIFF
--- a/cmd/oci-catalog/proto/ocicatalog.proto
+++ b/cmd/oci-catalog/proto/ocicatalog.proto
@@ -59,6 +59,8 @@ message Repository {
 // extended in the future with other options.
 message ListTagsRequest {
     Repository repository = 1;
+
+    RegistryProvider registry_provider = 2;
 }
 
 // Tag

--- a/cmd/oci-catalog/proto/ocicatalog.proto
+++ b/cmd/oci-catalog/proto/ocicatalog.proto
@@ -11,6 +11,15 @@ service OCICatalog {
     rpc ListTagsForRepository(ListTagsRequest) returns (stream Tag);
 }
 
+// RegistryProvider
+//
+// Optionally specify the registry provider when known.
+enum RegistryProvider {
+    UNKNOWN = 0;
+    DOCKER_HUB = 1;
+    HARBOR = 2;
+}
+
 // ListRepositoriesRequest
 //
 // Request for listing repositories of a registry or a namespaced registry.
@@ -27,9 +36,12 @@ message ListRepositoriesRequest {
     // Perhaps switch to be a one-of, so when testing, can pass a token
     // directly? Though wouldn't want this to be used or available in prod.
     string kubernetes_secret = 4;
-    // Possibly send hint or specific API to use (ie. a custom harbor install
-    // may not be recognisable from the URL, so the request will need to
-    // specify that the harbor API should be used?).
+
+    // In self-hosted registry examples, such as a self-hosted Harbor registry,
+    // there will be no information in the URL that can be used to determine
+    // the provider (and hence, which strategy / API to use). The optional
+    // registry_provider field can be used to explicitly identify the provider.
+    RegistryProvider registry_provider = 5;
 }
 
 // Repository

--- a/cmd/oci-catalog/src/providers/dockerhub.rs
+++ b/cmd/oci-catalog/src/providers/dockerhub.rs
@@ -11,6 +11,7 @@ use tonic::Status;
 
 /// The default page size with which requests are sent to docker hub.
 const DEFAULT_PAGE_SIZE: u8 = 100;
+pub const PROVIDER_NAME: &str = "DockerHubAPI";
 
 #[derive(Serialize, Deserialize)]
 struct DockerHubV2Repository {
@@ -33,8 +34,13 @@ pub struct DockerHubAPI {}
 
 #[tonic::async_trait]
 impl OCICatalogSender for DockerHubAPI {
+    fn id(&self) -> &str {
+        PROVIDER_NAME
+    }
+
     // Update to return a result so errors are handled properly.
     async fn send_repositories(
+        &self,
         tx: mpsc::Sender<Result<Repository, Status>>,
         request: &ListRepositoriesRequest,
     ) {
@@ -99,7 +105,7 @@ impl OCICatalogSender for DockerHubAPI {
         }
     }
 
-    async fn send_tags(tx: mpsc::Sender<Result<Tag, Status>>, _request: &ListTagsRequest) {
+    async fn send_tags(&self, tx: mpsc::Sender<Result<Tag, Status>>, _request: &ListTagsRequest) {
         for count in 0..10 {
             tx.send(Ok(Tag {
                 name: format!("tag-{}", count),

--- a/cmd/oci-catalog/src/providers/mod.rs
+++ b/cmd/oci-catalog/src/providers/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2023 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::oci_catalog::RegistryProvider;
+
 use super::{ListRepositoriesRequest, ListTagsRequest, Repository, Tag};
 use tokio::sync::mpsc;
 use tonic::Status;
@@ -14,8 +16,70 @@ pub mod dockerhub;
 #[tonic::async_trait]
 pub trait OCICatalogSender {
     async fn send_repositories(
+        &self,
         tx: mpsc::Sender<Result<Repository, Status>>,
         request: &ListRepositoriesRequest,
     );
-    async fn send_tags(tx: mpsc::Sender<Result<Tag, Status>>, request: &ListTagsRequest);
+    async fn send_tags(&self, tx: mpsc::Sender<Result<Tag, Status>>, request: &ListTagsRequest);
+
+    // The id simply gives a way in tests to determine which provider
+    // has been selected.
+    fn id(&self) -> &str;
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProviderError;
+
+pub fn provider_for_request(
+    registry: String,
+    provider: RegistryProvider,
+) -> Result<Box<dyn OCICatalogSender + Send + Sync>, ProviderError> {
+    match provider {
+        RegistryProvider::DockerHub => Ok(Box::new(dockerhub::DockerHubAPI::default())),
+        _ => match registry {
+            r if r.ends_with("docker.io") => Ok(Box::new(dockerhub::DockerHubAPI::default())),
+            _ => Err(ProviderError),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::with_registry_provider(
+        "https://example.com",
+        RegistryProvider::DockerHub,
+        dockerhub::PROVIDER_NAME
+    )]
+    #[case::without_provider_but_matching_url(
+        "https://registry-x.docker.io",
+        RegistryProvider::Unknown,
+        dockerhub::PROVIDER_NAME
+    )]
+    #[case::without_provider_or_matching_registry(
+        "https://registry-x.dockers.io",
+        RegistryProvider::Unknown,
+        ""
+    )]
+    fn test_provider_for_request(
+        #[case] registry: String,
+        #[case] provider: RegistryProvider,
+        #[case] expected_id: &str,
+    ) {
+        let result = provider_for_request(registry, provider);
+
+        if expected_id == "" {
+            assert!(result.is_err());
+            return;
+        } else {
+            assert!(result.is_ok());
+        }
+
+        let provider = result.unwrap();
+
+        assert_eq!(provider.id(), expected_id);
+    }
 }


### PR DESCRIPTION
### Description of the change

After improving the error handling, this PR adds a strategy pattern for enabling the provider to be chosen based on the request.

### Benefits

Other providers can be added easily.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #6263 
