### PR TITLE
Sort packages by version instead of relying on `ChartVersions[0]`

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -1204,7 +1204,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 		},
 		{
 			name:   "it returns the package version summary",
-			charts: []*models.Chart{makeChart("apache", "bitnami", "http://apache", "kubeapps", []string{"2.0.0", "3.0.0", "2.0.0", "1.0.0"}, DefaultChartCategory)},
+			charts: []*models.Chart{makeChart("apache", "bitnami", "http://apache", "kubeapps", []string{"2.0.0", "3.0.0", "1.0.0"}, DefaultChartCategory)},
 			request: &corev1.GetAvailablePackageVersionsRequest{
 				AvailablePackageRef: &corev1.AvailablePackageReference{
 					Context: &corev1.Context{

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -410,9 +410,9 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 			},
 			expectDBQueryNamespace: globalPackagingNamespace,
 			charts: []*models.Chart{
-				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
-				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
-				makeChart("chart-3-global", "repo-1", "http://chart-3", globalPackagingNamespace, []string{"2.0.0"}, DefaultChartCategory),
+				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"2.0.0", "3.0.0"}, DefaultChartCategory),
+				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"1.0.0", "2.0.0"}, DefaultChartCategory),
+				makeChart("chart-3-global", "repo-1", "http://chart-3", globalPackagingNamespace, []string{"1.0.0", "2.0.0"}, DefaultChartCategory),
 			},
 			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
 				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
@@ -478,8 +478,8 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 			},
 			expectDBQueryNamespace: "my-ns",
 			charts: []*models.Chart{
-				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
-				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
+				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"2.0.0", "3.0.0"}, DefaultChartCategory),
+				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"1.0.0", "2.0.0"}, DefaultChartCategory),
 			},
 			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
 				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
@@ -530,8 +530,8 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 			},
 			expectDBQueryNamespace: globalPackagingNamespace,
 			charts: []*models.Chart{
-				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
-				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
+				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"2.0.0", "3.0.0"}, DefaultChartCategory),
+				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"1.0.0", "2.0.0"}, DefaultChartCategory),
 			},
 			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
 				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
@@ -621,8 +621,8 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 			},
 			expectDBQueryNamespace: globalPackagingNamespace,
 			charts: []*models.Chart{
-				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
-				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
+				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"2.0.0", "3.0.0"}, DefaultChartCategory),
+				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"1.0.0", "2.0.0"}, DefaultChartCategory),
 				makeChart("chart-3", "repo-1", "http://chart-3", "my-ns", []string{"1.0.0"}, DefaultChartCategory),
 			},
 			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
@@ -665,8 +665,8 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 			},
 			expectDBQueryNamespace: globalPackagingNamespace,
 			charts: []*models.Chart{
-				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
-				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
+				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"2.0.0", "3.0.0"}, DefaultChartCategory),
+				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"1.0.0", "2.0.0"}, DefaultChartCategory),
 				makeChart("chart-3", "repo-1", "http://chart-3", "my-ns", []string{"1.0.0"}, DefaultChartCategory),
 			},
 			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
@@ -718,8 +718,8 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 			},
 			expectDBQueryNamespace: "my-ns",
 			charts: []*models.Chart{
-				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"3.0.0"}, "foo"),
-				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"2.0.0"}, "bar"),
+				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"2.0.0", "3.0.0"}, "foo"),
+				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"1.0.0", "2.0.0"}, "bar"),
 				makeChart("chart-3", "repo-1", "http://chart-3", "my-ns", []string{"1.0.0"}, "bar"),
 			},
 			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
