### PR TITLE
Switch CheckNamespaceExist to return a connect error as expected by client

### DIFF
--- a/cmd/kubeapps-apis/plugins/pkg/connecterror/connecterror.go
+++ b/cmd/kubeapps-apis/plugins/pkg/connecterror/connecterror.go
@@ -1,0 +1,29 @@
+// Copyright 2023 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+package connecterror
+
+import (
+	"fmt"
+
+	"github.com/bufbuild/connect-go"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+// FromK8sResourceError generates a grpc status error from a Kubernetes error
+// when querying a resource.
+func FromK8sError(verb, resource, identifier string, err error) error {
+	if identifier == "" {
+		identifier = "all"
+	}
+	if errors.IsNotFound(err) {
+		return connect.NewError(connect.CodeNotFound, fmt.Errorf("unable to %s the %s '%s' due to '%w'", verb, resource, identifier, err))
+	} else if errors.IsForbidden(err) {
+		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("Forbidden to %s the %s '%s' due to '%w'", verb, resource, identifier, err))
+	} else if errors.IsUnauthorized(err) {
+		return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("Authorization required to %s the %s '%s' due to '%w'", verb, resource, identifier, err))
+	} else if errors.IsAlreadyExists(err) {
+		return connect.NewError(connect.CodeAlreadyExists, fmt.Errorf("Cannot %s the %s '%s' due to '%w' as it already exists", verb, resource, identifier, err))
+	}
+	return connect.NewError(connect.CodeInternal, fmt.Errorf("unable to %s the %s '%s' due to '%w'", verb, resource, identifier, err))
+}

--- a/cmd/kubeapps-apis/plugins/pkg/connecterror/connecterror_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/connecterror/connecterror_test.go
@@ -1,0 +1,50 @@
+// Copyright 2023 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+package connecterror
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bufbuild/connect-go"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestErrorByStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		verb        string
+		resource    string
+		identifier  string
+		err         error
+		expectedErr error
+	}{
+		{
+			"error msg for all resources ",
+			"get",
+			"my-resource",
+			"",
+			status.Errorf(codes.InvalidArgument, "boom!"),
+			connect.NewError(connect.CodeInternal, fmt.Errorf("unable to get the my-resource 'all' due to 'rpc error: code = InvalidArgument desc = boom!'")),
+		},
+		{
+			"error msg for a single resources ",
+			"get",
+			"my-resource",
+			"my-id",
+			status.Errorf(codes.InvalidArgument, "boom!"),
+			connect.NewError(connect.CodeInternal, fmt.Errorf("unable to get the my-resource 'my-id' due to 'rpc error: code = InvalidArgument desc = boom!'")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := FromK8sError(tt.verb, tt.resource, tt.identifier, tt.err)
+			if got, want := err.Error(), tt.expectedErr.Error(); !cmp.Equal(want, got) {
+				t.Errorf("in %s: mismatch (-want +got):\n%s", tt.name, cmp.Diff(want, got))
+			}
+		})
+	}
+}

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	authorizationapi "k8s.io/api/authorization/v1"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/bufbuild/connect-go"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
+	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/connecterror"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/statuserror"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -30,7 +32,7 @@ func (s *Server) CheckNamespaceExists(ctx context.Context, r *connect.Request[v1
 
 	typedClient, err := s.clientGetter.Typed(r.Header(), cluster)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("unable to get the k8s client: '%w'", err))
 	}
 
 	_, err = typedClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
@@ -40,7 +42,7 @@ func (s *Server) CheckNamespaceExists(ctx context.Context, r *connect.Request[v1
 				Exists: false,
 			}), nil
 		}
-		return nil, statuserror.FromK8sError("get", "Namespace", namespace, err)
+		return nil, connecterror.FromK8sError("get", "Namespace", namespace, err)
 	}
 
 	return connect.NewResponse(&v1alpha1.CheckNamespaceExistsResponse{

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces_test.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces_test.go
@@ -47,7 +47,7 @@ func TestCheckNamespaceExists(t *testing.T) {
 		request           *v1alpha1.CheckNamespaceExistsRequest
 		k8sError          error
 		expectedResponse  *v1alpha1.CheckNamespaceExistsResponse
-		expectedErrorCode codes.Code
+		expectedErrorCode connect.Code
 		existingObjects   []runtime.Object
 	}{
 		{
@@ -97,7 +97,7 @@ func TestCheckNamespaceExists(t *testing.T) {
 				Group:    "v1",
 				Resource: "namespaces",
 			}, "default", errors.New("Bang")),
-			expectedErrorCode: codes.PermissionDenied,
+			expectedErrorCode: connect.CodePermissionDenied,
 		},
 		{
 			name: "returns an internal error if k8s returns an unexpected error",
@@ -108,7 +108,7 @@ func TestCheckNamespaceExists(t *testing.T) {
 				},
 			},
 			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
-			expectedErrorCode: codes.Internal,
+			expectedErrorCode: connect.CodeInternal,
 		},
 	}
 
@@ -129,7 +129,7 @@ func TestCheckNamespaceExists(t *testing.T) {
 
 			response, err := s.CheckNamespaceExists(context.Background(), connect.NewRequest(tc.request))
 
-			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+			if got, want := connect.CodeOf(err), tc.expectedErrorCode; err != nil && got != want {
 				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
 			}
 			if tc.expectedErrorCode != 0 {


### PR DESCRIPTION
### Description of the change

When we switched to connect-grpc, we continued sending standard gRPC error codes from Kubeapps-APIs, and without more information, the [connect-gRPC machinery was converting these to code unknown](https://connect.build/docs/go/errors/#working-with-errors).

When we check that a user has authenticated successfully by getting the default namespace after the login dance, either an OK or a forbidden means the request was authenticated, unauthenticated means it was not. But instead the error was coming back with an unknown code and so Kubeapps was not recognising this as authenticated. This was affecting logins for users who do not have permission to get the default namespace (see #6269 for the workaround).

I reproduced this locally (though with token auth) and so before this change, the gRPC request to CheckNamespaceExists came bace with what *looks* like a permission denied response - but the [grpc-status code is 2 - which is unknown](https://grpc.github.io/grpc/core/md_doc_statuscodes.html):

```
grpc-message | rpc  error: code = PermissionDenied desc = Forbidden to get the Namespace  'default' due to 'namespaces "default" is forbidden: User  "system:serviceaccount:kubeapps:kubeapps-view" cannot get resource  "namespaces" in API group "" in the namespace "default"'
grpc-status | 2 <----- this is "Unknown"
```

After this change, the error arrives as a PermissionDenied as expected:
```
grpc-message | Forbidden  to get the Namespace 'default' due to 'namespaces "default" is  forbidden: User "system:serviceaccount:kubeapps:kubeapps-view" cannot  get resource "namespaces" in API group "" in the namespace "default"'
grpc-status | 7 <----- this is the "PermissionDenied" code
```
which Kubeapps happily recognises and assumes the user is now authenticated.

### Benefits

People can login without requiring RBAC to get the default namespace.

### Possible drawbacks
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #6269 

### Additional information

Although I was glad to find the fix here, I'm still uncertain why our CI integration tests did not pick this up, given that the intention is that we check login with an unprivileged user. I need to investigate that further.

Also, this is a second attempt at fixing this after #6312 ended up touching too many call-sites. I'll then followup switching other call-sites and removing the old code.