### PR TITLE
Ensure Kubeapps-APIs sends correct response codes. Fixes #6269

### DIFF
--- a/cmd/kubeapps-apis/plugins/pkg/statuserror/statuserror.go
+++ b/cmd/kubeapps-apis/plugins/pkg/statuserror/statuserror.go
@@ -4,8 +4,9 @@
 package statuserror
 
 import (
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"fmt"
+
+	"github.com/bufbuild/connect-go"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -16,13 +17,13 @@ func FromK8sError(verb, resource, identifier string, err error) error {
 		identifier = "all"
 	}
 	if errors.IsNotFound(err) {
-		return status.Errorf(codes.NotFound, "unable to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
+		return connect.NewError(connect.CodeNotFound, fmt.Errorf("unable to %s the %s '%s' due to '%w'", verb, resource, identifier, err))
 	} else if errors.IsForbidden(err) {
-		return status.Errorf(codes.PermissionDenied, "Forbidden to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
+		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("Forbidden to %s the %s '%s' due to '%v'", verb, resource, identifier, err))
 	} else if errors.IsUnauthorized(err) {
-		return status.Errorf(codes.Unauthenticated, "Authorization required to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
+		return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("Authorization required to %s the %s '%s' due to '%v'", verb, resource, identifier, err))
 	} else if errors.IsAlreadyExists(err) {
-		return status.Errorf(codes.AlreadyExists, "Cannot %s the %s '%s' due to '%v' as it already exists", verb, resource, identifier, err)
+		return connect.NewError(connect.CodeAlreadyExists, fmt.Errorf("Cannot %s the %s '%s' due to '%v' as it already exists", verb, resource, identifier, err))
 	}
-	return status.Errorf(codes.Internal, "unable to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
+	return connect.NewError(connect.CodeInternal, fmt.Errorf("unable to %s the %s '%s' due to '%v'", verb, resource, identifier, err))
 }

--- a/cmd/kubeapps-apis/plugins/pkg/statuserror/statuserror_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/statuserror/statuserror_test.go
@@ -4,8 +4,10 @@
 package statuserror
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/bufbuild/connect-go"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -26,7 +28,7 @@ func TestErrorByStatus(t *testing.T) {
 			"my-resource",
 			"",
 			status.Errorf(codes.InvalidArgument, "boom!"),
-			status.Errorf(codes.Internal, "unable to get the my-resource 'all' due to 'rpc error: code = InvalidArgument desc = boom!'"),
+			connect.NewError(connect.CodeInternal, fmt.Errorf("unable to get the my-resource 'all' due to 'rpc error: code = InvalidArgument desc = boom!'")),
 		},
 		{
 			"error msg for a single resources ",
@@ -34,7 +36,7 @@ func TestErrorByStatus(t *testing.T) {
 			"my-resource",
 			"my-id",
 			status.Errorf(codes.InvalidArgument, "boom!"),
-			status.Errorf(codes.Internal, "unable to get the my-resource 'my-id' due to 'rpc error: code = InvalidArgument desc = boom!'"),
+			connect.NewError(connect.CodeInternal, fmt.Errorf("unable to get the my-resource 'my-id' due to 'rpc error: code = InvalidArgument desc = boom!'")),
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces_test.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces_test.go
@@ -47,7 +47,7 @@ func TestCheckNamespaceExists(t *testing.T) {
 		request           *v1alpha1.CheckNamespaceExistsRequest
 		k8sError          error
 		expectedResponse  *v1alpha1.CheckNamespaceExistsResponse
-		expectedErrorCode codes.Code
+		expectedErrorCode connect.Code
 		existingObjects   []runtime.Object
 	}{
 		{
@@ -97,7 +97,7 @@ func TestCheckNamespaceExists(t *testing.T) {
 				Group:    "v1",
 				Resource: "namespaces",
 			}, "default", errors.New("Bang")),
-			expectedErrorCode: codes.PermissionDenied,
+			expectedErrorCode: connect.CodePermissionDenied,
 		},
 		{
 			name: "returns an internal error if k8s returns an unexpected error",
@@ -108,7 +108,7 @@ func TestCheckNamespaceExists(t *testing.T) {
 				},
 			},
 			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
-			expectedErrorCode: codes.Internal,
+			expectedErrorCode: connect.CodeInternal,
 		},
 	}
 
@@ -129,7 +129,7 @@ func TestCheckNamespaceExists(t *testing.T) {
 
 			response, err := s.CheckNamespaceExists(context.Background(), connect.NewRequest(tc.request))
 
-			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+			if got, want := connect.CodeOf(err), tc.expectedErrorCode; err != nil && got != want {
 				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
 			}
 			if tc.expectedErrorCode != 0 {
@@ -155,7 +155,7 @@ func TestCreateNamespace(t *testing.T) {
 		request           *v1alpha1.CreateNamespaceRequest
 		k8sError          error
 		expectedResponse  *v1alpha1.CreateNamespaceResponse
-		expectedErrorCode codes.Code
+		expectedErrorCode connect.Code
 		existingObjects   []runtime.Object
 		validator         func(action clientGoTesting.Action) (handled bool, ret runtime.Object, err error)
 	}{
@@ -208,7 +208,7 @@ func TestCreateNamespace(t *testing.T) {
 				Group:    "v1",
 				Resource: "namespaces",
 			}, "default", errors.New("Bang")),
-			expectedErrorCode: codes.PermissionDenied,
+			expectedErrorCode: connect.CodePermissionDenied,
 		},
 		{
 			name: "returns already exists if k8s returns an already exists error",
@@ -222,7 +222,7 @@ func TestCreateNamespace(t *testing.T) {
 				Group:    "v1",
 				Resource: "namespaces",
 			}, "default"),
-			expectedErrorCode: codes.AlreadyExists,
+			expectedErrorCode: connect.CodeAlreadyExists,
 		},
 		{
 			name: "returns an internal error if k8s returns an unexpected error",
@@ -233,7 +233,7 @@ func TestCreateNamespace(t *testing.T) {
 				},
 			},
 			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
-			expectedErrorCode: codes.Internal,
+			expectedErrorCode: connect.CodeInternal,
 		},
 	}
 
