### PR TITLE
Ensure only single request for installed apps.

### DIFF
--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { deepClone } from "@cds/core/internal";
-import { act } from "@testing-library/react";
 import actions from "actions";
 import LoadingWrapper from "components/LoadingWrapper";
 import SearchFilter from "components/SearchFilter/SearchFilter";
@@ -18,16 +17,22 @@ import {
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins_pb";
 import context from "jest-plugin-context";
 import qs from "qs";
-import React from "react";
 import * as ReactRedux from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { Kube } from "shared/Kube";
-import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
+import {
+  defaultStore,
+  getStore,
+  initialState,
+  mountWrapper,
+  renderWithProviders,
+} from "shared/specs/mountWrapper";
 import { FetchError, IStoreState } from "shared/types";
 import Alert from "../js/Alert";
 import AppList from "./AppList";
 import AppListItem from "./AppListItem";
 import CustomResourceListItem from "./CustomResourceListItem";
+import { screen } from "@testing-library/react";
 
 let spyOnUseDispatch: jest.SpyInstance;
 const opActions = { ...actions.operators };
@@ -96,34 +101,73 @@ context("when changing props", () => {
     expect(wrapper.find(SearchFilter).prop("value")).toEqual("foo");
   });
 
-  it("should list apps in all namespaces", () => {
-    jest.spyOn(qs, "parse").mockReturnValue({
-      allns: "yes",
-    });
-    const wrapper = mountWrapper(
-      defaultStore,
-      <MemoryRouter initialEntries={["/foo?allns=yes"]}>
-        <AppList />
-      </MemoryRouter>,
-      false,
-    );
-    expect(wrapper.find("input[type='checkbox']")).toBeChecked();
-  });
-
   it("should fetch apps in all namespaces", async () => {
-    const state = deepClone(initialState) as IStoreState;
-    state.config.featureFlags = { ...initialState.config.featureFlags, operators: true };
-    const store = getStore(state);
     const fetchInstalledPackages = jest.fn();
     const getCustomResources = jest.fn();
     actions.installedpackages.fetchInstalledPackages = fetchInstalledPackages;
     actions.operators.getResources = getCustomResources;
-    const wrapper = mountWrapper(store, <AppList />);
-    act(() => {
-      wrapper.find("input[type='checkbox']").simulate("change");
+
+    renderWithProviders(<AppList />, {
+      preloadedState: {
+        clusters: {
+          currentCluster: "default-cluster",
+          clusters: {
+            "default-cluster": {
+              currentNamespace: "default",
+            },
+          },
+        },
+        config: {
+          featureFlags: {
+            operators: true,
+          },
+        },
+      },
+      initialEntries: ["/c/default-cluster/ns/default/apps?allns=no"],
     });
+
+    expect(fetchInstalledPackages).toHaveBeenCalledTimes(1);
+    expect(fetchInstalledPackages).toHaveBeenCalledWith("default-cluster", "default");
+    expect(getCustomResources).toHaveBeenCalledTimes(1);
+    expect(getCustomResources).toHaveBeenCalledWith("default-cluster", "default");
+
+    screen.getByRole("checkbox").click();
+
+    expect(fetchInstalledPackages).toHaveBeenCalledTimes(2);
     expect(fetchInstalledPackages).toHaveBeenCalledWith("default-cluster", "");
+    expect(getCustomResources).toHaveBeenCalledTimes(2);
     expect(getCustomResources).toHaveBeenCalledWith("default-cluster", "");
+  });
+
+  it("should not requests apps if namespace not set", async () => {
+    // If a page is reloaded, the namespace is not yet set in the state, so sending
+    // off a request at that point returns apps for all namespaces.
+    const fetchInstalledPackages = jest.fn();
+    const getCustomResources = jest.fn();
+    actions.installedpackages.fetchInstalledPackages = fetchInstalledPackages;
+    actions.operators.getResources = getCustomResources;
+
+    renderWithProviders(<AppList />, {
+      preloadedState: {
+        clusters: {
+          currentCluster: "default-cluster",
+          clusters: {
+            "default-cluster": {
+              currentNamespace: "",
+            },
+          },
+        },
+        config: {
+          featureFlags: {
+            operators: true,
+          },
+        },
+      },
+      initialEntries: ["/c/default-cluster/ns/default/apps?allns=no"],
+    });
+
+    expect(fetchInstalledPackages).toHaveBeenCalledTimes(0);
+    expect(getCustomResources).toHaveBeenCalledTimes(0);
   });
 
   it("should hide the all-namespace switch if the user doesn't have permissions", async () => {
@@ -133,37 +177,6 @@ context("when changing props", () => {
     });
     const wrapper = mountWrapper(defaultStore, <AppList />);
     expect(wrapper.find("input[type='checkbox']")).not.toExist();
-  });
-
-  describe("when store changes", () => {
-    let spyOnUseState: jest.SpyInstance;
-    afterEach(() => {
-      spyOnUseState.mockRestore();
-    });
-
-    it("should not set all-ns prop when getting changes in the namespace", async () => {
-      const setAllNS = jest.fn();
-      const useState = jest.fn();
-      spyOnUseState = jest
-        .spyOn(React, "useState")
-        /* @ts-expect-error: Argument of type '(init: any) => any[]' is not assignable to parameter of type '() => [unknown, Dispatch<unknown>]' */
-        .mockImplementation((init: any) => {
-          if (init === false) {
-            // Mocking the result of setAllNS
-            return [false, setAllNS];
-          }
-          return [init, useState];
-        });
-
-      mountWrapper(
-        defaultStore,
-        <MemoryRouter initialEntries={["/foo?allns=yes"]}>
-          <AppList />
-        </MemoryRouter>,
-        false,
-      );
-      expect(setAllNS).not.toHaveBeenCalledWith(false);
-    });
   });
 });
 

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -103,7 +103,7 @@ function AppList() {
             />
             {canSetAllNS && (
               <CdsToggleGroup className="flex-v-center">
-                <CdsToggle data-testid="cds-all-ns">
+                <CdsToggle>
                   <label>Show apps in all namespaces</label>
                   <input
                     type="checkbox"


### PR DESCRIPTION
### Description of the change

Fixes an issue I'd noticed while upgrading react-router, in that sometimes the installed apps for the namespace would display, then seconds later, be updated with installed apps across all namespaces.

### Benefits

No longer have this confusing UI behaviour.

### Possible drawbacks

None.

### Applicable issues

- ref #6187
