### PR TITLE
Switch resources plugin over to connect error.

### DIFF
--- a/cmd/kubeapps-apis/plugins/pkg/connecterror/connecterror.go
+++ b/cmd/kubeapps-apis/plugins/pkg/connecterror/connecterror.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
-// FromK8sResourceError generates a grpc status error from a Kubernetes error
+// FromK8sResourceError generates a grpc connect error from a Kubernetes error
 // when querying a resource.
 func FromK8sError(verb, resource, identifier string, err error) error {
 	if identifier == "" {

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces.go
@@ -59,7 +59,7 @@ func (s *Server) CreateNamespace(ctx context.Context, r *connect.Request[v1alpha
 
 	typedClient, err := s.clientGetter.Typed(r.Header(), cluster)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("unable to get the k8s client: '%w'", err))
 	}
 
 	_, err = typedClient.CoreV1().Namespaces().Create(ctx, &core.Namespace{
@@ -73,7 +73,7 @@ func (s *Server) CreateNamespace(ctx context.Context, r *connect.Request[v1alpha
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {
-		return nil, statuserror.FromK8sError("get", "Namespace", namespace, err)
+		return nil, connecterror.FromK8sError("get", "Namespace", namespace, err)
 	}
 
 	return connect.NewResponse(&v1alpha1.CreateNamespaceResponse{}), nil

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces_test.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces_test.go
@@ -155,7 +155,7 @@ func TestCreateNamespace(t *testing.T) {
 		request           *v1alpha1.CreateNamespaceRequest
 		k8sError          error
 		expectedResponse  *v1alpha1.CreateNamespaceResponse
-		expectedErrorCode codes.Code
+		expectedErrorCode connect.Code
 		existingObjects   []runtime.Object
 		validator         func(action clientGoTesting.Action) (handled bool, ret runtime.Object, err error)
 	}{
@@ -208,7 +208,7 @@ func TestCreateNamespace(t *testing.T) {
 				Group:    "v1",
 				Resource: "namespaces",
 			}, "default", errors.New("Bang")),
-			expectedErrorCode: codes.PermissionDenied,
+			expectedErrorCode: connect.CodePermissionDenied,
 		},
 		{
 			name: "returns already exists if k8s returns an already exists error",
@@ -222,7 +222,7 @@ func TestCreateNamespace(t *testing.T) {
 				Group:    "v1",
 				Resource: "namespaces",
 			}, "default"),
-			expectedErrorCode: codes.AlreadyExists,
+			expectedErrorCode: connect.CodeAlreadyExists,
 		},
 		{
 			name: "returns an internal error if k8s returns an unexpected error",
@@ -233,7 +233,7 @@ func TestCreateNamespace(t *testing.T) {
 				},
 			},
 			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
-			expectedErrorCode: codes.Internal,
+			expectedErrorCode: connect.CodeInternal,
 		},
 	}
 
@@ -257,7 +257,7 @@ func TestCreateNamespace(t *testing.T) {
 
 			response, err := s.CreateNamespace(context.Background(), connect.NewRequest(tc.request))
 
-			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+			if got, want := connect.CodeOf(err), tc.expectedErrorCode; err != nil && got != want {
 				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
 			}
 			if tc.expectedErrorCode != 0 {


### PR DESCRIPTION

### Description of the change

Follows on from #6319, cleaning up the resources plugin so that it uses the connect error.

### Applicable issues

- ref #6269

### Additional information

PRs will follow for the helm and flux plugins, before removing the original status error code.