### PR TITLE
Changed baseUrl to use relative path to support URL subpath

### DIFF
--- a/dashboard/src/shared/KubeappsGrpcClient.ts
+++ b/dashboard/src/shared/KubeappsGrpcClient.ts
@@ -36,7 +36,7 @@ export class KubeappsGrpcClient {
       return await next(req);
     };
     this.transport = createGrpcWebTransport({
-      baseUrl: `/${URL.api.kubeappsapis}`,
+      baseUrl: `./${URL.api.kubeappsapis}`,
       interceptors: [auth],
     });
   }


### PR DESCRIPTION
### Description of the change
Fixes static `baseUrl: /...` to be relative `baseUrl: ./...`

### Benefits
Restores previous functionality of working behind url subpath aka ingress

### Possible drawbacks
Unknown

### Applicable issues

- fixes #6314

### Additional information
