### PR TITLE
Use OCI catalog service when available for OCI validation

### DIFF
--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -166,6 +166,8 @@ spec:
                 secretKeyRef:
                   key: postgres-password
                   name: {{ include "kubeapps.postgresql.secretName" . }}
+            - name: OCI_CATALOG_URL
+              value: {{ printf ":%d" .Values.ociCatalog.containerPorts.http . }}
             {{- end }}
             {{- if .Values.kubeappsapis.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.extraEnvVars "context" $) | nindent 12 }}

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -167,7 +167,7 @@ spec:
                   key: postgres-password
                   name: {{ include "kubeapps.postgresql.secretName" . }}
             - name: OCI_CATALOG_URL
-              value: {{ printf ":%d" .Values.ociCatalog.containerPorts.http . }}
+              value: {{ printf ":%d" (int .Values.ociCatalog.containerPorts.http) | quote }}
             {{- end }}
             {{- if .Values.kubeappsapis.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.extraEnvVars "context" $) | nindent 12 }}

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -167,7 +167,7 @@ spec:
                   key: postgres-password
                   name: {{ include "kubeapps.postgresql.secretName" . }}
             - name: OCI_CATALOG_URL
-              value: {{ printf ":%d" (int .Values.ociCatalog.containerPorts.http) | quote }}
+              value: {{ printf ":%d" (int .Values.ociCatalog.containerPorts.grpc) | quote }}
             {{- end }}
             {{- if .Values.kubeappsapis.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.extraEnvVars "context" $) | nindent 12 }}
@@ -260,7 +260,7 @@ spec:
           {{- end }}
           env:
             - name: OCI_CATALOG_PORT
-              value: {{ .Values.ociCatalog.containerPorts.http | quote }}
+              value: {{ .Values.ociCatalog.containerPorts.grpc | quote }}
             - name: RUST_LOG
               # Use info,pinniped_proxy::pinniped=debug for module control.
               value: info
@@ -277,22 +277,22 @@ spec:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.ociCatalog.extraEnvVarsSecret "context" $) }}
             {{- end }}
           ports:
