### PR TITLE
Ensure token auth can be configured while oauthLoginURI is defined.

### DIFF
--- a/dashboard/src/components/LoginForm/LoginForm.test.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.test.tsx
@@ -174,8 +174,14 @@ describe("oauth login form", () => {
       ...defaultStore,
       config: {
         oauthLoginURI: "/sign/in",
+        authProxyEnabled: true,
       } as IConfigState,
     };
+    const checkCookieAuthentication = jest.fn().mockReturnValue({
+      then: jest.fn(() => false),
+      catch: jest.fn(() => false),
+    });
+    actions.auth.checkCookieAuthentication = checkCookieAuthentication;
     const wrapper = mountWrapper(getStore(state), <LoginForm />);
 
     expect(wrapper.find("input#token").exists()).toBe(false);
@@ -206,6 +212,7 @@ describe("oauth login form", () => {
       ...defaultStore,
       config: {
         authProxyEnabled: true,
+        oauthLoginURI: "/sign/in",
       } as IConfigState,
     };
     const checkCookieAuthentication = jest.fn().mockReturnValue({
@@ -232,9 +239,18 @@ describe("oauth login form", () => {
       config: {
         authProxySkipLoginPage: true,
         oauthLoginURI: "/sign/in",
+        authProxyEnabled: true,
       },
     };
-    mountWrapper(getStore(state), <LoginForm />);
+    const checkCookieAuthentication = jest.fn().mockReturnValue({
+      then: jest.fn(() => true),
+      catch: jest.fn(() => true),
+    });
+    actions.auth.checkCookieAuthentication = checkCookieAuthentication;
+
+    act(() => {
+      mountWrapper(getStore(state), <LoginForm />);
+    });
     expect(window.location.replace).toHaveBeenCalledWith("/sign/in");
   });
 });


### PR DESCRIPTION
### Description of the change

When switching from a container to a component with hooks, I missed that the prop was passed from the container as:

```
   oauthLoginURI: authProxyEnabled ? oauthLoginURI : "",
```

but with the component the oauthLoginURI was always defined.

### Benefits

Can configure token auth again

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #6187

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
