### PR TITLE
Refactor repo validation so as to not require http-only validators.

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
@@ -248,7 +248,7 @@ func TestAddPackageRepository(t *testing.T) {
 		expectedAuthCreatedSecret   *apiv1.Secret
 		expectedDockerCreatedSecret *apiv1.Secret
 		userManagedSecrets          bool
-		repoClientGetter            newRepoClient
+		repoClientGetter            repositoryClientGetter
 		expectedGlobalSecret        *apiv1.Secret
 	}{
 		{

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -59,7 +59,7 @@ const (
 )
 
 type createRelease func(*action.Configuration, string, string, string, *chart.Chart, map[string]string, int32) (*release.Release, error)
-type newRepoClient func(appRepo *appRepov1.AppRepository, secret *corek8sv1.Secret) (httpclient.Client, error)
+type repositoryClientGetter func(appRepo *appRepov1.AppRepository, secret *corek8sv1.Secret) (httpclient.Client, error)
 
 // Server implements the helm packages v1alpha1 interface.
 type Server struct {
@@ -80,7 +80,7 @@ type Server struct {
 	kubeappsCluster                 string // Specifies the cluster on which Kubeapps is installed.
 	kubeappsNamespace               string // Namespace in which Kubeapps is installed
 	pluginConfig                    *common.HelmPluginConfig
-	repoClientGetter                newRepoClient
+	repoClientGetter                repositoryClientGetter
 	clientQPS                       float32
 }
 

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/test_util_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/test_util_test.go
@@ -160,7 +160,7 @@ func addTlsToSecret(secret *apiv1.Secret, pub, priv, ca []byte) *apiv1.Secret {
 	return secret
 }
 
-func newRepoHttpClient(responses map[string]*http.Response) newRepoClient {
+func newRepoHttpClient(responses map[string]*http.Response) repositoryClientGetter {
 	return func(appRepo *appRepov1.AppRepository, secret *apiv1.Secret) (httpclient.Client, error) {
 		return &fakeHTTPClient{
 			responses: responses,


### PR DESCRIPTION
### Description of the change

First part of integration work to update the OCI repo support to use the oci-catalog service. This PR refactors the existing repository validation to remove the assumption of an `HTTPValidator` (since the gRPC validation doesn't use an httpclient etc.)

### Benefits

Step towards adding grpc validation for OCI repositories using the new service.

### Possible drawbacks

None

### Applicable issues

- ref #6263 
