### PR TITLE
Update the OCIApiClient to be aware of (and use) oci-catalog service

### DIFF
--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -6,6 +6,7 @@ package server
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"errors"
 	"fmt"
 	"image"
@@ -318,7 +319,7 @@ func Test_getOCIRepo(t *testing.T) {
 		assert.NoError(t, err)
 
 		client := repo.(*OCIRegistry).ociCli
-		if got, want := client.(*OciAPIClient).Url.String(), "https://test"; got != want {
+		if got, want := client.(*OciAPIClient).RegistryNamespaceUrl.String(), "https://test"; got != want {
 			t.Errorf("got: %q, want: %q", got, want)
 		}
 	})
@@ -804,8 +805,8 @@ func Test_ociAPICli(t *testing.T) {
 
 	t.Run("TagList - failed request", func(t *testing.T) {
 		apiCli := &OciAPIClient{
-			Url: url,
-			NetClient: &badHTTPClient{
+			RegistryNamespaceUrl: url,
+			HttpClient: &badHTTPClient{
 				errMsg: "forbidden",
 			},
 		}
@@ -815,34 +816,8 @@ func Test_ociAPICli(t *testing.T) {
 
 	t.Run("TagList - successful request", func(t *testing.T) {
 		apiCli := &OciAPIClient{
-			Url: url,
-			NetClient: &goodOCIAPIHTTPClient{
-				response: `{"name":"test/apache","tags":["7.5.1","8.1.1"]}`,
-			},
-		}
-		result, err := apiCli.TagList("apache", "my-user-agent")
-		assert.NoError(t, err)
-		expectedTagList := &TagList{Name: "test/apache", Tags: []string{"7.5.1", "8.1.1"}}
-		if !cmp.Equal(result, expectedTagList) {
-			t.Errorf("Unexpected result %v", cmp.Diff(result, expectedTagList))
-		}
-	})
-
-	t.Run("TagList with auth - failure", func(t *testing.T) {
-		apiCli := &OciAPIClient{
-			Url:        url,
-			AuthHeader: "Bearer wrong",
-			NetClient:  &authenticatedOCIAPIHTTPClient{},
-		}
-		_, err := apiCli.TagList("apache", "my-user-agent")
-		assert.Error(t, fmt.Errorf("GET request to [http://oci-test/v2/apache/tags/list] failed due to status [500]"), err)
-	})
-
-	t.Run("TagList with auth - success", func(t *testing.T) {
-		apiCli := &OciAPIClient{
-			Url:        url,
-			AuthHeader: "Bearer ThisSecretAccessTokenAuthenticatesTheClient",
-			NetClient: &authenticatedOCIAPIHTTPClient{
+			RegistryNamespaceUrl: url,
+			HttpClient: &goodOCIAPIHTTPClient{
 				response: `{"name":"test/apache","tags":["7.5.1","8.1.1"]}`,
 			},
 		}
@@ -856,8 +831,8 @@ func Test_ociAPICli(t *testing.T) {
 
 	t.Run("IsHelmChart - failed request", func(t *testing.T) {
 		apiCli := &OciAPIClient{
-			Url:       url,
-			NetClient: &badHTTPClient{},
+			RegistryNamespaceUrl: url,
+			HttpClient:           &badHTTPClient{},
 		}
 		_, err := apiCli.IsHelmChart("apache", "7.5.1", "my-user-agent")
 		assert.Error(t, fmt.Errorf("GET request to [http://oci-test/v2/apache/manifests/7.5.1] failed due to status [500]"), err)
@@ -865,8 +840,8 @@ func Test_ociAPICli(t *testing.T) {
 
 	t.Run("IsHelmChart - successful request", func(t *testing.T) {
 		apiCli := &OciAPIClient{
-			Url: url,
-			NetClient: &goodOCIAPIHTTPClient{
+			RegistryNamespaceUrl: url,
+			HttpClient: &goodOCIAPIHTTPClient{
 				responseByPath: map[string]string{
 					// 7.5.1 is not a chart
 					"/v2/test/apache/manifests/7.5.1": `{"schemaVersion":2,"config":{"mediaType":"other","digest":"sha256:123","size":665}}`,
@@ -889,64 +864,84 @@ func Test_ociAPICli(t *testing.T) {
 	urlWithNamespace, _ := parseRepoURL("http://oci-test/test/project")
 	t.Run("CatalogAvailable - successful request", func(t *testing.T) {
 		apiCli := &OciAPIClient{
-			Url: urlWithNamespace,
-			NetClient: &goodOCIAPIHTTPClient{
+			RegistryNamespaceUrl: urlWithNamespace,
+			HttpClient: &goodOCIAPIHTTPClient{
 				responseByPath: map[string]string{
 					"/v2/test/project/charts-index/manifests/latest": chartsIndexManifestJSON,
 				},
 			},
 		}
 
-		if got, want := apiCli.CatalogAvailable("my-user-agent"), true; got != want {
+		got, err := apiCli.CatalogAvailable(context.Background(), "my-user-agent")
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		if got, want := got, true; got != want {
 			t.Errorf("got: %t, want: %t", got, want)
 		}
 	})
 
 	t.Run("CatalogAvailable - returns false for incorrect media type", func(t *testing.T) {
 		apiCli := &OciAPIClient{
-			Url: urlWithNamespace,
-			NetClient: &goodOCIAPIHTTPClient{
+			RegistryNamespaceUrl: urlWithNamespace,
+			HttpClient: &goodOCIAPIHTTPClient{
 				responseByPath: map[string]string{
 					"/v2/test/project/charts-index/manifests/latest": `{"config": {"mediaType": "something-else"}}`,
 				},
 			},
 		}
 
-		if got, want := apiCli.CatalogAvailable("my-user-agent"), false; got != want {
+		got, err := apiCli.CatalogAvailable(context.Background(), "my-user-agent")
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		if got, want := got, false; got != want {
 			t.Errorf("got: %t, want: %t", got, want)
 		}
 	})
 
 	t.Run("CatalogAvailable - returns false for a 404", func(t *testing.T) {
 		apiCli := &OciAPIClient{
-			Url: urlWithNamespace,
-			NetClient: &goodOCIAPIHTTPClient{
+			RegistryNamespaceUrl: urlWithNamespace,
+			HttpClient: &goodOCIAPIHTTPClient{
 				responseByPath: map[string]string{
 					"/v2/test/project/chart-index/manifests/latest": chartsIndexMultipleJSON,
 				},
 			},
 		}
 
-		if got, want := apiCli.CatalogAvailable("my-user-agent"), false; got != want {
+		got, err := apiCli.CatalogAvailable(context.Background(), "my-user-agent")
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		if got, want := got, false; got != want {
 			t.Errorf("got: %t, want: %t", got, want)
 		}
 	})
 
 	t.Run("CatalogAvailable - returns false on any other", func(t *testing.T) {
 		apiCli := &OciAPIClient{
-			Url:       urlWithNamespace,
-			NetClient: &badHTTPClient{},
+			RegistryNamespaceUrl: urlWithNamespace,
+			HttpClient:           &badHTTPClient{},
 		}
 
-		if got, want := apiCli.CatalogAvailable("my-user-agent"), false; got != want {
+		got, err := apiCli.CatalogAvailable(context.Background(), "my-user-agent")
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		if got, want := got, false; got != want {
 			t.Errorf("got: %t, want: %t", got, want)
 		}
 	})
 
 	t.Run("Catalog - successful request", func(t *testing.T) {
 		apiCli := &OciAPIClient{
-			Url: urlWithNamespace,
-			NetClient: &goodOCIAPIHTTPClient{
+			RegistryNamespaceUrl: urlWithNamespace,
+			HttpClient: &goodOCIAPIHTTPClient{
 				responseByPath: map[string]string{
 					"/v2/test/project/charts-index/manifests/latest":                                                              chartsIndexManifestJSON,
 					"/v2/test/project/charts-index/blobs/sha256:f9f7df0ae3f50aaf9ff390034cec4286d2aa43f061ce4bc7aa3c9ac862800aba": chartsIndexMultipleJSON,
@@ -978,8 +973,8 @@ func (o *fakeOCIAPICli) IsHelmChart(appName, tag, userAgent string) (bool, error
 	return true, o.err
 }
 
-func (o *fakeOCIAPICli) CatalogAvailable(userAgent string) bool {
-	return false
+func (o *fakeOCIAPICli) CatalogAvailable(ctx context.Context, userAgent string) (bool, error) {
+	return false, nil
 }
 
 func (o *fakeOCIAPICli) Catalog(userAgent string) ([]string, error) {
@@ -1381,8 +1376,8 @@ version: 1.0.0
 					Checksum: "123",
 				},
 				ociCli: &OciAPIClient{
-					Url: url,
-					NetClient: &goodOCIAPIHTTPClient{
+					RegistryNamespaceUrl: url,
+					HttpClient: &goodOCIAPIHTTPClient{
 						responseByPath: tags,
 					},
 				},
@@ -1427,8 +1422,8 @@ version: 1.0.0
 				Checksum: "123",
 			},
 			ociCli: &OciAPIClient{
-				Url: url,
-				NetClient: &goodOCIAPIHTTPClient{
+				RegistryNamespaceUrl: url,
+				HttpClient: &goodOCIAPIHTTPClient{
 					responseByPath: fakeURIs,
 				},
 			},

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -782,24 +782,6 @@ func (h *goodOCIAPIHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return w.Result(), nil
 }
 
-type authenticatedOCIAPIHTTPClient struct {
-	response string
-}
-
-func (h *authenticatedOCIAPIHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	w := httptest.NewRecorder()
-
-	// Ensure we're sending the right Authorization header
-	if req.Header.Get("Authorization") != "Bearer ThisSecretAccessTokenAuthenticatesTheClient" {
-		w.WriteHeader(500)
-	}
-	_, err := w.Write([]byte(h.response))
-	if err != nil {
-		log.Fatalf("%+v", err)
-	}
-	return w.Result(), nil
-}
-
 func Test_ociAPICli(t *testing.T) {
 	url, _ := parseRepoURL("http://oci-test")
 

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_validation.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_validation.go
@@ -216,35 +216,63 @@ func getOCIAppRepositoryMediaType(client httpclient.Client, repoURL string, repo
 
 // validateOCIAppRepository validates OCI Repos only
 // return true if mediaType == "application/vnd.cncf.helm.config" otherwise false
-func (v *HelmOCIValidator) validateOCIAppRepository(appRepo *apprepov1alpha1.AppRepository, cli httpclient.Client) (bool, error) {
+func (v *HelmOCIValidator) validateOCIAppRepository(ctx context.Context, appRepo *apprepov1alpha1.AppRepository) (bool, error) {
 
 	repoURL := strings.TrimSuffix(strings.TrimSpace(appRepo.Spec.URL), "/")
 	// If the app repo url was specified using the oci protocol - "oci://" -
 	// then we need to replace it to interact with the http(s) distribution
 	// spec API.
 	repoURL = strings.Replace(repoURL, "oci://", fmt.Sprintf("%s://", v.OCIReplacementProto), 1)
+
+	var httpCLI httpclient.Client
+	var err error
+	if v.ClientGetter != nil {
+		httpCLI, err = v.ClientGetter(v.AppRepo, v.Secret)
+		if err != nil {
+			return false, err
+		}
+	}
+	// First move below, but final will be to move this into the oci api client?
+
 	// For the OCI case, if no repositories are listed then we validate that a
 	// catalog is available for the registry, otherwise we want to validate that
 	// all the listed repositories are valid
 	if len(appRepo.Spec.OCIRepositories) == 0 {
+		if v.ClientGetter == nil {
+			return false, fmt.Errorf("an http ClientGetter is required to validate a repository")
+		}
 		u, err := url.Parse(repoURL)
 		if err != nil {
 			log.Errorf("Could not parse URL: %+v", err)
 			return false, err
 		}
-		oci := utils.OciAPIClient{AuthHeader: "", Url: u, NetClient: cli}
-		if oci.CatalogAvailable("") {
+		var grpcClient ocicatalog.OCICatalogServiceClient
+		if v.OCICatalogAddr != "" {
+			var closer func()
+			grpcClient, closer, err = ocicatalog_client.NewClient(v.OCICatalogAddr)
+			if err != nil {
+				return false, err
+			}
+			defer closer()
+		}
+		oci := utils.OciAPIClient{RegistryNamespaceUrl: u, HttpClient: httpCLI, GrpcClient: grpcClient}
+		if available, err := oci.CatalogAvailable(ctx, ""); err != nil {
+			log.Errorf("error calling CatalogAvailable: %+v", err)
+			return false, err
+		} else if available {
 			return true, nil
 		}
+
 		return false, ErrEmptyOCIRegistry
 	}
+
 	for _, repoName := range appRepo.Spec.OCIRepositories {
-		tagVersion, err := getOCIAppRepositoryTag(cli, repoURL, repoName)
+		tagVersion, err := getOCIAppRepositoryTag(httpCLI, repoURL, repoName)
 		if err != nil {
 			return false, err
 		}
 
-		mediaType, err := getOCIAppRepositoryMediaType(cli, repoURL, repoName, tagVersion)
+		mediaType, err := getOCIAppRepositoryMediaType(httpCLI, repoURL, repoName, tagVersion)
 		if err != nil {
 			return false, err
 		}
@@ -315,15 +343,15 @@ type HelmOCIValidator struct {
 	OCIReplacementProto string
 }
 
-func queryOCICatalog(ctx context.Context, ociCatalogAddr string, appRepoURL string) (*ValidationResponse, error) {
+func queryOCICatalog(ctx context.Context, ociCatalogAddr string, appRepoURL string) (bool, error) {
 	u, err := url.Parse(appRepoURL)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse URL for OCI Catalog %q: %+v", appRepoURL, err)
+		return false, fmt.Errorf("unable to parse URL for OCI Catalog %q: %+v", appRepoURL, err)
 	}
 
 	client, closer, err := ocicatalog_client.NewClient(ociCatalogAddr)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 	defer closer()
 
@@ -333,15 +361,15 @@ func queryOCICatalog(ctx context.Context, ociCatalogAddr string, appRepoURL stri
 		ContentTypes: []string{"helm"},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error querying OCI Catalog for repos: %+v", err)
+		return false, fmt.Errorf("error querying OCI Catalog for repos: %+v", err)
 	}
 
 	// It's enough to receive a single repo to be valid.
 	_, err = repos_stream.Recv()
 	if err != nil {
-		return nil, fmt.Errorf("error receiving OCI Repositories: %+v", err)
+		return false, fmt.Errorf("error receiving OCI Repositories: %+v", err)
 	}
-	return &ValidationResponse{Code: 200, Message: "OK"}, nil
+	return true, nil
 }
 
 func (v HelmOCIValidator) Validate(ctx context.Context) (*ValidationResponse, error) {
@@ -351,28 +379,11 @@ func (v HelmOCIValidator) Validate(ctx context.Context) (*ValidationResponse, er
 		return nil, fmt.Errorf("unable to validate without either http client or OCI Catalog address")
 	}
 
+<<<<<<< HEAD
 	// Prefer the OCI Catalog service, but we just log and ignore errors
 	// for now so that behaviour does not change for VAC index support.
 	if v.OCICatalogAddr != "" {
-		resp, err := queryOCICatalog(ctx, v.OCICatalogAddr, v.AppRepo.Spec.URL)
-		if err == nil {
-			return resp, nil
-		}
-		log.Errorf("Unable to query OCI Catalog service at %q: %+v", v.OCICatalogAddr, err)
-	}
-
-	if v.ClientGetter == nil {
-		return nil, fmt.Errorf("unable to validate without http client")
-	}
-	var response *ValidationResponse
-	response = &ValidationResponse{Code: 200, Message: "OK"}
-
-	cli, err := v.ClientGetter(v.AppRepo, v.Secret)
-	if err != nil {
-		return nil, err
-	}
-	// If there was an error validating the OCI repository, it's not an internal error.
-	isValidRepo, err := v.validateOCIAppRepository(v.AppRepo, cli)
+		resp, err , err := v.validateOCIAppRepository(ctx, v.AppRepo)
 	if err != nil || !isValidRepo {
 		response = &ValidationResponse{Code: 400, Message: err.Error()}
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_validation_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_validation_test.go
@@ -442,6 +442,11 @@ func TestOCIValidateWithCatalogServer(t *testing.T) {
 	ociCatalogAddr, ociCatalogDouble, cleanup := ocicatalog_clienttest.SetupTestDouble(t)
 	defer cleanup()
 
+	// We don't want to use the http client at all in these tests.
+	fakeClient := &fakeHTTPCli{
+		response: nil,
+		err:      fmt.Errorf("should not be used"),
+	}
 	testCases := []struct {
 		name             string
 		repos            []*ocicatalog.Repository
@@ -458,6 +463,9 @@ func TestOCIValidateWithCatalogServer(t *testing.T) {
 					},
 				},
 				OCICatalogAddr: ociCatalogAddr,
+				ClientGetter: func(*v1alpha1.AppRepository, *corev1.Secret) (httpclient.Client, error) {
+					return fakeClient, nil
+				},
 			},
 			repos: []*ocicatalog.Repository{
 				{
@@ -481,6 +489,9 @@ func TestOCIValidateWithCatalogServer(t *testing.T) {
 					},
 				},
 				OCICatalogAddr: ociCatalogAddr,
+				ClientGetter: func(*v1alpha1.AppRepository, *corev1.Secret) (httpclient.Client, error) {
+					return fakeClient, nil
+				},
 			},
 			repos: []*ocicatalog.Repository{
 				{
@@ -501,8 +512,14 @@ func TestOCIValidateWithCatalogServer(t *testing.T) {
 					},
 				},
 				OCICatalogAddr: ociCatalogAddr,
+				ClientGetter: func(*v1alpha1.AppRepository, *corev1.Secret) (httpclient.Client, error) {
+					return fakeClient, nil
+				},
 			},
-			expectError: true,
+			expectedResponse: &ValidationResponse{
+				Code:    400,
+				Message: "unable to determine the OCI catalog, you need to specify at least one repository",
+			},
 		},
 	}
 

--- a/pkg/ocicatalog_client/ocicatalog_client.go
+++ b/pkg/ocicatalog_client/ocicatalog_client.go
@@ -11,7 +11,14 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+const (
+	CONTENT_TYPE_HELM = "helm"
+)
+
 func NewClient(ociCatalogAddr string) (ocicatalog.OCICatalogServiceClient, func(), error) {
+	if ociCatalogAddr == "" {
+		return nil, nil, fmt.Errorf("ociCatalogAddr must be specified")
+	}
 	conn, err := grpc.Dial(ociCatalogAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to contact OCI Catalog at %q: %+v", ociCatalogAddr, err)


### PR DESCRIPTION
### Description of the change

This PR moves the validation code that checks the oci-catalog service into the existing OCIApiClient itself, so that we can use the same and encapsulate the functionality in the one place - the OCIApiClient - when adding the sync functionality.

### Benefits

Functionality encapsulated in the one client. Also improves existing code to use contexts in network calls.

Also removes the `AuthHeader` that was not being used, since some time ago we switched to creating the http client using the header, so the auth is present there already.

### Possible drawbacks

None that I can see (let CI determine).

### Applicable issues

- ref #6263 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
