### PR TITLE
Ensure craco build has enough heap space.

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm-run-all build-css compile-lang build-js",
     "build-css": "sass src/ --no-source-map && yarn run copy-clr",
-    "build-js": "craco build",
+    "build-js": "export NODE_OPTIONS=--max-old-space-size=4096 && craco build",
     "compile-lang": "formatjs compile-folder lang src/locales/ --ast --format simple",
     "copy-clr": "shx cp ./node_modules/@clr/ui/clr-ui-dark.min.css public/clr-ui-dark.min.css && shx cp node_modules/@clr/ui/clr-ui.min.css public/clr-ui.min.css && shx cp ./node_modules/@clr/ui/clr-ui-dark.min.css.map public/clr-ui-dark.min.css.map && shx cp ./node_modules/@clr/ui/clr-ui.min.css.map public/clr-ui.min.css.map",
     "eject": "craco eject",


### PR DESCRIPTION
### Description of the change

Ensures that the `craco build` step has enough heap space. I can reproduce the issue that CI sees by reducing the heap space and re-running:

```
% yarn build
yarn run v1.22.19
warning ../../package.json: No license field
$ npm-run-all build-css compile-lang build-js
warning ../../package.json: No license field
$ sass src/ --no-source-map && yarn run copy-clr
warning ../../package.json: No license field
$ shx cp ./node_modules/@clr/ui/clr-ui-dark.min.css public/clr-ui-dark.min.css && shx cp node_modules/@clr/ui/clr-ui.min.css public/clr-ui.min.css && shx cp ./node_modules/@clr/ui/clr-ui-dark.min.css.map public/clr-ui-dark.min.css.map && shx cp ./node_modules/@clr/ui/clr-ui.min.css.map public/clr-ui.min.css.map
warning ../../package.json: No license field
$ formatjs compile-folder lang src/locales/ --ast --format simple
warning ../../package.json: No license field
$ export NODE_OPTIONS=--max-old-space-size=256 && craco build
Creating an optimized production build...

<--- Last few GCs --->

[47979:0x158008000]     7400 ms: Scavenge (reduce) 251.8 (262.0) -> 251.2 (262.0) MB, 1.3 / 0.0 ms  (average mu = 0.230, current mu = 0.085) allocation failure 
[47979:0x158008000]     7406 ms: Scavenge (reduce) 252.2 (262.0) -> 251.3 (262.0) MB, 0.5 / 0.0 ms  (average mu = 0.230, current mu = 0.085) allocation failure 
[47979:0x158008000]     7408 ms: Scavenge (reduce) 252.2 (262.0) -> 251.4 (262.0) MB, 0.4 / 0.0 ms  (average mu = 0.230, current mu = 0.085) allocation failure 
```

### Benefits

Less friction getting things landed.

### Possible drawbacks

Could be a patch solution for a memory leak.

### Applicable issues

- ref #6052