@@ -852,7 +852,7 @@ func TestAvailablePackageDetailFromChart(t *testing.T) {
 	}{
 		{
 			name:  "it returns AvailablePackageDetail if the chart is correct",
-			chart: makeChart("foo", "repo-1", "http://foo", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
+			chart: makeChart("foo", "repo-1", "http://foo", "my-ns", []string{"2.0.0", "3.0.0"}, DefaultChartCategory),
 			chartFiles: &models.ChartFiles{
 				Readme:        "chart readme",
 				DefaultValues: "chart values",
@@ -885,7 +885,7 @@ func TestAvailablePackageDetailFromChart(t *testing.T) {
 		},
 		{
 			name:  "it includes additional values files in AvailablePackageDetail when available",
-			chart: makeChart("foo", "repo-1", "http://foo", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
+			chart: makeChart("foo", "repo-1", "http://foo", "my-ns", []string{"2.0.0", "3.0.0"}, DefaultChartCategory),
 			chartFiles: &models.ChartFiles{
 				Readme:        "chart readme",
 				DefaultValues: "chart values",
@@ -972,7 +972,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 					Identifier: "repo-1%2Ffoo",
 				},
 			},
-			charts: []*models.Chart{makeChart("foo", "repo-1", "http://foo", "my-ns", []string{"3.0.0"}, DefaultChartCategory)},
+			charts: []*models.Chart{makeChart("foo", "repo-1", "http://foo", "my-ns", []string{"2.0.0", "3.0.0"}, DefaultChartCategory)},
 			expectedPackage: &corev1.AvailablePackageDetail{
 				Name:             "foo",
 				DisplayName:      "foo",
@@ -1007,7 +1007,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 				},
 				PkgVersion: "1.0.0",
 			},
-			charts: []*models.Chart{makeChart("foo", "repo-1", "http://foo", "my-ns", []string{"3.0.0", "2.0.0", "1.0.0"}, DefaultChartCategory)},
+			charts: []*models.Chart{makeChart("foo", "repo-1", "http://foo", "my-ns", []string{"1.0.0", "2.0.0", "3.0.0"}, DefaultChartCategory)},
 			expectedPackage: &corev1.AvailablePackageDetail{
 				Name:             "foo",
 				DisplayName:      "foo",
@@ -1204,7 +1204,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 		},
 		{
 			name:   "it returns the package version summary",
-			charts: []*models.Chart{makeChart("apache", "bitnami", "http://apache", "kubeapps", []string{"3.0.0", "2.0.0", "1.0.0"}, DefaultChartCategory)},
+			charts: []*models.Chart{makeChart("apache", "bitnami", "http://apache", "kubeapps", []string{"2.0.0", "3.0.0", "2.0.0", "1.0.0"}, DefaultChartCategory)},
 			request: &corev1.GetAvailablePackageVersionsRequest{
 				AvailablePackageRef: &corev1.AvailablePackageReference{
 					Context: &corev1.Context{

--- a/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils.go
+++ b/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils.go
@@ -197,15 +197,21 @@ func AvailablePackageSummaryFromChart(chart *models.Chart, plugin *plugins.Plugi
 	pkg.AvailablePackageRef.Context = &corev1.Context{Namespace: chart.Repo.Namespace}
 
 	if chart.ChartVersions != nil || len(chart.ChartVersions) != 0 {
+		sortedVersions, err := SortByPackageVersion(chart.ChartVersions)
+		if err != nil {
+			return nil, err
+		}
+
 		pkg.LatestVersion = &corev1.PackageAppVersion{
-			PkgVersion: chart.ChartVersions[0].Version,
-			AppVersion: chart.ChartVersions[0].AppVersion,
+			PkgVersion: sortedVersions[0].Version.String(),
+			AppVersion: sortedVersions[0].AppVersion,
 		}
 	}
 
 	return pkg, nil
 }
 
+// TODO(agamez): I have replaced chart.ChartVersions[0] with SortByPackageVersion(...)[0]
 // TODO @gfichtenholt: I really wanted to put helm plugin's implementation of AvailablePackageDetailFromChart()
 // here, and use it in flux plugin as well. But I found out a couple of flaws in the implementation and decided
 // against it. Namely:

--- a/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils.go
+++ b/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils.go
@@ -199,12 +199,17 @@ func AvailablePackageSummaryFromChart(chart *models.Chart, plugin *plugins.Plugi
 	if chart.ChartVersions != nil || len(chart.ChartVersions) != 0 {
 		sortedVersions, err := SortByPackageVersion(chart.ChartVersions)
 		if err != nil {
-			return nil, err
-		}
-
-		pkg.LatestVersion = &corev1.PackageAppVersion{
-			PkgVersion: sortedVersions[0].Version.String(),
-			AppVersion: sortedVersions[0].AppVersion,
+			// If there was an error parsing a version as semver, fall back to ChartVersions[0]
+			log.Errorf("error parsing versions as semver: %w", err)
+			pkg.LatestVersion = &corev1.PackageAppVersion{
+				PkgVersion: chart.ChartVersions[0].Version,
+				AppVersion: chart.ChartVersions[0].AppVersion,
+			}
+		} else {
+			pkg.LatestVersion = &corev1.PackageAppVersion{
+				PkgVersion: sortedVersions[0].Version.String(),
+				AppVersion: sortedVersions[0].AppVersion,
+			}
 		}
 	}
 

--- a/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils.go
+++ b/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils.go
@@ -54,13 +54,13 @@ func GetDefaultVersionsInSummary() VersionsInSummary {
 	return defaultVersionsInSummary
 }
 
-type packageSemVersion struct {
+type PackageSemVersion struct {
 	*semver.Version
-	appVersion string
+	AppVersion string
 }
 
-func sortByPackageVersion(versions []models.ChartVersion) ([]*packageSemVersion, error) {
-	var sortedVersions []*packageSemVersion
+func SortByPackageVersion(versions []models.ChartVersion) ([]*PackageSemVersion, error) {
+	var sortedVersions []*PackageSemVersion
 	for _, v := range versions {
 		version, err := semver.NewVersion(v.Version)
 		if err != nil {
@@ -70,9 +70,9 @@ func sortByPackageVersion(versions []models.ChartVersion) ([]*packageSemVersion,
 			return nil, fmt.Errorf("Chart version %q is not semver", v.Version)
 		}
 
-		sortedVersions = append(sortedVersions, &packageSemVersion{
+		sortedVersions = append(sortedVersions, &PackageSemVersion{
 			Version:    version,
-			appVersion: v.AppVersion,
+			AppVersion: v.AppVersion,
 		})
 	}
 	sort.Slice(sortedVersions, func(i, j int) bool {
@@ -87,7 +87,7 @@ func PackageAppVersionsSummary(versions []models.ChartVersion, versionInSummary 
 	var pav []*corev1.PackageAppVersion
 
 	// Sort versions
-	sortedVersions, err := sortByPackageVersion(versions)
+	sortedVersions, err := SortByPackageVersion(versions)
 	if err != nil {
 		// If there was an error parsing a version as semver, we log the error
 		// and simply return the versions, as Helm does.
@@ -127,7 +127,7 @@ func PackageAppVersionsSummary(versions []models.ChartVersion, versionInSummary 
 		// Include the version and update the version map.
 		pav = append(pav, &corev1.PackageAppVersion{
 			PkgVersion: version.Version.String(),
-			AppVersion: version.appVersion,
+			AppVersion: version.AppVersion,
 		})
 
 		if _, ok := versionMap[version.Major()]; !ok {
@@ -154,7 +154,7 @@ func IsValidChart(chart *models.Chart) (bool, error) {
 		return false, connect.NewError(connect.CodeInternal, fmt.Errorf("required field .Repo not found on helm chart: %v", chart))
 	}
 	if chart.ChartVersions == nil || len(chart.ChartVersions) == 0 {
-		return false, connect.NewError(connect.CodeInternal, fmt.Errorf("required field .chart.ChartVersions[0] not found on helm chart: %v", chart))
+		return false, connect.NewError(connect.CodeInternal, fmt.Errorf("required field .chart.ChartVersions not found on helm chart or is empty: %v", chart))
 	} else {
 		for _, chartVersion := range chart.ChartVersions {
 			if chartVersion.Version == "" {

--- a/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go
@@ -542,9 +542,9 @@ func TestAvailablePackageSummaryFromChart(t *testing.T) {
 				},
 				Maintainers: []chart.Maintainer{{Name: "me", Email: "me@me.me"}},
 				ChartVersions: []models.ChartVersion{
-					{Version: "3.0.0", AppVersion: DefaultAppVersion, Readme: "chart readme", DefaultValues: "chart values", Schema: "chart schema"},
-					{Version: "2.0.0", AppVersion: DefaultAppVersion, Readme: "chart readme", DefaultValues: "chart values", Schema: "chart schema"},
 					{Version: "1.0.0", AppVersion: DefaultAppVersion, Readme: "chart readme", DefaultValues: "chart values", Schema: "chart schema"},
+					{Version: "2.0.0", AppVersion: DefaultAppVersion, Readme: "chart readme", DefaultValues: "chart values", Schema: "chart schema"},
+					{Version: "3.0.0", AppVersion: DefaultAppVersion, Readme: "chart readme", DefaultValues: "chart values", Schema: "chart schema"},
 				},
 			},
 			expected: &corev1.AvailablePackageSummary{


### PR DESCRIPTION
### Description of the change

As described in #6584, we were returning wrong versions in some corner cases (mainly using pre-releases). It seems we were relying on `ChartVersions[0]` with the explicit assumption that it would always contain the latest version. However, this is not the case. Since the DB does not know about semver (unless we used some [extensions](https://github.com/theory/pg-semver)), the ORDER BY query might be wrong.

This PR is replacing the occurrences of `ChartVersions[0]` in favor of a previous semver sorting. The affected operations are: `GetAvailablePackageDetail`, `GetAvailablePackageSummaries`, `GetInstalledPackageSummaries` and `GetInstalledPackageDetail`.

### Benefits

The `latestVersion` returned by the API (and therefore used by the UI -as is-, we don't sort them in client-side) will be the one that has to be.

### Possible drawbacks

1. In this PR I have just tacked the Helm plugin, not the Flux one.
2. In the code we have relied on this assumption, not 100% of the side effects, if any.

### Applicable issues

- fixes #6584

### Additional information

Example of a new version being properly detected:

![image](https://github.com/vmware-tanzu/kubeapps/assets/11535726/f46dd30b-fc1e-471a-88b1-c434b91ce1d5)


