### PR TITLE
Add initial values and container to the kubeapps-apis service.

### DIFF
--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -62,6 +62,13 @@ Return the proper kubeappsapis image name
 {{- end -}}
 
 {{/*
+Return the proper oci-catalog image name
+*/}}
+{{- define "kubeapps.ociCatalog.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.ociCatalog.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name for PostgreSQL dependency.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -228,6 +228,85 @@ spec:
           {{- if .Values.kubeappsapis.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
+        {{- if .Values.ociCatalog.enabled }}
+        - name: oci-catalog
+          image: {{ include "kubeapps.ociCatalog.image" . }}
+          imagePullPolicy: {{ .Values.ociCatalog.image.pullPolicy | quote }}
+          {{- if .Values.ociCatalog.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.ociCatalog.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.kubeappsapis.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.ociCatalog.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.ociCatalog.command "context" $) | nindent 12 }}
+          {{- else }}
+          command:
+            - /oci-catalog
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.ociCatalog.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.args "context" $) | nindent 12 }}
+          {{- else }}
+          args:
+            {{- range .Values.ociCatalog.extraFlags }}
+            - {{ . }}
+            {{- end }}
+          {{- end }}
+          env:
+            - name: OCI_CATALOG_PORT
+              value: {{ .Values.ociCatalog.containerPorts.http | quote }}
+            {{- if .Values.ociCatalog.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.ociCatalog.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.ociCatalog.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.ociCatalog.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.ociCatalog.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.ociCatalog.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          ports:
+            - name: grpc-http
+              containerPort: {{ .Values.ociCatalog.containerPorts.http }}
+          {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.ociCatalog.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ociCatalog.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.ociCatalog.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.livenessProbe "enabled") "context" $) | nindent 12 }}
+            exec:
+              command: ["grpc_health_probe", "-addr=:{{ .Values.ociCatalog.containerPorts.http }}"]
+            initialDelaySeconds: 10
+          {{- end }}
+          {{- if .Values.ociCatalog.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ociCatalog.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.ociCatalog.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ociCatalog.readinessProbe "enabled") "context" $) | nindent 12 }}
+            exec:
+              command: ["grpc_health_probe", "-addr=:{{ .Values.ociCatalog.containerPorts.http }}"]
+            initialDelaySeconds: 5
+          {{- end }}
+          {{- if .Values.ociCatalog.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ociCatalog.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.ociCatalog.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ociCatalog.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: grpc-http
+          {{- end }}
+          {{- end }}
+          {{- if .Values.ociCatalog.resources }}
+          resources: {{- toYaml .Values.ociCatalog.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          {{- if .Values.ociCatalog.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.ociCatalog.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+        {{- end }}
         {{- if .Values.kubeappsapis.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.sidecars "context" $) | trim | nindent 8 }}
         {{- end }}

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -259,6 +259,9 @@ spec:
           env:
             - name: OCI_CATALOG_PORT
               value: {{ .Values.ociCatalog.containerPorts.http | quote }}
+            - name: RUST_LOG
+              # Use info,pinniped_proxy::pinniped=debug for module control.
+              value: info
             {{- if .Values.ociCatalog.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.ociCatalog.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -284,7 +284,6 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command: ["grpc_health_probe", "-addr=:{{ .Values.ociCatalog.containerPorts.http }}"]
-            initialDelaySeconds: 10
           {{- end }}
           {{- if .Values.ociCatalog.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ociCatalog.customReadinessProbe "context" $) | nindent 12 }}
@@ -292,7 +291,6 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ociCatalog.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command: ["grpc_health_probe", "-addr=:{{ .Values.ociCatalog.containerPorts.http }}"]
-            initialDelaySeconds: 5
           {{- end }}
           {{- if .Values.ociCatalog.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ociCatalog.customStartupProbe "context" $) | nindent 12 }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1843,6 +1843,157 @@ kubeappsapis:
     automountServiceAccountToken: true
     annotations: {}
 
+## @section OCI Catalog chart configuration
+ociCatalog:
+  ## @param ociCatalog.enabled Enable the OCI catolog gRPC service for cataloging
+  ## OCI repositories
+  enabled: false
+  ## Bitnami Kubeapps OCI Catalog image
+  ## ref: https://hub.docker.com/r/bitnami/kubeapps-ocicatalog/
+  ## @param dashboard.image.registry Dashboard image registry
+  ## @param dashboard.image.repository Dashboard image repository
+  ## @param dashboard.image.tag Dashboard image tag (immutable tags are recommended)
+  ## @param dashboard.image.digest Dashboard image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+  ## @param dashboard.image.pullPolicy Dashboard image pull policy
+  ## @param dashboard.image.pullSecrets Dashboard image pull secrets
+  ## @param dashboard.image.debug Enable image debug mode
+  ##
+  image:
+    registry: docker.io
+    repository: kubeapps/oci-catalog
+    tag: latest
+    digest: ""
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+    ## Enable debug mode
+    ##
+    debug: false
+  ## @param ociCatalog.extraFlags Additional command line flags for OCI Catalog
+  ##
+  extraFlags: []
+  ## @param ociCatalog.extraEnvVars Array with extra environment variables to add to the oci-catalog container
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param ocicatalog.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for the OCI Catalog container
+  ##
+  extraEnvVarsCM: ""
+  ## @param ocicatalog.extraEnvVarsSecret Name of existing Secret containing extra env vars for the OCI Catalog container
+  ##
+  extraEnvVarsSecret: ""
+  ## @param ocicatalog.containerPorts.http OCI Catalog HTTP container port
+  ##
+  containerPorts:
+    http: 50061
+  ## OCI Catalog containers' resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param ocicatalog.resources.limits.cpu The CPU limits for the OCI Catalog container
+  ## @param ocicatalog.resources.limits.memory The memory limits for the OCI Catalog container
+  ## @param ocicatalog.resources.requests.cpu The requested CPU for the OCI Catalog container
+  ## @param ocicatalog.resources.requests.memory The requested memory for the OCI Catalog container
+  ##
+  resources:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+    requests:
+      cpu: 25m
+      memory: 32Mi
+  ## Configure Container Security Context (only main container)
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param ociCatalog.containerSecurityContext.enabled Enabled OCI Catalog containers' Security Context
+  ## @param ociCatalog.containerSecurityContext.runAsUser Set OCI Catalog container's Security Context runAsUser
+  ## @param ociCatalog.containerSecurityContext.runAsNonRoot Set OCI Catalog container's Security Context runAsNonRoot
+  ##
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+    runAsNonRoot: true
+  ## Configure extra options for OCI Catalog containers' liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ## @param ocicatalog.livenessProbe.enabled Enable livenessProbe
+  ## @param ocicatalog.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param ocicatalog.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param ocicatalog.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param ocicatalog.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param ocicatalog.livenessProbe.successThreshold Success threshold for livenessProbe
+  ## OCI Catalog containers' liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param ocicatalog.readinessProbe.enabled Enable readinessProbe
+  ## @param ocicatalog.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param ocicatalog.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param ocicatalog.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param ocicatalog.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param ocicatalog.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param ocicatalog.startupProbe.enabled Enable startupProbe
+  ## @param ocicatalog.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param ocicatalog.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param ocicatalog.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param ocicatalog.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param ocicatalog.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param ocicatalog.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+  ## @param ocicatalog.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+  ## @param ocicatalog.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## @param ociCatalog.lifecycleHooks Custom lifecycle hooks for OCI Catalog containers
+  ##
+  lifecycleHooks: {}
+  ## @param ociCatalog.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param ocicatalog.args Override default container args (useful when using custom images)
+  ##
+  args: []
+  ## @param ocicatalog.extraVolumes Optionally specify extra list of additional volumes for the OCI Catalog pod(s)
+  ##
+  extraVolumes: []
+  ## @param ocicatalog.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the OCI Catalog container(s)
+  ##
+  extraVolumeMounts: []
+
 ## @section Redis&reg; chart configuration
 ## ref: https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml
 ##

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -7,6 +7,7 @@ FROM bitnami/golang:1.20.7 as builder
 WORKDIR /go/src/github.com/vmware-tanzu/kubeapps
 COPY go.mod go.sum ./
 ARG VERSION="devel"
+ARG TARGETARCH
 
 # If true, run golangci-lint to detect issues
 ARG lint
@@ -28,7 +29,7 @@ RUN if [ ! -z "$lint" ]; then \
 RUN curl -sSL "https://github.com/bufbuild/buf/releases/download/v$BUF_VERSION/buf-Linux-x86_64" -o "/tmp/buf" && chmod +x "/tmp/buf"
 
 # TODO: Remove and instead use built-in gRPC container probes once we're supporting >= 1.24 only. https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/
-RUN curl -sSL "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64" -o "/bin/grpc_health_probe" && chmod +x "/bin/grpc_health_probe"
+RUN curl -sSL "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH}" -o "/bin/grpc_health_probe" && chmod +x "/bin/grpc_health_probe"
 
 
 # With the trick below, Go's build cache is kept between builds.

--- a/cmd/oci-catalog/Cargo.lock
+++ b/cmd/oci-catalog/Cargo.lock
@@ -82,6 +82,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +758,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-build",
+ "tonic-health",
  "url",
 ]
 
@@ -1386,6 +1409,19 @@ dependencies = [
  "prost-build",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080964d45894b90273d2b1dd755fdd114560db8636bb41cea615213c45043c4d"
+dependencies = [
+ "async-stream",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/cmd/oci-catalog/Cargo.lock
+++ b/cmd/oci-catalog/Cargo.lock
@@ -251,22 +251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
-
-[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,21 +316,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -577,6 +546,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,19 +569,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -731,24 +701,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,50 +744,6 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
-name = "openssl"
-version = "0.10.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -884,12 +792,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -1068,26 +970,43 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1148,6 +1067,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,35 +1110,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
-name = "schannel"
-version = "0.1.22"
+name = "sct"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1268,6 +1196,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
@@ -1379,12 +1313,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-rustls"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "native-tls",
+ "rustls",
  "tokio",
 ]
 
@@ -1546,6 +1480,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,12 +1501,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "want"
@@ -1657,6 +1591,25 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/cmd/oci-catalog/Cargo.toml
+++ b/cmd/oci-catalog/Cargo.toml
@@ -12,7 +12,7 @@ env_logger = "0.10"
 futures-core = "0.3"
 log = "0.4"
 prost = "0.11"
-reqwest = "0.11"
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.30", features = ["macros", "rt-multi-thread"] }

--- a/cmd/oci-catalog/Cargo.toml
+++ b/cmd/oci-catalog/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0"
 tokio = { version = "1.30", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1"
 tonic = "0.9"
+tonic-health = "0.9.2"
 url = "2.4"
 
 [build-dependencies]

--- a/cmd/oci-catalog/Dockerfile
+++ b/cmd/oci-catalog/Dockerfile
@@ -6,10 +6,17 @@
 FROM rust:1.71.1 as builder
 
 WORKDIR /oci-catalog
-ARG VERSION
+ARG VERSION="devel"
+ARG TARGETARCH
+
+# https://github.com/grpc-ecosystem/grpc-health-probe/releases/
+ARG GRPC_HEALTH_PROBE_VERSION="0.4.19"
 
 # Ensure protoc is available for the build.rs step.
 RUN apt-get update && apt-get -y install --no-install-recommends protobuf-compiler && rm -rf /var/lib/apt/lists/*
+
+# TODO: Remove and instead use built-in gRPC container probes once we're supporting >= 1.24 only. https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/
+RUN curl -sSL "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH}" -o "/bin/grpc_health_probe" && chmod +x "/bin/grpc_health_probe"
 
 # Create a release build of oci-catalog itself.
 # To build a statically linked version, will need to use the rusttls rather than
@@ -29,6 +36,7 @@ RUN --mount=type=cache,target=/oci-catalog/target \
 FROM bitnami/minideb:bookworm
 RUN apt-get update && apt-get install -y ca-certificates libssl3 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /oci-catalog/oci-catalog /oci-catalog
+COPY --from=builder /bin/grpc_health_probe /bin/
 USER 1001
 EXPOSE 50061
 CMD [ "/oci-catalog"]

--- a/cmd/oci-catalog/Dockerfile
+++ b/cmd/oci-catalog/Dockerfile
@@ -30,5 +30,5 @@ FROM bitnami/minideb:bookworm
 RUN apt-get update && apt-get install -y ca-certificates libssl3 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /oci-catalog/oci-catalog /oci-catalog
 USER 1001
-EXPOSE 50051
+EXPOSE 50061
 CMD [ "/oci-catalog"]

--- a/cmd/oci-catalog/src/main.rs
+++ b/cmd/oci-catalog/src/main.rs
@@ -80,8 +80,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = ([0, 0, 0, 0], opt.port).into();
     let kubeapps_oci_catalog = KubeappsOCICatalog::default();
 
+    let (mut _health_reporter, health_service) = tonic_health::server::health_reporter();
+    // TODO(absoludity): Need to implement a decent check for the actual service
+    // that won't kill us with request quotas.  See
+    // https://github.com/hyperium/tonic/blob/master/examples/src/health/server.rs
+    // for an example setup.
+
     let server = Server::builder()
         .add_service(OciCatalogServer::new(kubeapps_oci_catalog))
+        .add_service(health_service)
         .serve(addr);
     log::info!("listening for gRPC requests at {}", addr);
     server.await.expect("unexpected error while serving");


### PR DESCRIPTION
### Description of the change

Adds the initial values and container for the oci-catalog to the kubeapps-apis service.

Leaving in draft for the moment as there are a number of things I want to check IRL while playing:
- ~~Use an actual grpc liveness check (to test that out, since we can remove the grpc health binary, as our oldest k8s version is now past 1.24)~~ Bitnami tests are still testing with 1.23 apparently.
- Evaluate whether kubeapps-apis is really the right pod for having this side-car. We'll need to use the service when validating a repo from the UX (which is kubeapps-apis), but also during the sync job. It could also run as a separate pod, but not sure it's worth the resources.

Note: I've got `ociCatalog.enabled` defaulting to false now, so no change to the chart output.

### Benefits

Can start integration.

### Possible drawbacks

### Applicable issues

- ref #6263 

### Additional Information

```console
$ helm template ./chart/kubeapps --debug --set ociCatalog.enabled=true | grep -A 40 oci-catalog
install.go:200: [debug] Original chart version: ""
install.go:217: [debug] CHART PATH: /Users/minelson/dev/vmware/kubeapps/chart/kubeapps

        - name: oci-catalog
          image: docker.io/kubeapps/oci-catalog:latest
          imagePullPolicy: "IfNotPresent"
          securityContext:
            runAsNonRoot: true
            runAsUser: 1001
          command:
            - /oci-catalog
          args:
          env:
            - name: OCI_CATALOG_PORT
              value: "50061"
          envFrom:
          ports:
            - name: grpc-http
              containerPort: 50061
          livenessProbe:
            failureThreshold: 6
            initialDelaySeconds: 60
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 5
            exec:
              command: ["grpc_health_probe", "-addr=:50061"]
            initialDelaySeconds: 10
          readinessProbe:
            failureThreshold: 6
            initialDelaySeconds: 0
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 5
            exec:
              command: ["grpc_health_probe", "-addr=:50061"]
            initialDelaySeconds: 5
          resources:
            limits:
              cpu: 250m
              memory: 256Mi
            requests:
              cpu: 25m
              memory: 32Mi
          volumeMounts:
      volumes:
        - name: clusters-config
          configMap:
            name: release-name-kubeapps-clusters-config
        - name: ca-certs
          emptyDir: {}
```

With these changes in dev:

```
k -n kubeapps logs kubeapps-internal-kubeappsapis-7f5cc7f98b-wnqq4 oci-catalog     
[2023-08-14T01:42:41Z INFO  oci_catalog] listening for gRPC requests at 0.0.0.0:50061
```
