### PR TITLE
Switch flux plugin over to connect errors.

### DIFF
--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/chart_cache.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/chart_cache.go
@@ -13,12 +13,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bufbuild/connect-go"
 	"github.com/go-redis/redis/v8"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/pkgutils"
 	"github.com/vmware-tanzu/kubeapps/pkg/chart/models"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -577,7 +576,7 @@ func (c *ChartCache) String() string {
 func (c *ChartCache) fromKey(key string) (namespace, chartID, chartVersion string, err error) {
 	parts := strings.Split(key, KeySegmentsSeparator)
 	if len(parts) != 4 || parts[0] != "helmcharts" || len(parts[1]) == 0 || len(parts[2]) == 0 || len(parts[3]) == 0 {
-		return "", "", "", status.Errorf(codes.Internal, "invalid key [%s]", key)
+		return "", "", "", connect.NewError(connect.CodeInternal, fmt.Errorf("invalid key [%s]", key))
 	}
 	return parts[1], parts[2], parts[3], nil
 }
@@ -609,7 +608,7 @@ func (c *ChartCache) ExpectResync() (chan int, error) {
 	}()
 
 	if c.resyncCh != nil {
-		return nil, status.Errorf(codes.Internal, "ExpectSync() already called")
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("ExpectSync() already called"))
 	} else {
 		c.resyncCh = make(chan int, 1)
 		return c.resyncCh, nil

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common/utils_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common/utils_test.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func _TestRWMutexUtils(t *testing.T) {
+func TestRWMutexUtils(t *testing.T) {
 	rw := &sync.RWMutex{}
 
 	writeLocked := RWMutexWriteLocked(rw)

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common/utils_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common/utils_test.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func TestRWMutexUtils(t *testing.T) {
+func _TestRWMutexUtils(t *testing.T) {
 	rw := &sync.RWMutex{}
 
 	writeLocked := RWMutexWriteLocked(rw)

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -32,8 +32,6 @@ import (
 	"github.com/vmware-tanzu/kubeapps/pkg/dbutils"
 	httpclient "github.com/vmware-tanzu/kubeapps/pkg/http-client"
 	"github.com/vmware-tanzu/kubeapps/pkg/kube"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -1031,13 +1029,7 @@ func (s *Server) GetInstalledPackageResourceRefs(ctx context.Context, request *c
 	refs, err := resourcerefs.GetInstalledPackageResourceRefs(
 		request.Header(), types.NamespacedName{Name: identifier, Namespace: pkgRef.Context.Namespace}, fn)
 	if err != nil {
-		// TODO(minelson): Remove once 6269 is complete.
-		switch status.Code(err) {
-		case codes.NotFound:
-			return nil, connect.NewError(connect.CodeNotFound, err)
-		default:
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
+		return nil, err
 	} else {
 		return connect.NewResponse(&corev1.GetInstalledPackageResourceRefsResponse{
 			Context:      pkgRef.GetContext(),

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
@@ -38,9 +38,7 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *conn
 	pageSize := request.Msg.GetPaginationOptions().GetPageSize()
 	itemOffset, err := paginate.ItemOffsetFromPageToken(request.Msg.GetPaginationOptions().GetPageToken())
 	if err != nil {
-		// TODO(minelson): When 6269 is complete, this can just be returned as an
-		// err (as the paginate module will return connect errors).
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		return nil, err
 	}
 	// Assume the default cluster if none is specified
 	if cluster == "" {

--- a/cmd/kubeapps-apis/plugins/pkg/clientgetter/clients_provider.go
+++ b/cmd/kubeapps-apis/plugins/pkg/clientgetter/clients_provider.go
@@ -5,8 +5,10 @@ package clientgetter
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
+	"github.com/bufbuild/connect-go"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/core"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -99,12 +101,12 @@ func (cp ClientProvider) Dynamic(headers http.Header, cluster string) (dynamic.I
 func (cp ClientProvider) ControllerRuntime(headers http.Header, cluster string) (client.WithWatch, error) {
 	clientGetter, err := cp.GetClients(headers, cluster)
 	if err != nil {
-		code := codes.FailedPrecondition
+		code := connect.CodeFailedPrecondition
 		if status.Code(err) == codes.Unauthenticated {
 			// want to make sure we return same status in this case
-			code = codes.Unauthenticated
+			code = connect.CodeUnauthenticated
 		}
-		return nil, status.Errorf(code, "unable to build clients due to: %v", err)
+		return nil, connect.NewError(code, fmt.Errorf("unable to build clients due to: %w", err))
 	}
 	return clientGetter.ControllerRuntime()
 }

--- a/cmd/kubeapps-apis/plugins/pkg/paginate/paginate.go
+++ b/cmd/kubeapps-apis/plugins/pkg/paginate/paginate.go
@@ -4,10 +4,10 @@
 package paginate
 
 import (
+	"fmt"
 	"strconv"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"github.com/bufbuild/connect-go"
 )
 
 // PageOffsetFromPageToken converts a page token to an integer offset
@@ -23,8 +23,8 @@ func PageOffsetFromPageToken(pageToken string) (int, error) {
 	}
 	offset, err := strconv.ParseInt(pageToken, 10, 0)
 	if err != nil {
-		return 0, status.Errorf(codes.InvalidArgument, "unable to interpret page token %q: %v",
-			pageToken, err)
+		return 0, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unable to interpret page token %q: %w",
+			pageToken, err))
 	}
 	return int(offset), nil
 }

--- a/cmd/kubeapps-apis/plugins/pkg/paginate/paginate_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/paginate/paginate_test.go
@@ -6,8 +6,7 @@ package paginate
 import (
 	"testing"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"github.com/bufbuild/connect-go"
 )
 
 func TestPageOffsetFromPageToken(t *testing.T) {
@@ -20,7 +19,7 @@ func TestPageOffsetFromPageToken(t *testing.T) {
 	}
 
 	_, err = PageOffsetFromPageToken("not a number")
-	if got, want := status.Code(err), codes.InvalidArgument; got != want {
+	if got, want := connect.CodeOf(err), connect.CodeInvalidArgument; err != nil && got != want {
 		t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 	}
 }

--- a/cmd/kubeapps-apis/plugins/pkg/resourcerefs/resourcerefs_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/resourcerefs/resourcerefs_test.go
@@ -6,12 +6,11 @@ package resourcerefs
 import (
 	"testing"
 
+	"github.com/bufbuild/connect-go"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/resourcerefs/resourcerefstest"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func TestGetInstalledPackageResourceRefs(t *testing.T) {
@@ -31,11 +30,8 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 			resourceRefs, err := ResourceRefsFromManifest(
 				tc.ExistingReleases[0].Manifest,
 				tc.ExistingReleases[0].Namespace)
-			expectedStatusCode := tc.ExpectedErrStatusCode
-			if expectedStatusCode == 0 {
-				expectedStatusCode = codes.OK
-			}
-			if got, want := status.Code(err), expectedStatusCode; got != want {
+			expectedStatusCode := tc.ExpectedErrCode
+			if got, want := connect.CodeOf(err), expectedStatusCode; err != nil && got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 

--- a/cmd/kubeapps-apis/plugins/pkg/resourcerefs/resourcerefstest/testsetup.go
+++ b/cmd/kubeapps-apis/plugins/pkg/resourcerefs/resourcerefstest/testsetup.go
@@ -4,8 +4,8 @@
 package resourcerefstest
 
 import (
+	"github.com/bufbuild/connect-go"
 	corev1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	"google.golang.org/grpc/codes"
 )
 
 // this is done so that test scenarios can be re-used in another package (helm and flux plug-ins)
@@ -17,10 +17,10 @@ type TestReleaseStub struct {
 }
 
 type TestCase struct {
-	Name                  string
-	ExistingReleases      []TestReleaseStub
-	ExpectedResourceRefs  []*corev1.ResourceRef
-	ExpectedErrStatusCode codes.Code
+	Name                 string
+	ExistingReleases     []TestReleaseStub
+	ExpectedResourceRefs []*corev1.ResourceRef
+	ExpectedErrCode      connect.Code
 }
 
 var (
@@ -186,7 +186,7 @@ should not be :! parsed as yaml$
 `,
 				},
 			},
-			ExpectedErrStatusCode: codes.Internal,
+			ExpectedErrCode: connect.CodeInternal,
 		},
 		{
 			Name: "handles duplicate labels as helm does",
@@ -498,8 +498,8 @@ metadata:
 			},
 		},
 		{
-			Name:                  "returns a not found error if the helm release is not found (2)",
-			ExpectedErrStatusCode: codes.NotFound,
+			Name:            "returns a not found error if the helm release is not found (2)",
+			ExpectedErrCode: connect.CodeNotFound,
 		},
 		{
 			Name: "returns internal error if the yaml manifest cannot be parsed (2)",
@@ -514,7 +514,7 @@ should not be :! parsed as yaml$
 `,
 				},
 			},
-			ExpectedErrStatusCode: codes.Internal,
+			ExpectedErrCode: connect.CodeInternal,
 		},
 		{
 			Name: "handles duplicate labels in the manifest as helm does (2)",


### PR DESCRIPTION
### Description of the change

Second-last PR removing the use of the grpc status returns from kubeapps-apis. This PR switches the flux plugin over to use `connect.NewError`

### Applicable issues

- Ref #6269

### Additional information

Next and final PR switches shared helper libraries.