@@ -257,7 +257,7 @@ func TestCreateNamespace(t *testing.T) {
 
 			response, err := s.CreateNamespace(context.Background(), connect.NewRequest(tc.request))
 
-			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+			if got, want := connect.CodeOf(err), tc.expectedErrorCode; err != nil && got != want {
 				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
 			}
 			if tc.expectedErrorCode != 0 {
@@ -288,7 +288,7 @@ func TestGetNamespaceNames(t *testing.T) {
 		k8sError                error
 		requestHeaders          http.Header
 		expectedResponse        *v1alpha1.GetNamespaceNamesResponse
-		expectedErrorCode       codes.Code
+		expectedErrorCode       connect.Code
 		existingObjects         []runtime.Object
 	}{
 		{
@@ -334,13 +334,13 @@ func TestGetNamespaceNames(t *testing.T) {
 				Group:    "v1",
 				Resource: "namespaces",
 			}, "default", errors.New("Bang")),
-			expectedErrorCode: codes.PermissionDenied,
+			expectedErrorCode: connect.CodePermissionDenied,
 		},
 		{
 			name:              "returns an internal error if k8s returns an unexpected error",
 			request:           defaultRequest,
 			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
-			expectedErrorCode: codes.Internal,
+			expectedErrorCode: connect.CodeInternal,
 		},
 		{
 			name: "it should return the list of only active namespaces if accessible",
@@ -630,7 +630,7 @@ func TestGetNamespaceNames(t *testing.T) {
 
 			response, err := s.GetNamespaceNames(ctx, connect.NewRequest(tc.request))
 
-			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+			if got, want := connect.CodeOf(err), tc.expectedErrorCode; err != nil && got != want {
 				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
 			}
 			if tc.expectedErrorCode != 0 {


### PR DESCRIPTION
### Description of the change

When we switched to connect-grpc, we continued sending standard gRPC error codes from Kubeapps-APIs, and without more information, the [connect-gRPC machinery was converting these to code unknown](https://connect.build/docs/go/errors/#working-with-errors).

When we check that a user has authenticated successfully by getting the default namespace after the login dance, either an OK or a forbidden means the request was authenticated, unauthenticated means it was not. But instead the error was coming back with an unknown code and so Kubeapps was not recognising this as authenticated. This was affecting logins for users who do not have permission to get the default namespace (see #6269 for the workaround).

I reproduced this locally (though with token auth) and so before this change, the gRPC request to CheckNamespaceExists came bace with what *looks* like a permission denied response - but the [grpc-status code is 2 - which is unknown](https://grpc.github.io/grpc/core/md_doc_statuscodes.html):

```
grpc-message | rpc  error: code = PermissionDenied desc = Forbidden to get the Namespace  'default' due to 'namespaces "default" is forbidden: User  "system:serviceaccount:kubeapps:kubeapps-view" cannot get resource  "namespaces" in API group "" in the namespace "default"'
grpc-status | 2 <----- this is "Unknown"
```

After this change, the error arrives as a PermissionDenied as expected:
```
grpc-message | Forbidden  to get the Namespace 'default' due to 'namespaces "default" is  forbidden: User "system:serviceaccount:kubeapps:kubeapps-view" cannot  get resource "namespaces" in API group "" in the namespace "default"'
grpc-status | 7 <----- this is the "PermissionDenied" code
```
which Kubeapps happily recognises and assumes the user is now authenticated.

### Benefits

People can login without requiring RBAC to get the default namespace.

### Possible drawbacks
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #6269 

### Additional information

Although I was glad to find the fix here, I'm still uncertain why our CI integration tests did not pick this up, given that the intention is that we check login with an unprivileged user. I need to investigate that further.
