### PR TITLE
Refactor some names to avoid confusion between OCI repositories and Helm repositories.

### DIFF
--- a/cmd/asset-syncer/server/delete.go
+++ b/cmd/asset-syncer/server/delete.go
@@ -27,7 +27,7 @@ func Delete(serveOpts Config, args []string) error {
 	}
 	defer manager.Close()
 
-	repo := models.Repo{Name: args[0], Namespace: serveOpts.Namespace}
+	repo := models.AppRepository{Name: args[0], Namespace: serveOpts.Namespace}
 	if err = manager.Delete(repo); err != nil {
 		return fmt.Errorf("can't delete chart repository %s from database: %v", args[0], err)
 	}

--- a/cmd/asset-syncer/server/postgresql_db_test.go
+++ b/cmd/asset-syncer/server/postgresql_db_test.go
@@ -30,27 +30,27 @@ func TestEnsureRepoExists(t *testing.T) {
 
 	testCases := []struct {
 		name          string
-		existingRepos []models.Repo
-		newRepo       models.Repo
+		existingRepos []models.AppRepository
+		newRepo       models.AppRepository
 		expectedID    int
 	}{
 		{
 			name: "it returns a new ID if it does not yet exist",
-			existingRepos: []models.Repo{
+			existingRepos: []models.AppRepository{
 				{Namespace: "my-namespace", Name: "other-repo"},
 				{Namespace: "other-namespace", Name: "my-repo"},
 			},
-			newRepo:    models.Repo{Namespace: "my-namespace", Name: "my-name"},
+			newRepo:    models.AppRepository{Namespace: "my-namespace", Name: "my-name"},
 			expectedID: 3,
 		},
 		{
 			name: "it returns the existing ID if the repo exists in the db",
-			existingRepos: []models.Repo{
+			existingRepos: []models.AppRepository{
 				{Namespace: "my-namespace", Name: "my-name"},
 				{Namespace: "my-namespace", Name: "other-repo"},
 				{Namespace: "other-namespace", Name: "my-repo"},
 			},
-			newRepo:    models.Repo{Namespace: "my-namespace", Name: "my-name"},
+			newRepo:    models.AppRepository{Namespace: "my-namespace", Name: "my-name"},
 			expectedID: 1,
 		},
 	}
@@ -82,7 +82,7 @@ func TestEnsureRepoExists(t *testing.T) {
 func TestImportCharts(t *testing.T) {
 	pgtest.SkipIfNoDB(t)
 
-	repo := models.Repo{
+	repo := models.AppRepository{
 		Name:      "repo-name",
 		Namespace: "repo-namespace",
 	}
@@ -133,23 +133,23 @@ func TestInsertFiles(t *testing.T) {
 	}{
 		{
 			name:       "it inserts new chart files",
-			chartFiles: models.ChartFiles{ID: filesID, Readme: "A Readme", Repo: &models.Repo{Namespace: namespace}},
+			chartFiles: models.ChartFiles{ID: filesID, Readme: "A Readme", Repo: &models.AppRepository{Namespace: namespace}},
 			fileCount:  1,
 		},
 		{
 			name: "it updates existing chart files",
 			existingFiles: []models.ChartFiles{
-				{ID: filesID, Readme: "A Readme", Repo: &models.Repo{Namespace: namespace}},
+				{ID: filesID, Readme: "A Readme", Repo: &models.AppRepository{Namespace: namespace}},
 			},
-			chartFiles: models.ChartFiles{ID: filesID, Readme: "A New Readme", Repo: &models.Repo{Namespace: namespace}},
+			chartFiles: models.ChartFiles{ID: filesID, Readme: "A New Readme", Repo: &models.AppRepository{Namespace: namespace}},
 			fileCount:  1,
 		},
 		{
 			name: "it imports the same repo name and chart version in different namespaces",
 			existingFiles: []models.ChartFiles{
-				{ID: filesID, Readme: "A different Readme", Repo: &models.Repo{Namespace: "another-namespace"}},
+				{ID: filesID, Readme: "A different Readme", Repo: &models.AppRepository{Namespace: "another-namespace"}},
 			},
-			chartFiles: models.ChartFiles{ID: filesID, Readme: "A Readme", Repo: &models.Repo{Namespace: namespace}},
+			chartFiles: models.ChartFiles{ID: filesID, Readme: "A Readme", Repo: &models.AppRepository{Namespace: namespace}},
 			fileCount:  2,
 		},
 	}
@@ -191,13 +191,13 @@ func TestDelete(t *testing.T) {
 		repoName      = "my-repo"
 		chartID       = repoName + "/my-chart"
 	)
-	repoToDelete := models.Repo{Namespace: repoNamespace, Name: repoName}
-	otherRepo := models.Repo{Namespace: "other-namespace", Name: repoName}
+	repoToDelete := models.AppRepository{Namespace: repoNamespace, Name: repoName}
+	otherRepo := models.AppRepository{Namespace: "other-namespace", Name: repoName}
 
 	testCases := []struct {
 		name           string
 		existingFiles  []models.ChartFiles
-		repo           models.Repo
+		repo           models.AppRepository
 		expectedRepos  int
 		expectedCharts int
 		expectedFiles  int
@@ -254,9 +254,9 @@ func TestRemoveMissingCharts(t *testing.T) {
 	const (
 		repoName = "my-repo"
 	)
-	repo := models.Repo{Name: repoName, Namespace: "my-namespace"}
-	repoOtherNameSameNamespace := models.Repo{Name: "other-repo", Namespace: "my-namespace"}
-	repoSameNameOtherNamespace := models.Repo{Name: repoName, Namespace: "other-namespace"}
+	repo := models.AppRepository{Name: repoName, Namespace: "my-namespace"}
+	repoOtherNameSameNamespace := models.AppRepository{Name: "other-repo", Namespace: "my-namespace"}
+	repoSameNameOtherNamespace := models.AppRepository{Name: repoName, Namespace: "other-namespace"}
 
 	testCases := []struct {
 		name string
@@ -393,7 +393,7 @@ func TestRepoAlreadyProcessed(t *testing.T) {
 		repoName      = "my-repo"
 		checksum      = "deadbeef"
 	)
-	repo := models.Repo{Namespace: repoNamespace, Name: repoName}
+	repo := models.AppRepository{Namespace: repoNamespace, Name: repoName}
 
 	pam, cleanup := getInitializedManager(t)
 	defer cleanup()
@@ -429,7 +429,7 @@ func TestRepoAlreadyProcessed(t *testing.T) {
 	}
 
 	// it does not match the same repo in a different namespace
-	got = pam.LastChecksum(models.Repo{Namespace: "other-namespace", Name: repo.Name})
+	got = pam.LastChecksum(models.AppRepository{Namespace: "other-namespace", Name: repo.Name})
 	if got != "" {
 		t.Errorf("got: %s, want: %s", got, "")
 	}
@@ -445,7 +445,7 @@ func TestFilesExist(t *testing.T) {
 		filesID   = chartID + "-1.0"
 		digest    = "some-digest"
 	)
-	repo := models.Repo{Namespace: namespace, Name: repoName}
+	repo := models.AppRepository{Namespace: namespace, Name: repoName}
 	pam, cleanup := getInitializedManager(t)
 	defer cleanup()
 
@@ -467,10 +467,10 @@ func TestFilesExist(t *testing.T) {
 	}
 
 	// false when it exists in another repo
-	if got, want := pam.filesExist(models.Repo{Namespace: repo.Namespace, Name: "other-name"}, filesID, digest), false; got != want {
+	if got, want := pam.filesExist(models.AppRepository{Namespace: repo.Namespace, Name: "other-name"}, filesID, digest), false; got != want {
 		t.Errorf("got: %t, want: %t", got, want)
 	}
-	if got, want := pam.filesExist(models.Repo{Namespace: "other-namespace", Name: repo.Name}, filesID, digest), false; got != want {
+	if got, want := pam.filesExist(models.AppRepository{Namespace: "other-namespace", Name: repo.Name}, filesID, digest), false; got != want {
 		t.Errorf("got: %t, want: %t", got, want)
 	}
 }
@@ -485,7 +485,7 @@ func TestUpdateIcon(t *testing.T) {
 		chartID         = repoName + "/chart-id"
 	)
 	iconData := []byte("icon-data")
-	repo := models.Repo{Namespace: repoNamespace, Name: repoName}
+	repo := models.AppRepository{Namespace: repoNamespace, Name: repoName}
 
 	testCases := []struct {
 		name           string
@@ -520,7 +520,7 @@ func TestUpdateIcon(t *testing.T) {
 				for _, chartID := range chartIDs {
 					charts = append(charts, models.Chart{ID: chartID})
 				}
-				pgtest.EnsureChartsExist(t, pam, charts, models.Repo{Namespace: namespace, Name: repoName})
+				pgtest.EnsureChartsExist(t, pam, charts, models.AppRepository{Namespace: namespace, Name: repoName})
 			}
 
 			err := pam.updateIcon(repo, iconData, iconContentType, chartID)

--- a/cmd/asset-syncer/server/postgresql_utils_test.go
+++ b/cmd/asset-syncer/server/postgresql_utils_test.go
@@ -29,7 +29,7 @@ func Test_DeletePGRepo(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
-	repo := models.Repo{Name: "testrepo", Namespace: "testnamespace"}
+	repo := models.AppRepository{Name: "testrepo", Namespace: "testnamespace"}
 	mock.ExpectQuery(`DELETE FROM repos WHERE name = \$1 AND namespace = \$2`).
 		WithArgs(repo.Name, repo.Namespace).
 		WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1))
@@ -48,7 +48,7 @@ func Test_PGRepoLastChecksum(t *testing.T) {
 		WithArgs("foo", "repo-namespace").
 		WillReturnRows(sqlmock.NewRows([]string{"checksum"}).AddRow("123"))
 
-	got := pgManager.LastChecksum(models.Repo{Namespace: "repo-namespace", Name: "foo"})
+	got := pgManager.LastChecksum(models.AppRepository{Namespace: "repo-namespace", Name: "foo"})
 	if got != "123" {
 		t.Errorf("got: %s, want: %s", got, "123")
 	}
@@ -79,7 +79,7 @@ func Test_PGremoveMissingCharts(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
-	repo := models.Repo{Name: "repo"}
+	repo := models.AppRepository{Name: "repo"}
 	charts := []models.Chart{{ID: "foo", Repo: &repo}, {ID: "bar"}}
 	mock.ExpectQuery(`^DELETE FROM charts WHERE chart_id NOT IN \('foo', 'bar'\) AND repo_name = \$1 AND repo_namespace = \$2`).
 		WithArgs(repo.Name, repo.Namespace).
@@ -103,7 +103,7 @@ func Test_PGupdateIcon(t *testing.T) {
 			WithArgs("stable/wordpress", "repo-namespace", "repo-name").
 			WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1))
 
-		err := pgManager.updateIcon(models.Repo{Namespace: "repo-namespace", Name: "repo-name"}, data, contentType, id)
+		err := pgManager.updateIcon(models.AppRepository{Namespace: "repo-namespace", Name: "repo-name"}, data, contentType, id)
 
 		if err != nil {
 			t.Errorf("%+v", err)
@@ -117,7 +117,7 @@ func Test_PGupdateIcon(t *testing.T) {
 			WithArgs("stable/wordpress", "repo-namespace", "repo-name").
 			WillReturnRows(sqlmock.NewRows([]string{"ID"}))
 
-		err := pgManager.updateIcon(models.Repo{Namespace: "repo-namespace", Name: "repo-name"}, data, contentType, id)
+		err := pgManager.updateIcon(models.AppRepository{Namespace: "repo-namespace", Name: "repo-name"}, data, contentType, id)
 
 		if got, want := err, sql.ErrNoRows; got != want {
 			t.Errorf("got: %+v, want: %+v", got, want)
@@ -131,7 +131,7 @@ func Test_PGupdateIcon(t *testing.T) {
 			WithArgs("stable/wordpress", "repo-namespace", "repo-name").
 			WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1).AddRow(2))
 
-		err := pgManager.updateIcon(models.Repo{Namespace: "repo-namespace", Name: "repo-name"}, data, contentType, id)
+		err := pgManager.updateIcon(models.AppRepository{Namespace: "repo-namespace", Name: "repo-name"}, data, contentType, id)
 
 		if got, want := errors.Is(err, ErrMultipleRows), true; got != want {
 			t.Errorf("got: %t, want: %t", got, want)
@@ -147,7 +147,7 @@ func Test_PGfilesExist(t *testing.T) {
 		id     = "stable/wordpress"
 		digest = "foo"
 	)
-	repo := models.Repo{Namespace: "namespace", Name: "repo-name"}
+	repo := models.AppRepository{Namespace: "namespace", Name: "repo-name"}
 
 	rows := sqlmock.NewRows([]string{"info"}).AddRow(`true`)
 	mock.ExpectQuery(`^SELECT EXISTS\(
@@ -175,7 +175,7 @@ func Test_PGinsertFiles(t *testing.T) {
 		chartID   string = repoName + "/wordpress"
 		filesID   string = chartID + "-2.1.3"
 	)
-	files := models.ChartFiles{ID: filesID, Readme: "foo", DefaultValues: "bar", Repo: &models.Repo{Namespace: namespace, Name: repoName}}
+	files := models.ChartFiles{ID: filesID, Readme: "foo", DefaultValues: "bar", Repo: &models.AppRepository{Namespace: namespace, Name: repoName}}
 	mock.ExpectQuery(`INSERT INTO files \(chart_id, repo_name, repo_namespace, chart_files_ID, info\)*`).
 		WithArgs(chartID, repoName, namespace, filesID, files).
 		WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow("3"))

--- a/cmd/asset-syncer/server/sync.go
+++ b/cmd/asset-syncer/server/sync.go
@@ -56,7 +56,7 @@ func Sync(serveOpts Config, version string, args []string) error {
 		return fmt.Errorf("error: %v", err)
 	}
 
-	var repoIface Repo
+	var repoIface ChartCatalog
 	if args[2] == "helm" {
 		repoIface, err = getHelmRepo(serveOpts.Namespace, args[0], args[1], authorizationHeader, filters, netClient, serveOpts.UserAgent)
 	} else {
@@ -65,14 +65,14 @@ func Sync(serveOpts Config, version string, args []string) error {
 	if err != nil {
 		return fmt.Errorf("error: %v", err)
 	}
-	repo := repoIface.Repo()
+	repo := repoIface.AppRepository()
 	checksum, err := repoIface.Checksum()
 	if err != nil {
 		return fmt.Errorf("error: %v", err)
 	}
 
 	// Check if the repo has been already processed
-	lastChecksum := manager.LastChecksum(models.Repo{Namespace: repo.Namespace, Name: repo.Name})
+	lastChecksum := manager.LastChecksum(models.AppRepository{Namespace: repo.Namespace, Name: repo.Name})
 	log.Infof("Last checksum: %v", lastChecksum)
 	if lastChecksum == checksum {
 		log.Infof("Skipping repository since there are no updatesrepo.URL= %v", repo.URL)
@@ -98,7 +98,7 @@ func Sync(serveOpts Config, version string, args []string) error {
 			log.Infof("No charts in repository to be synced, repo.URL= %v", repo.URL)
 			return nil
 		}
-		if err = manager.Sync(models.Repo{Name: repo.Name, Namespace: repo.Namespace}, charts); err != nil {
+		if err = manager.Sync(models.AppRepository{Name: repo.Name, Namespace: repo.Namespace}, charts); err != nil {
 			return fmt.Errorf("can't add chart repository to database: %v", err)
 		}
 

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/integration_utils_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/integration_utils_test.go
@@ -1315,7 +1315,7 @@ func usesBitnamiCatalog(t *testing.T) error {
 			return err
 		}
 
-		modelRepo := &models.Repo{
+		modelRepo := &models.AppRepository{
 			Namespace: "default",
 			Name:      "bitnami",
 			URL:       outside_cluster_bitnami_url,

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/oci_repo.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/oci_repo.go
@@ -782,7 +782,7 @@ func getOciChartModel(appName string, tags TagList, ociChartRepo *OCIChartReposi
 		maintainers = append(maintainers, *maintainer)
 	}
 
-	modelRepo := &models.Repo{
+	modelRepo := &models.AppRepository{
 		Namespace: repo.Namespace,
 		Name:      repo.Name,
 		URL:       repo.Spec.URL,

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo.go
@@ -661,7 +661,7 @@ func (s *repoEventSink) indexOneRepo(repo sourcev1.HelmRepository) ([]models.Cha
 		return nil, err
 	}
 
-	modelRepo := &models.Repo{
+	modelRepo := &models.AppRepository{
 		Namespace: repo.Namespace,
 		Name:      repo.Name,
 		URL:       repo.Spec.URL,

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_validation_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_validation_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	ocicatalog "github.com/vmware-tanzu/kubeapps/cmd/oci-catalog/gen/catalog/v1alpha1"
 	httpclient "github.com/vmware-tanzu/kubeapps/pkg/http-client"
-	"github.com/vmware-tanzu/kubeapps/pkg/ocicatalogtest"
+	"github.com/vmware-tanzu/kubeapps/pkg/ocicatalog_client/ocicatalog_clienttest"
 	corev1 "k8s.io/api/core/v1"
 	log "k8s.io/klog/v2"
 )
@@ -439,7 +439,7 @@ func TestOCIValidate(t *testing.T) {
 }
 
 func TestOCIValidateWithCatalogServer(t *testing.T) {
-	ociCatalogAddr, ociCatalogDouble, cleanup := ocicatalogtest.SetupTestDouble(t)
+	ociCatalogAddr, ociCatalogDouble, cleanup := ocicatalog_clienttest.SetupTestDouble(t)
 	defer cleanup()
 
 	testCases := []struct {

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -975,7 +975,7 @@ func (s *Server) fetchChartWithRegistrySecrets(ctx context.Context, headers http
 	return ch, registrySecrets, nil
 }
 
-func chartTarballURL(r *models.Repo, cv models.ChartVersion) string {
+func chartTarballURL(r *models.AppRepository, cv models.ChartVersion) string {
 	// The tarball URL will always be the first URL, ie. URL[0], in the repo.chartVersions[i]:
 	// https://helm.sh/docs/topics/chart_repository/#the-index-file
 	// https://github.com/helm/helm/blob/v3.7.1/cmd/helm/search/search_test.go#L63

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -172,7 +172,7 @@ func makeChart(chartName, repoName, repoUrl, namespace string, chartVersions []s
 		Icon:        DefaultChartIconURL,
 		Maintainers: []chart.Maintainer{{Name: "me", Email: "me@me.me"}},
 		Sources:     []string{"http://source-1"},
-		Repo: &models.Repo{
+		Repo: &models.AppRepository{
 			Name:      repoName,
 			Namespace: namespace,
 			URL:       repoUrl,
@@ -2032,25 +2032,25 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 func TestChartTarballURLBuild(t *testing.T) {
 	testCases := []struct {
 		name         string
-		repo         *models.Repo
+		repo         *models.AppRepository
 		chartVersion *models.ChartVersion
 		expectedUrl  string
 	}{
 		{
 			name:         "tarball url with relative URL without leading slash in chart",
-			repo:         &models.Repo{URL: "https://demo.repo/repo1"},
+			repo:         &models.AppRepository{URL: "https://demo.repo/repo1"},
 			chartVersion: &models.ChartVersion{URLs: []string{"chart/test"}},
 			expectedUrl:  "https://demo.repo/repo1/chart/test",
 		},
 		{
 			name:         "tarball url with relative URL with leading slash in chart",
-			repo:         &models.Repo{URL: "https://demo.repo/repo1"},
+			repo:         &models.AppRepository{URL: "https://demo.repo/repo1"},
 			chartVersion: &models.ChartVersion{URLs: []string{"/chart/test"}},
 			expectedUrl:  "https://demo.repo/repo1/chart/test",
 		},
 		{
 			name:         "tarball url with absolute URL",
-			repo:         &models.Repo{URL: "https://demo.repo/repo1"},
+			repo:         &models.AppRepository{URL: "https://demo.repo/repo1"},
 			chartVersion: &models.ChartVersion{URLs: []string{"https://demo.repo/repo1/chart/test"}},
 			expectedUrl:  "https://demo.repo/repo1/chart/test",
 		},
@@ -2153,7 +2153,7 @@ func chartAssetForReleaseStub(rel *releaseStub) *models.Chart {
 	return &models.Chart{
 		Name: rel.name,
 		ID:   rel.chartID,
-		Repo: &models.Repo{
+		Repo: &models.AppRepository{
 			Namespace: rel.chartNamespace,
 		},
 		ChartVersions: chartVersions,
@@ -2194,7 +2194,7 @@ func populateAssetForTarball(t *testing.T, mock sqlmock.Sqlmock, chartId, namesp
 	chart := &models.Chart{
 		Name: chartId,
 		ID:   chartId,
-		Repo: &models.Repo{
+		Repo: &models.AppRepository{
 			Namespace: globalPackagingNamespace,
 		},
 		ChartVersions: []models.ChartVersion{{

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/postgres_db_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/postgres_db_test.go
@@ -74,7 +74,7 @@ func TestGetChart(t *testing.T) {
 			pam, cleanup := getInitializedManager(t)
 			defer cleanup()
 			for namespace, charts := range tc.existingCharts {
-				pgtest.EnsureChartsExist(t, pam, charts, models.Repo{Name: repoName, Namespace: namespace})
+				pgtest.EnsureChartsExist(t, pam, charts, models.AppRepository{Name: repoName, Namespace: namespace})
 			}
 
 			chart, err := pam.GetChart(tc.namespace, tc.chartId)
@@ -159,7 +159,7 @@ func TestGetVersion(t *testing.T) {
 			pam, cleanup := getInitializedManager(t)
 			defer cleanup()
 			for namespace, charts := range tc.existingCharts {
-				pgtest.EnsureChartsExist(t, pam, charts, models.Repo{Name: repoName, Namespace: namespace})
+				pgtest.EnsureChartsExist(t, pam, charts, models.AppRepository{Name: repoName, Namespace: namespace})
 			}
 
 			chart, err := pam.GetChartVersion(tc.namespace, tc.chartId, tc.requestedVersion)
@@ -370,7 +370,7 @@ func TestGetPaginatedChartList(t *testing.T) {
 			defer cleanup()
 			for namespace, chartsPerRepo := range tc.existingCharts {
 				for repo, charts := range chartsPerRepo {
-					pgtest.EnsureChartsExist(t, pam, charts, models.Repo{Name: repo, Namespace: namespace})
+					pgtest.EnsureChartsExist(t, pam, charts, models.AppRepository{Name: repo, Namespace: namespace})
 				}
 			}
 
@@ -489,7 +489,7 @@ func TestGetChartsWithFilters(t *testing.T) {
 			defer cleanup()
 			for namespace, chartsPerRepo := range tc.existingCharts {
 				for repo, charts := range chartsPerRepo {
-					pgtest.EnsureChartsExist(t, pam, charts, models.Repo{Name: repo, Namespace: namespace})
+					pgtest.EnsureChartsExist(t, pam, charts, models.AppRepository{Name: repo, Namespace: namespace})
 				}
 			}
 

--- a/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go
@@ -398,7 +398,7 @@ func TestIsValidChart(t *testing.T) {
 			in: &models.Chart{
 				Name: "foo",
 				ID:   "foo/bar",
-				Repo: &models.Repo{
+				Repo: &models.AppRepository{
 					Name:      "bar",
 					Namespace: "my-ns",
 				},
@@ -414,7 +414,7 @@ func TestIsValidChart(t *testing.T) {
 			name: "it returns false if the chart name is missing",
 			in: &models.Chart{
 				ID: "foo/bar",
-				Repo: &models.Repo{
+				Repo: &models.AppRepository{
 					Name:      "bar",
 					Namespace: "my-ns",
 				},
@@ -430,7 +430,7 @@ func TestIsValidChart(t *testing.T) {
 			name: "it returns false if the chart ID is missing",
 			in: &models.Chart{
 				Name: "foo",
-				Repo: &models.Repo{
+				Repo: &models.AppRepository{
 					Name:      "bar",
 					Namespace: "my-ns",
 				},
@@ -480,7 +480,7 @@ func TestIsValidChart(t *testing.T) {
 			in: &models.Chart{
 				Name: "foo",
 				ID:   "foo/bar",
-				Repo: &models.Repo{
+				Repo: &models.AppRepository{
 					Name:      "bar",
 					Namespace: "my-ns",
 				},
@@ -536,7 +536,7 @@ func TestAvailablePackageSummaryFromChart(t *testing.T) {
 				Category:    DefaultChartCategory,
 				Description: "best chart",
 				Icon:        "foo.bar/icon.svg",
-				Repo: &models.Repo{
+				Repo: &models.AppRepository{
 					Name:      "bar",
 					Namespace: "my-ns",
 				},
@@ -569,7 +569,7 @@ func TestAvailablePackageSummaryFromChart(t *testing.T) {
 			in: &models.Chart{
 				Name: "foo",
 				ID:   "foo/bar",
-				Repo: &models.Repo{
+				Repo: &models.AppRepository{
 					Name:      "bar",
 					Namespace: "my-ns",
 				},

--- a/pkg/chart/models/chart.go
+++ b/pkg/chart/models/chart.go
@@ -12,16 +12,16 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 )
 
-// Repo holds the App repository basic details
-type Repo struct {
+// AppRepository holds the App repository basic details
+type AppRepository struct {
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
 	URL       string `json:"url"`
 	Type      string `json:"type"`
 }
 
-// RepoInternal holds the App repository details including auth
-type RepoInternal struct {
+// AppRepositoryInternal holds the App repository details including auth
+type AppRepositoryInternal struct {
 	Namespace           string `json:"namespace"`
 	Name                string `json:"name"`
 	URL                 string `json:"url"`
@@ -33,7 +33,7 @@ type RepoInternal struct {
 type Chart struct {
 	ID              string             `json:"ID" bson:"chart_id"`
 	Name            string             `json:"name"`
-	Repo            *Repo              `json:"repo"`
+	Repo            *AppRepository     `json:"repo"`
 	Description     string             `json:"description"`
 	Home            string             `json:"home"`
 	Keywords        []string           `json:"keywords"`
@@ -83,7 +83,7 @@ type ChartFiles struct {
 	DefaultValues           string
 	AdditionalDefaultValues map[string]string
 	Schema                  string
-	Repo                    *Repo
+	Repo                    *AppRepository
 	Digest                  string
 }
 

--- a/pkg/dbutils/dbutilstest/pgtest/pgtest.go
+++ b/pkg/dbutils/dbutilstest/pgtest/pgtest.go
@@ -68,7 +68,7 @@ func CountRows(t *testing.T, db dbutils.PostgresDB, table string) int {
 	return count
 }
 
-func EnsureChartsExist(t *testing.T, pam dbutils.PostgresAssetManagerIface, charts []models.Chart, repo models.Repo) {
+func EnsureChartsExist(t *testing.T, pam dbutils.PostgresAssetManagerIface, charts []models.Chart, repo models.AppRepository) {
 	_, err := pam.EnsureRepoExists(repo.Namespace, repo.Name)
 	if err != nil {
 		t.Fatalf("%+v", err)

--- a/pkg/helm/index.go
+++ b/pkg/helm/index.go
@@ -27,7 +27,7 @@ func parseRepoIndex(contents []byte) (*repo.IndexFile, error) {
 
 // Takes an entry from the index and constructs a model representation of the
 // object.
-func newChart(entry repo.ChartVersions, r *models.Repo, shallow bool) models.Chart {
+func newChart(entry repo.ChartVersions, r *models.AppRepository, shallow bool) models.Chart {
 	var c models.Chart
 	err := copier.Copy(&c, entry[0])
 	if err != nil {
@@ -51,7 +51,7 @@ func newChart(entry repo.ChartVersions, r *models.Repo, shallow bool) models.Cha
 // ChartsFromIndex receives an array of bytes containing the contents of index.yaml from a helm repo and returns
 // all Chart models from that index. The shallow flag controls whether only the latest version of the charts is returned
 // or all versions
-func ChartsFromIndex(contents []byte, r *models.Repo, shallow bool) ([]models.Chart, error) {
+func ChartsFromIndex(contents []byte, r *models.AppRepository, shallow bool) ([]models.Chart, error) {
 	var charts []models.Chart
 	index, err := parseRepoIndex(contents)
 	if err != nil {

--- a/pkg/helm/index_test.go
+++ b/pkg/helm/index_test.go
@@ -40,7 +40,7 @@ func Test_parseRepoIndex(t *testing.T) {
 }
 
 func Test_chartsFromIndex(t *testing.T) {
-	r := &models.Repo{Name: "test", URL: "http://testrepo.com"}
+	r := &models.AppRepository{Name: "test", URL: "http://testrepo.com"}
 	charts, err := ChartsFromIndex([]byte(validRepoIndexYAML), r, false)
 	assert.NoError(t, err)
 	assert.Equal(t, len(charts), 2, "number of charts")
@@ -56,7 +56,7 @@ func Test_chartsFromIndex(t *testing.T) {
 }
 
 func Test_chartsFromIndexHarborUnified(t *testing.T) {
-	r := &models.Repo{Name: "test", URL: "http://testrepo.com"}
+	r := &models.AppRepository{Name: "test", URL: "http://testrepo.com"}
 	charts, err := ChartsFromIndex([]byte(validRepoIndexHarborUnifiedYAML), r, false)
 	assert.NoError(t, err)
 	assert.Equal(t, len(charts), 2, "number of charts")
@@ -66,7 +66,7 @@ func Test_chartsFromIndexHarborUnified(t *testing.T) {
 }
 
 func Test_shallowChartsFromIndex(t *testing.T) {
-	r := &models.Repo{Name: "test", URL: "http://testrepo.com"}
+	r := &models.AppRepository{Name: "test", URL: "http://testrepo.com"}
 	charts, err := ChartsFromIndex([]byte(validRepoIndexYAML), r, true)
 	assert.NoError(t, err)
 	assert.Equal(t, len(charts), 2, "number of charts")
@@ -74,7 +74,7 @@ func Test_shallowChartsFromIndex(t *testing.T) {
 }
 
 func Test_newChart(t *testing.T) {
-	r := &models.Repo{Name: "test", URL: "http://testrepo.com"}
+	r := &models.AppRepository{Name: "test", URL: "http://testrepo.com"}
 	index, _ := parseRepoIndex([]byte(validRepoIndexYAML))
 	c := newChart(index.Entries["wordpress"], r, false)
 	assert.Equal(t, c.Name, "wordpress", "correctly built")
@@ -85,7 +85,7 @@ func Test_newChart(t *testing.T) {
 }
 
 func Test_loadRepoWithEmptyCharts(t *testing.T) {
-	r := &models.Repo{Name: "test", URL: "http://testrepo.com"}
+	r := &models.AppRepository{Name: "test", URL: "http://testrepo.com"}
 	indexWithEmptyChart := validRepoIndexYAML + `emptyChart: []`
 	charts, err := ChartsFromIndex([]byte(indexWithEmptyChart), r, true)
 	assert.NoError(t, err)

--- a/pkg/ocicatalog_client/ocicatalog_client.go
+++ b/pkg/ocicatalog_client/ocicatalog_client.go
@@ -1,0 +1,23 @@
+// Copyright 2023 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+package ocicatalog_client
+
+import (
+	"fmt"
+
+	ocicatalog "github.com/vmware-tanzu/kubeapps/cmd/oci-catalog/gen/catalog/v1alpha1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func NewClient(ociCatalogAddr string) (ocicatalog.OCICatalogServiceClient, func(), error) {
+	conn, err := grpc.Dial(ociCatalogAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to contact OCI Catalog at %q: %+v", ociCatalogAddr, err)
+	}
+
+	closer := func() { conn.Close() }
+
+	return ocicatalog.NewOCICatalogServiceClient(conn), closer, nil
+}

--- a/pkg/ocicatalog_client/ocicatalog_clienttest/ocicatalog_clienttest.go
+++ b/pkg/ocicatalog_client/ocicatalog_clienttest/ocicatalog_clienttest.go
@@ -1,7 +1,7 @@
 // Copyright 2023 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
-package ocicatalogtest
+package ocicatalog_clienttest
 
 import (
 	"net"


### PR DESCRIPTION
### Description of the change

The code currently talks about OCI repositories and Helm repositories and Helm repositories that are OCI registries. This PR is just splitting out some renaming to avoid the confusion, so instead we have:
- `Repo` model -> `AppRepository` which correspond to our `AppRepository` custom resource which can represent a Helm repository or an OCI registry (or a namespace within an OCI registry) which contains many oci repositories.
- `Repo` interace -> `ChartCatalog` interface, as this is implemented by both Helm and OCI versions

It contains another small refactor pulling out a `ocicatalog_client.NewClient` helper.

Leaving as draft for now in case I come across any other straight renames/refactors in the current work.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #6263 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
