### PR TITLE
Build and push the dev oci-catalog image.

### DIFF
--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -234,7 +234,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install protoc dependency
-        run: sudo apt-get install -y protobuf-compiler
+        run: |
+          apt-get update -y
+          apt-get install -y protobuf-compiler
       - name: Run rust unit tests
         run: cargo test --manifest-path cmd/oci-catalog/Cargo.toml
 

--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -233,6 +233,8 @@ jobs:
       image: rust:${{needs.setup.outputs.rust_version}}
     steps:
       - uses: actions/checkout@v3
+      - name: Install protoc dependency
+        run: sudo apt-get install -y protobuf-compiler
       - name: Run rust unit tests
         run: cargo test --manifest-path cmd/oci-catalog/Cargo.toml
 

--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -39,7 +39,7 @@ env:
   HELM_VERSION_MIN: "v3.8.0"
   HELM_VERSION_STABLE: "v3.12.2"
   GITHUB_VERSION: "2.32.1"
-  IMAGES_TO_PUSH: "apprepository-controller dashboard asset-syncer pinniped-proxy kubeapps-apis"
+  IMAGES_TO_PUSH: "apprepository-controller dashboard asset-syncer pinniped-proxy kubeapps-apis oci-catalog"
   # IMG_DEV_TAG is the tags used for the Kubeapps docker images. Ideally there should be an IMG_PROD_TAG
   # but its value is dynamic and GitHub actions doesn't support it in the `env` block, so it is generated
   # as an output of the `setup` job.
@@ -256,6 +256,7 @@ jobs:
           - asset-syncer
           - kubeapps-apis
           - pinniped-proxy
+          - oci-catalog
     steps:
       - id: setup
         run: |

--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -225,6 +225,17 @@ jobs:
       - name: Run rust unit tests
         run: cargo test --manifest-path cmd/pinniped-proxy/Cargo.toml
 
+  test_oci_catalog:
+    needs:
+      - setup
+    runs-on: ubuntu-latest
+    container:
+      image: rust:${{needs.setup.outputs.rust_version}}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run rust unit tests
+        run: cargo test --manifest-path cmd/oci-catalog/Cargo.toml
+
   test_chart_render:
     needs:
       - setup
@@ -409,6 +420,7 @@ jobs:
       - test_go
       - test_dashboard
       - test_pinniped_proxy
+      - test_oci_catalog
       - test_chart_render
       - build_docker_images
       - build_dashboard_image
@@ -731,6 +743,7 @@ jobs:
       - test_go
       - test_dashboard
       - test_pinniped_proxy
+      - test_oci_catalog
       - test_chart_render
       - build_docker_images
       - build_dashboard_image

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -218,6 +218,7 @@ updateRepoWithLocalChanges() {
     replaceImage_latestToProduction asset-syncer "${targetChartPath}/values.yaml"
     replaceImage_latestToProduction pinniped-proxy "${targetChartPath}/values.yaml"
     replaceImage_latestToProduction kubeapps-apis "${targetChartPath}/values.yaml"
+    replaceImage_latestToProduction oci-catalog "${targetChartPath}/values.yaml"
 }
 
 ########################################################################################################################
@@ -275,6 +276,7 @@ updateRepoWithRemoteChanges() {
     replaceImage_productionToLatest asset-syncer "${KUBEAPPS_CHART_DIR}/values.yaml"
     replaceImage_productionToLatest pinniped-proxy "${KUBEAPPS_CHART_DIR}/values.yaml"
     replaceImage_productionToLatest kubeapps-apis "${KUBEAPPS_CHART_DIR}/values.yaml"
+    replaceImage_productionToLatest oci-catalog "${KUBEAPPS_CHART_DIR}/values.yaml"
 }
 
 ########################################################################################################################

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -368,6 +368,7 @@ images=(
   "dashboard"
   "pinniped-proxy"
   "${kubeapps_apis_image}"
+  "oci-catalog"
 )
 images=("${images[@]/#/${IMG_PREFIX}}")
 images=("${images[@]/%/${IMG_MODIFIER}}")
@@ -382,6 +383,8 @@ img_flags=(
   "--set" "pinnipedProxy.image.repository=${images[3]}"
   "--set" "kubeappsapis.image.tag=${IMG_DEV_TAG}"
   "--set" "kubeappsapis.image.repository=${images[4]}"
+  "--set" "ociCatalog.image.tag=${IMG_DEV_TAG}"
+  "--set" "ociCatalog.image.repository=${images[5]}"
 )
 
 additional_flags_file=$(generateAdditionalValuesFile)


### PR DESCRIPTION
### Description of the change

While setting up the dev chart changes, just realised I hadn't yet updated to publish the dev image.

### Benefits

Dev image for oci-catalog will be available.

### Applicable issues

- ref #6263 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
