### PR TITLE
Small fixes for IRL test of VAC catalog index.

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_validation.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_validation.go
@@ -60,9 +60,6 @@ func (s *Server) ValidateRepository(appRepo *apprepov1alpha1.AppRepository, secr
 func getValidator(appRepo *apprepov1alpha1.AppRepository) (HttpValidator, error) {
 	if appRepo.Spec.Type == "oci" {
 		// For the OCI case, we want to validate that all the given repositories are valid
-		if len(appRepo.Spec.OCIRepositories) == 0 {
-			return nil, ErrEmptyOCIRegistry
-		}
 		return HelmOCIValidator{
 			AppRepo: appRepo,
 		}, nil
@@ -225,13 +222,13 @@ func getOCIAppRepositoryMediaType(client httpclient.Client, repoURL string, repo
 func ValidateOCIAppRepository(appRepo *apprepov1alpha1.AppRepository, cli httpclient.Client) (bool, error) {
 
 	repoURL := strings.TrimSuffix(strings.TrimSpace(appRepo.Spec.URL), "/")
-
 	// For the OCI case, if no repositories are listed then we validate that a
 	// catalog is available for the registry, otherwise we want to validate that
 	// all the listed repositories are valid
 	if len(appRepo.Spec.OCIRepositories) == 0 {
 		u, err := url.Parse(repoURL)
 		if err != nil {
+			log.Errorf("could not parse URL: %+v", err)
 			return false, err
 		}
 		oci := utils.OciAPIClient{AuthHeader: "", Url: u, NetClient: cli}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -1140,7 +1140,7 @@ func (s *Server) GetPackageRepositoryDetail(ctx context.Context, request *connec
 }
 
 func (s *Server) GetPackageRepositorySummaries(ctx context.Context, request *connect.Request[corev1.GetPackageRepositorySummariesRequest]) (*connect.Response[corev1.GetPackageRepositorySummariesResponse], error) {
-	log.Infof("+helm GetPackageRepositorySummaries [%v]", request)
+	log.Infof("+helm GetPackageRepositorySummaries [%v]", request.Msg.GetContext())
 
 	if summaries, err := s.repoSummaries(ctx, request.Header(), request.Msg.GetContext().GetCluster(), request.Msg.GetContext().GetNamespace()); err != nil {
 		return nil, err

--- a/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
+++ b/dashboard/src/components/Config/PkgRepoList/PkgRepoForm.tsx
@@ -1958,7 +1958,6 @@ export function PkgRepoForm(props: IPkgRepoFormProps) {
                           placeholder={"nginx, jenkins"}
                           value={ociRepositories || ""}
                           onChange={handleOCIRepositoriesChange}
-                          required={type === RepositoryStorageTypes.PACKAGE_REPOSITORY_STORAGE_OCI}
                         />
                       </CdsTextarea>
                     )}


### PR DESCRIPTION
### Description of the change

Two small fixes required when testing the VAC catalog for an OCI registry:
1. Ensure the UX no longer requires the filter field
2. Ensure in the backend the repositories are set before the CheckSum is calculated.

### Benefits

With this change, Kubeapps displays the full catalog from a VAC-published OCI registry.

- ref #6263