-            - name: grpc-http
-              containerPort: {{ .Values.ociCatalog.containerPorts.http }}
+            - name: grpc
+              containerPort: {{ .Values.ociCatalog.containerPorts.grpc }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.ociCatalog.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ociCatalog.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.ociCatalog.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
-              command: ["grpc_health_probe", "-addr=:{{ .Values.ociCatalog.containerPorts.http }}"]
+              command: ["grpc_health_probe", "-addr=:{{ .Values.ociCatalog.containerPorts.grpc }}"]
           {{- end }}
           {{- if .Values.ociCatalog.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ociCatalog.customReadinessProbe "context" $) | nindent 12 }}
           {{- else if .Values.ociCatalog.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ociCatalog.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
-              command: ["grpc_health_probe", "-addr=:{{ .Values.ociCatalog.containerPorts.http }}"]
+              command: ["grpc_health_probe", "-addr=:{{ .Values.ociCatalog.containerPorts.grpc }}"]
           {{- end }}
           {{- if .Values.ociCatalog.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ociCatalog.customStartupProbe "context" $) | nindent 12 }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1898,7 +1898,7 @@ ociCatalog:
   ## @param ocicatalog.containerPorts.http OCI Catalog HTTP container port
   ##
   containerPorts:
-    http: 50061
+    grpc: 50061
   ## OCI Catalog containers' resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## @param ocicatalog.resources.limits.cpu The CPU limits for the OCI Catalog container

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
@@ -98,7 +98,7 @@ func (s *Server) newRepo(ctx context.Context, headers http.Header, repo *HelmRep
 
 	// Repository validation
 	if repo.customDetail != nil && repo.customDetail.PerformValidation {
-		if err = s.ValidateRepository(helmRepoCrd, secret); err != nil {
+		if err = s.ValidateRepository(ctx, helmRepoCrd, secret); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_validation_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_validation_test.go
@@ -410,7 +410,7 @@ func TestOCIValidateWithCatalogServer(t *testing.T) {
 
 	testCases := []struct {
 		name             string
-		repos            []ocicatalog.Repository
+		repos            []*ocicatalog.Repository
 		validator        HelmOCIValidator
 		expectedResponse *ValidationResponse
 		expectError      bool
@@ -425,7 +425,7 @@ func TestOCIValidateWithCatalogServer(t *testing.T) {
 				},
 				OCICatalogAddr: ociCatalogAddr,
 			},
-			repos: []ocicatalog.Repository{
+			repos: []*ocicatalog.Repository{
 				{
 					Name: "apache",
 				},
@@ -448,7 +448,7 @@ func TestOCIValidateWithCatalogServer(t *testing.T) {
 				},
 				OCICatalogAddr: ociCatalogAddr,
 			},
-			repos: []ocicatalog.Repository{
+			repos: []*ocicatalog.Repository{
 				{
 					Name: "apache",
 				},

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -92,6 +92,7 @@ func NewServer(configGetter core.KubernetesConfigGetter, globalPackagingCluster 
 	var ASSET_SYNCER_DB_NAME = os.Getenv("ASSET_SYNCER_DB_NAME")
 	var ASSET_SYNCER_DB_USERNAME = os.Getenv("ASSET_SYNCER_DB_USERNAME")
 	var ASSET_SYNCER_DB_USERPASSWORD = os.Getenv("ASSET_SYNCER_DB_USERPASSWORD")
+	var OCI_CATALOG_URL = os.Getenv("OCI_CATALOG_URL")
 
 	// Namespace where Kubeapps is installed to be in line with the asset syncer
 	kubeappsNamespace := os.Getenv("POD_NAMESPACE")
@@ -171,6 +172,7 @@ func NewServer(configGetter core.KubernetesConfigGetter, globalPackagingCluster 
 		createReleaseFunc:        agent.CreateRelease,
 		repoClientGetter:         newRepositoryClient,
 		clientQPS:                clientQPS,
+		OCICatalogAddr:           OCI_CATALOG_URL,
 	}
 }
 

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -82,6 +82,7 @@ type Server struct {
 	pluginConfig                    *common.HelmPluginConfig
 	repoClientGetter                repositoryClientGetter
 	clientQPS                       float32
+	OCICatalogAddr                  string
 }
 
 // NewServer returns a Server automatically configured with a function to obtain

--- a/pkg/ocicatalogtest/ocicatalogtest.go
+++ b/pkg/ocicatalogtest/ocicatalogtest.go
@@ -1,0 +1,55 @@
+// Copyright 2023 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+package ocicatalogtest
+
+import (
+	"net"
+	"testing"
+
+	ocicatalog "github.com/vmware-tanzu/kubeapps/cmd/oci-catalog/gen/catalog/v1alpha1"
+	"google.golang.org/grpc"
+)
+
+type OCICatalogDouble struct {
+	Repositories []ocicatalog.Repository
+	Tags         []ocicatalog.Tag
+	ocicatalog.UnimplementedOCICatalogServiceServer
+}
+
+// Dummy implementation that just sends the canned repositories.
+func (c OCICatalogDouble) ListRepositoriesForRegistry(r *ocicatalog.ListRepositoriesForRegistryRequest, stream ocicatalog.OCICatalogService_ListRepositoriesForRegistryServer) error {
+	for _, repo := range c.Repositories {
+		stream.Send(&repo)
+	}
+	return nil
+}
+
+func (c OCICatalogDouble) ListTagsForRepository(r *ocicatalog.ListTagsForRepositoryRequest, stream ocicatalog.OCICatalogService_ListTagsForRepositoryServer) error {
+	for _, tag := range c.Tags {
+		stream.Send(&tag)
+	}
+	return nil
+}
+
+// SetupTestDouble starts the gRPC service, returns the test double and a
+// function to cleanup
+func SetupTestDouble(t *testing.T) (string, *OCICatalogDouble, func()) {
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	catalogDouble := &OCICatalogDouble{}
+	grpcServer := grpc.NewServer()
+	ocicatalog.RegisterOCICatalogServiceServer(grpcServer, catalogDouble)
+
+	go func() {
+		grpcServer.Serve(lis)
+	}()
+
+	return lis.Addr().String(), catalogDouble, func() {
+		grpcServer.Stop()
+		lis.Close()
+	}
+}


### PR DESCRIPTION
### Description of the change

Follows on from #6620, uses the grpc Client to check if we can find repos for an OCI registry. While there I improved a couple of other things regarding the validation:
- a context.Context can (and must) now be passed through to the validation (we should always pass the request context through subsequent requests); and
- the getValidator function is now a method so that the different validators can have custom data set (such as the OCI catalog address, or the repo client getter).

I've added a basic test double grpc service for the OCI catalog to use here in tests, and will undoubtedly improve this test double when adding the actual sync functionality to use the OCI catalog service next.

### Benefits

OCI Catalog service can be used to check an OCI Registry, without impacting current behaviour.

### Possible drawbacks

None that I'm aware of.

### Applicable issues

- ref #6263

### Additional information

I'll test IRL locally and update here:

Logs showing the fallback when the OCI catalog is not running:
```
E0816 03:49:15.487354       1 repositories_validation.go:354] unable to query OCI Catalog service at ":50061": error querying OCI Catalog for repos: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :50061: connect: connection refused"
E0816 03:49:16.462758       1 utils.go:400] unable to get catalog manifest: GET request to [https://registry-1.docker.io/v2/bitnamicharts/charts-index/manifests/latest] failed due to status [401]: {"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":[{"Type":"repository","Class":"","Name":"bitnamicharts/charts-index","Action":"pull"}]}]}
E0816 03:49:16.462894       1 repositories_validation.go:52] Failed repository validation validation: &{Code:400 Message:unable to determine the OCI catalog, you need to specify at least one repository}
```

and verified I can add the Bitnami catalog using the OCI `https://registry-1.docker.io/bitnamicharts` . That is, it passes validation and gets added. It doesn't yet sync - that'll be the next PR.
