### PR TITLE
Improve kubeapps-apis dockerfile and docs

### DIFF
--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -8,12 +8,27 @@ WORKDIR /go/src/github.com/vmware-tanzu/kubeapps
 COPY go.mod go.sum ./
 ARG VERSION="devel"
 
+# If true, run golangci-lint to detect issues
+ARG lint
+
+# https://github.com/bufbuild/buf/releases/
 ARG BUF_VERSION="1.25.1"
+
+# https://github.com/golangci/golangci-lint/releases
 ARG GOLANGCILINT_VERSION="1.53.3"
 
+# https://github.com/grpc-ecosystem/grpc-health-probe/releases/
+ARG GRPC_HEALTH_PROBE_VERSION="0.4.19"
+
 # Install lint tools
+RUN if [ ! -z "$lint" ]; then \
+        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v$GOLANGCILINT_VERSION; \
+    fi
+
 RUN curl -sSL "https://github.com/bufbuild/buf/releases/download/v$BUF_VERSION/buf-Linux-x86_64" -o "/tmp/buf" && chmod +x "/tmp/buf"
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v$GOLANGCILINT_VERSION
+
+# TODO: Remove and instead use built-in gRPC container probes once we're supporting >= 1.24 only. https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/
+RUN curl -sSL "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64" -o "/bin/grpc_health_probe" && chmod +x "/bin/grpc_health_probe"
 
 
 # With the trick below, Go's build cache is kept between builds.
@@ -27,13 +42,10 @@ RUN --mount=type=cache,target=/go/pkg/mod  \
 COPY pkg pkg
 COPY cmd cmd
 
-# If true, run golangci-lint to detect issues
-ARG lint
-
 RUN if [ ! -z "$lint" ]; then \
     # Run golangci-lint to detect issues
-    golangci-lint run --timeout=10m ./cmd/kubeapps-apis/... && \
-    golangci-lint run --timeout=10m ./pkg/...; \
+        golangci-lint run --timeout=10m ./cmd/kubeapps-apis/... && \
+        golangci-lint run --timeout=10m ./pkg/...; \
     fi
 
 # Lint the proto files to detect errors at build time
@@ -77,11 +89,6 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -ldflags "-X github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/cmd.version=$VERSION" \
     -o /resources-v1alpha1-plugin.so -buildmode=plugin \
     ./cmd/kubeapps-apis/plugins/resources/v1alpha1/*.go
-
-# Remove and instead use built-in gRPC container probes once we're
-# supporting >= 1.24 only. https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.18 && \
-    curl -sSL "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64" -o "/bin/grpc_health_probe" && chmod +x "/bin/grpc_health_probe"
 
 # Note: unlike the other docker images for go, we cannot use scratch as the plugins
 # are loaded using the dynamic linker.

--- a/site/content/docs/latest/reference/developer/release-process.md
+++ b/site/content/docs/latest/reference/developer/release-process.md
@@ -22,7 +22,8 @@ For building the [development container images](https://hub.docker.com/u/kubeapp
   - [pinniped-proxy/Dockerfile](https://github.com/vmware-tanzu/kubeapps/blob/main/cmd/pinniped-proxy/Dockerfile)
   - [oci-catalog/Dockerfile](https://github.com/vmware-tanzu/kubeapps/blob/main/cmd/oci-catalog/Dockerfile)
 
-In some images, some build-time linters are used (e.g., `buf` linter, `gosec` or `golangci-lint` checkers, etc.). When updating the base container image, these linters (like `BUF_VERSION`, `GOLANGCILINT_VERSION`) _should_ be updated to the latest minor/patch version.
+In some images, some build-time linters or tools are used (e.g., `buf` linter, `gosec` or `golangci-lint` checkers,`grpc-health-probe`, etc.).
+When updating the base container image, these tools (like `BUF_VERSION`, `GOLANGCILINT_VERSION`, `GRPC_HEALTH_PROBE_VERSION`) _should_ be updated to the latest minor/patch version.
 
 > As part of this release process, these image tags _must_ be updated to the latest minor/patch version. In case of a major version, the change _should_ be tracked in a separate PR.
 > **Note**: as the official container images are those being created by Bitnami, we _should_ ensure that we are using the same major version as they are using.


### PR DESCRIPTION
### Description of the change

Just a minor PR mainly sorting the `ARG`s and adding some comments to make it easier to find the latest release. Also, making the download of golangci-lint conditional.
Finally, adding `GRPC_HEALTH_PROBE_VERSION` to the docs, so that we can find it easily.

### Benefits

More clear dockerfile

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
