### PR TITLE
Update proto copyright dates so generated matches existing dates.

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -16,7 +16,9 @@ header:
     - LICENSE
     - NOTICE
     - open_source_licenses.txt
+    - dashboard/build/**
     - dashboard/src/setupProxy.js
+    - dashboard/yarn-error.log
     - "**/*.css"
     - "**/*.dccache"
     - "**/*.html"

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -12,7 +12,7 @@ ARG VERSION="devel"
 ARG lint
 
 # https://github.com/bufbuild/buf/releases/
-ARG BUF_VERSION="1.25.1"
+ARG BUF_VERSION="1.26.0"
 
 # https://github.com/golangci/golangci-lint/releases
 ARG GOLANGCILINT_VERSION="1.53.3"
@@ -22,7 +22,7 @@ ARG GRPC_HEALTH_PROBE_VERSION="0.4.19"
 
 # Install lint tools
 RUN if [ ! -z "$lint" ]; then \
-        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v$GOLANGCILINT_VERSION; \
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v$GOLANGCILINT_VERSION; \
     fi
 
 RUN curl -sSL "https://github.com/bufbuild/buf/releases/download/v$BUF_VERSION/buf-Linux-x86_64" -o "/tmp/buf" && chmod +x "/tmp/buf"
@@ -44,8 +44,8 @@ COPY cmd cmd
 
 RUN if [ ! -z "$lint" ]; then \
     # Run golangci-lint to detect issues
-        golangci-lint run --timeout=10m ./cmd/kubeapps-apis/... && \
-        golangci-lint run --timeout=10m ./pkg/...; \
+    golangci-lint run --timeout=10m ./cmd/kubeapps-apis/... && \
+    golangci-lint run --timeout=10m ./pkg/...; \
     fi
 
 # Lint the proto files to detect errors at build time

