### PR TITLE
Use the OCI Catalog when syncing charts.

### DIFF
--- a/cmd/asset-syncer/server/sync.go
+++ b/cmd/asset-syncer/server/sync.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -20,6 +21,7 @@ func Sync(serveOpts Config, version string, args []string) error {
 		return fmt.Errorf("need exactly three arguments: [REPO NAME] [REPO URL] [REPO TYPE] (got %v)", len(args))
 	}
 
+	ctx := context.Background()
 	dbConfig := dbutils.Config{URL: serveOpts.DatabaseURL, Database: serveOpts.DatabaseName, Username: serveOpts.DatabaseUser, Password: serveOpts.DatabasePassword}
 	globalPackagingNamespace := serveOpts.GlobalPackagingNamespace
 	manager, err := newManager(dbConfig, globalPackagingNamespace)
@@ -66,7 +68,7 @@ func Sync(serveOpts Config, version string, args []string) error {
 		return fmt.Errorf("error: %v", err)
 	}
 	repo := repoIface.AppRepository()
-	checksum, err := repoIface.Checksum()
+	checksum, err := repoIface.Checksum(ctx)
 	if err != nil {
 		return fmt.Errorf("error: %v", err)
 	}
@@ -90,7 +92,7 @@ func Sync(serveOpts Config, version string, args []string) error {
 	}
 
 	for _, fetchLatestOnly := range fetchLatestOnlySlice {
-		charts, err := repoIface.Charts(fetchLatestOnly)
+		charts, err := repoIface.Charts(ctx, fetchLatestOnly)
 		if err != nil {
 			return fmt.Errorf("error: %v", err)
 		}


### PR DESCRIPTION
### Description of the change

This PR updates the sync code to also try the OCI Catalog service for app repositories where the repos aren't listed (after trying the VAC index).

### Benefits

Finishes the work of #6263, although, as we've discussed, to benefit from this (ie. be able to add the public bitnami OCI repo), we need to add a couple more features, since currently it uses the existing OCI Distribution API which *requires* authentication. We'd like to ensure people don't need authentication to use a public OCI namespace, such as the bitnami catalog.

### Possible drawbacks


### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #6263

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