--- a/cmd/kubeapps-apis/gen/core/packages/v1alpha1/packages.pb.go
+++ b/cmd/kubeapps-apis/gen/core/packages/v1alpha1/packages.pb.go
@@ -835,19 +835,21 @@ type GetAvailablePackageVersionsResponse struct {
 	// patch versions of the most recent three minor versions of the most recent three
 	// major versions when available, something like:
 	// [
-	//   { pkg_version: "10.3.19", app_version: "2.16.8" },
-	//   { pkg_version: "10.3.18", app_version: "2.16.8" },
-	//   { pkg_version: "10.3.17", app_version: "2.16.7" },
-	//   { pkg_version: "10.2.6", app_version: "2.15.3" },
-	//   { pkg_version: "10.2.5", app_version: "2.15.2" },
-	//   { pkg_version: "10.2.4", app_version: "2.15.2" },
-	//   { pkg_version: "10.1.8", app_version: "2.13.5" },
-	//   { pkg_version: "10.1.7", app_version: "2.13.5" },
-	//   { pkg_version: "10.1.6", app_version: "2.13.5" },
-	//   { pkg_version: "9.5.4", app_version: "2.8.9" },
-	//   ...
-	//   { pkg_version: "8.2.5", app_version: "1.19.5" },
-	//   ...
+	//
+	//	{ pkg_version: "10.3.19", app_version: "2.16.8" },
+	//	{ pkg_version: "10.3.18", app_version: "2.16.8" },
+	//	{ pkg_version: "10.3.17", app_version: "2.16.7" },
+	//	{ pkg_version: "10.2.6", app_version: "2.15.3" },
+	//	{ pkg_version: "10.2.5", app_version: "2.15.2" },
+	//	{ pkg_version: "10.2.4", app_version: "2.15.2" },
+	//	{ pkg_version: "10.1.8", app_version: "2.13.5" },
+	//	{ pkg_version: "10.1.7", app_version: "2.13.5" },
+	//	{ pkg_version: "10.1.6", app_version: "2.13.5" },
+	//	{ pkg_version: "9.5.4", app_version: "2.8.9" },
+	//	...
+	//	{ pkg_version: "8.2.5", app_version: "1.19.5" },
+	//	...
+	//
 	// ]
 	// If a version_query is present and the plugin chooses to support it,
 	// the full history of versions matching the version query should be returned.
@@ -1586,9 +1588,9 @@ type InstalledPackageSummary struct {
 	//
 	// The current version of the package being reconciled, which may be
 	// in one of these states:
-	//  - has been successfully installed/upgraded or
-	//  - is currently being installed/upgraded or
-	//  - has failed to install/upgrade
+	//   - has been successfully installed/upgraded or
+	//   - is currently being installed/upgraded or
+	//   - has failed to install/upgrade
 	CurrentVersion *PackageAppVersion `protobuf:"bytes,4,opt,name=current_version,json=currentVersion,proto3" json:"current_version,omitempty"`
 	// Installed package icon URL
 	//
@@ -1607,8 +1609,8 @@ type InstalledPackageSummary struct {
 	// Only non-empty if an available upgrade matches the specified pkg_version_reference.
 	// For example, if the pkg_version_reference is ">10.3.0 < 10.4.0" and 10.3.1
 	// is installed, then:
-	//   * if 10.3.2 is available, latest_matching_version should be 10.3.2, but
-	//   * if 10.4 is available while >10.3.1 is not, this should remain empty.
+	//   - if 10.3.2 is available, latest_matching_version should be 10.3.2, but
+	//   - if 10.4 is available while >10.3.1 is not, this should remain empty.
 	LatestMatchingVersion *PackageAppVersion `protobuf:"bytes,8,opt,name=latest_matching_version,json=latestMatchingVersion,proto3" json:"latest_matching_version,omitempty"`
 	// LatestVersion
 	//
@@ -1776,8 +1778,8 @@ type InstalledPackageDetail struct {
 	// Only non-empty if an available upgrade matches the specified pkg_version_reference.
 	// For example, if the pkg_version_reference is ">10.3.0 < 10.4.0" and 10.3.1
 	// is installed, then:
-	//   * if 10.3.2 is available, latest_matching_version should be 10.3.2, but
-	//   * if 10.4 is available while >10.3.1 is not, this should remain empty.
+	//   - if 10.3.2 is available, latest_matching_version should be 10.3.2, but
+	//   - if 10.4 is available while >10.3.1 is not, this should remain empty.
 	LatestMatchingVersion *PackageAppVersion `protobuf:"bytes,10,opt,name=latest_matching_version,json=latestMatchingVersion,proto3" json:"latest_matching_version,omitempty"`
 	// LatestVersion
 	//

--- a/cmd/kubeapps-apis/gen/core/packages/v1alpha1/repositories.pb.go
+++ b/cmd/kubeapps-apis/gen/core/packages/v1alpha1/repositories.pb.go
@@ -167,9 +167,9 @@ type AddPackageRepositoryRequest struct {
 	NamespaceScoped bool `protobuf:"varint,4,opt,name=namespace_scoped,json=namespaceScoped,proto3" json:"namespace_scoped,omitempty"`
 	// Package storage type
 	// In general, each plug-in will define an acceptable set of valid types
-	// - for direct helm plug-in valid values are: "helm" and "oci"
-	// - for flux plug-in valid values are: "helm" and "oci". In the
-	//   future, we may add support for git and/or AWS s3-style buckets
+	//   - for direct helm plug-in valid values are: "helm" and "oci"
+	//   - for flux plug-in valid values are: "helm" and "oci". In the
+	//     future, we may add support for git and/or AWS s3-style buckets
 	Type string `protobuf:"bytes,5,opt,name=type,proto3" json:"type,omitempty"`
 	// A URL identifying the package repository location. Must contain at
 	// least a protocol and host
@@ -197,11 +197,12 @@ type AddPackageRepositoryRequest struct {
 	// See https://developers.google.com/protocol-buffers/docs/proto3#any
 	// Just for reference, some of the examples that have been chosen not to
 	// be part of the core API but rather plugin-specific details are:
-	//   direct-helm:
-	//      - image pull secrets
-	//      - list of oci repositories
-	//      - filter rules
-	//      - sync job pod template
+	//
+	//	direct-helm:
+	//	   - image pull secrets
+	//	   - list of oci repositories
+	//	   - filter rules
+	//	   - sync job pod template
 	CustomDetail *anypb.Any `protobuf:"bytes,11,opt,name=custom_detail,json=customDetail,proto3" json:"custom_detail,omitempty"`
 }
 
@@ -315,7 +316,6 @@ func (x *AddPackageRepositoryRequest) GetCustomDetail() *anypb.Any {
 }
 
 // PackageRepositoryTlsConfig
-//
 type PackageRepositoryTlsConfig struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -427,11 +427,13 @@ func (*PackageRepositoryTlsConfig_SecretRef) isPackageRepositoryTlsConfig_Packag
 // Note that (1)-(4) may be done over HTTP or HTTPs without any custom
 // certificates or certificate authority
 // (1) is handled by not not having PackageRepositoryAuth field on
-//     the parent object
+//
+//	the parent object
+//
 // a given plug-in may or may not support a given authentication type.
 // For example
-//  - direct-helm plug-in does not currently support (6), while flux does
-//  - flux plug-in does not support (3) or (4) while direct-helm does
+//   - direct-helm plug-in does not currently support (6), while flux does
+//   - flux plug-in does not support (3) or (4) while direct-helm does
 type PackageRepositoryAuth struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -614,7 +616,6 @@ func (*PackageRepositoryAuth_SshCreds) isPackageRepositoryAuth_PackageRepoAuthOn
 func (*PackageRepositoryAuth_OpaqueCreds) isPackageRepositoryAuth_PackageRepoAuthOneOf() {}
 
 // UsernamePassword
-//
 type UsernamePassword struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -673,7 +674,6 @@ func (x *UsernamePassword) GetPassword() string {
 }
 
 // TlsCertKey
-//
 type TlsCertKey struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -732,7 +732,6 @@ func (x *TlsCertKey) GetKey() string {
 }
 
 // DockerCredentials
-//
 type DockerCredentials struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -809,7 +808,6 @@ func (x *DockerCredentials) GetEmail() string {
 }
 
 // SshCredentials
-//
 type SshCredentials struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -868,7 +866,6 @@ func (x *SshCredentials) GetKnownHosts() string {
 }
 
 // OpaqueCredentials
-//
 type OpaqueCredentials struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -918,7 +915,6 @@ func (x *OpaqueCredentials) GetData() map[string]string {
 }
 
 // SecretKeyReference
-//
 type SecretKeyReference struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -927,16 +923,17 @@ type SecretKeyReference struct {
 	// The name of an existing secret in the same namespace as the object
 	// that refers to it (e.g. PackageRepository), containing authentication
 	// credentials for the said package repository.
-	// - For HTTP/S basic auth the secret must be of type
-	//   "kubernetes.io/basic-auth" or opaque and contain username and
-	//   password fields
-	// - For TLS the secret must be of type "kubernetes.io/tls" or opaque
-	//   and contain a certFile and keyFile, and/or
-	//   caCert fields.
-	// - For Bearer or Custom Auth, the secret must be opaque, and
-	//   the key must be provided
-	// - For Docker Registry Credentials (OCI registries) the secret
-	//   must of of type "kubernetes.io/dockerconfigjson"
+	//   - For HTTP/S basic auth the secret must be of type
+	//     "kubernetes.io/basic-auth" or opaque and contain username and
+	//     password fields
+	//   - For TLS the secret must be of type "kubernetes.io/tls" or opaque
+	//     and contain a certFile and keyFile, and/or
+	//     caCert fields.
+	//   - For Bearer or Custom Auth, the secret must be opaque, and
+	//     the key must be provided
+	//   - For Docker Registry Credentials (OCI registries) the secret
+	//     must of of type "kubernetes.io/dockerconfigjson"
+	//
 	// For more details, refer to
 	// https://kubernetes.io/docs/concepts/configuration/secret/
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -1125,11 +1122,12 @@ type UpdatePackageRepositoryRequest struct {
 	// See https://developers.google.com/protocol-buffers/docs/proto3#any
 	// Just for reference, some of the examples that have been chosen not to
 	// be part of the core API but rather plugin-specific details are:
-	//   direct-helm:
-	//      - image pull secrets
-	//      - list of oci repositories
-	//      - filter rules
-	//      - sync job pod template
+	//
+	//	direct-helm:
+	//	   - image pull secrets
+	//	   - list of oci repositories
+	//	   - filter rules
+	//	   - sync job pod template
 	CustomDetail *anypb.Any `protobuf:"bytes,11,opt,name=custom_detail,json=customDetail,proto3" json:"custom_detail,omitempty"`
 }
 
@@ -1346,9 +1344,10 @@ type AddPackageRepositoryResponse struct {
 	unknownFields protoimpl.UnknownFields
 
 	// TODO: add example for API docs
-	// option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
-	//   example: '{"package_repo_ref": {}}'
-	// };
+	//
+	//	option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
+	//	  example: '{"package_repo_ref": {}}'
+	//	};
 	PackageRepoRef *PackageRepositoryReference `protobuf:"bytes,1,opt,name=package_repo_ref,json=packageRepoRef,proto3" json:"package_repo_ref,omitempty"`
 }
 
@@ -1467,7 +1466,6 @@ func (x *PackageRepositoryStatus) GetUserReason() string {
 }
 
 // PackageRepositoryDetail
-//
 type PackageRepositoryDetail struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1670,7 +1668,6 @@ func (x *GetPackageRepositoryDetailResponse) GetDetail() *PackageRepositoryDetai
 }
 
 // PackageRepositorySummary
-//
 type PackageRepositorySummary struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1/fluxv2.pb.go
+++ b/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1/fluxv2.pb.go
@@ -38,10 +38,11 @@ type FluxPackageRepositoryCustomDetail struct {
 
 	// optional field that allows specifying an OIDC provider used for authentication purposes
 	// Supported options are:
-	//  - generic
-	//  - aws
-	//  - azure
-	//  - gcp
+	//   - generic
+	//   - aws
+	//   - azure
+	//   - gcp
+	//
 	// The provider field is supported only for Helm OCI repositories. The repository type must
 	// be set to "oci"
 	// ref https://fluxcd.io/flux/components/source/helmrepositories/#provider

--- a/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1/helm.pb.go
+++ b/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1/helm.pb.go
@@ -151,9 +151,10 @@ type RollbackInstalledPackageResponse struct {
 	unknownFields protoimpl.UnknownFields
 
 	// TODO: add example for API docs
-	// option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
-	//   example: '{"installed_package_ref": {}}'
-	// };
+	//
+	//	option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
+	//	  example: '{"installed_package_ref": {}}'
+	//	};
 	InstalledPackageRef *v1alpha1.InstalledPackageReference `protobuf:"bytes,1,opt,name=installed_package_ref,json=installedPackageRef,proto3" json:"installed_package_ref,omitempty"`
 }
 

--- a/cmd/kubeapps-apis/proto/kubeappsapis/apidocs/v1alpha1/apidocs.proto
+++ b/cmd/kubeapps-apis/proto/kubeappsapis/apidocs/v1alpha1/apidocs.proto
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 the Kubeapps contributors.
+// Copyright 2021-2023 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";

--- a/cmd/kubeapps-apis/proto/kubeappsapis/core/packages/v1alpha1/repositories.proto
+++ b/cmd/kubeapps-apis/proto/kubeappsapis/core/packages/v1alpha1/repositories.proto
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 the Kubeapps contributors.
+// Copyright 2021-2023 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";

--- a/cmd/kubeapps-apis/proto/kubeappsapis/core/plugins/v1alpha1/plugins.proto
+++ b/cmd/kubeapps-apis/proto/kubeappsapis/core/plugins/v1alpha1/plugins.proto
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 the Kubeapps contributors.
+// Copyright 2021-2023 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";

--- a/cmd/kubeapps-apis/proto/kubeappsapis/plugins/fluxv2/packages/v1alpha1/fluxv2.proto
+++ b/cmd/kubeapps-apis/proto/kubeappsapis/plugins/fluxv2/packages/v1alpha1/fluxv2.proto
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 the Kubeapps contributors.
+// Copyright 2021-2023 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";
@@ -132,7 +132,7 @@ message FluxPackageRepositoryCustomDetail {
   //  - aws
   //  - azure
   //  - gcp
-  // The provider field is supported only for Helm OCI repositories. The repository type must 
+  // The provider field is supported only for Helm OCI repositories. The repository type must
   // be set to "oci"
   // ref https://fluxcd.io/flux/components/source/helmrepositories/#provider
   string provider = 1;

--- a/cmd/kubeapps-apis/proto/kubeappsapis/plugins/helm/packages/v1alpha1/helm.proto
+++ b/cmd/kubeapps-apis/proto/kubeappsapis/plugins/helm/packages/v1alpha1/helm.proto
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 the Kubeapps contributors.
+// Copyright 2021-2023 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";

--- a/cmd/kubeapps-apis/proto/kubeappsapis/plugins/kapp_controller/packages/v1alpha1/kapp_controller.proto
+++ b/cmd/kubeapps-apis/proto/kubeappsapis/plugins/kapp_controller/packages/v1alpha1/kapp_controller.proto
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 the Kubeapps contributors.
+// Copyright 2021-2023 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";

--- a/cmd/kubeapps-apis/proto/kubeappsapis/plugins/resources/v1alpha1/resources.proto
+++ b/cmd/kubeapps-apis/proto/kubeappsapis/plugins/resources/v1alpha1/resources.proto
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 the Kubeapps contributors.
+// Copyright 2021-2023 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";


### PR DESCRIPTION
### Description of the change

Just a small copyright date update in proto files and mechanical re-generation with current buf.

I was needing to run buf generate on my own work branch and was seeing distracting side-effects such as dates which had been manually (?) changed to 2023 in generated files being reverted back to 2022. So this PR just updates the dates in the proto files and regenerates so I won't have that noise in my own diff.

### Benefits

Easier reviewing.

### Applicable issues

- ref #6263

### Additional information

I'll land this once passing to continue.