### PR TITLE
Pass OCI Catalog URL through to syncer.

### DIFF
--- a/chart/kubeapps/templates/apprepository/deployment.yaml
+++ b/chart/kubeapps/templates/apprepository/deployment.yaml
@@ -128,6 +128,10 @@ spec:
           env:
             - name: REPO_SYNC_IMAGE
               value: {{ include "kubeapps.apprepository.syncImage" . }}
+            {{- if .Values.ociCatalog.enabled }}
+            - name: OCI_CATALOG_URL
+              value: {{ printf "%s:%d" (include "kubeapps.kubeappsapis.fullname" .) (int .Values.ociCatalog.containerPorts.grpc) | quote }}
+            {{- end }}
             {{- if .Values.apprepository.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.apprepository.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -166,8 +166,10 @@ spec:
                 secretKeyRef:
                   key: postgres-password
                   name: {{ include "kubeapps.postgresql.secretName" . }}
+            {{- if .Values.ociCatalog.enabled }}
             - name: OCI_CATALOG_URL
               value: {{ printf ":%d" (int .Values.ociCatalog.containerPorts.grpc) | quote }}
+            {{- end }}
             {{- end }}
             {{- if .Values.kubeappsapis.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.extraEnvVars "context" $) | nindent 12 }}

--- a/chart/kubeapps/templates/kubeappsapis/service.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/service.yaml
@@ -29,5 +29,11 @@ spec:
       targetPort: grpc-http
       protocol: TCP
       name: grpc-http
+    {{- if .Values.ociCatalog.enabled }}
+    - port: {{ .Values.ociCatalog.containerPorts.grpc }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: kubeappsapis

--- a/cmd/apprepository-controller/cmd/root.go
+++ b/cmd/apprepository-controller/cmd/root.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"flag"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -47,6 +48,9 @@ func initServerOpts() {
 	serveOpts.ImagePullSecretsRefs = getImagePullSecretsRefs(serveOpts.RepoSyncImagePullSecrets)
 	serveOpts.ParsedCustomAnnotations = parseLabelsAnnotations(serveOpts.CustomAnnotations)
 	serveOpts.ParsedCustomLabels = parseLabelsAnnotations(serveOpts.CustomLabels)
+	if serveOpts.OciCatalogUrl == "" {
+		serveOpts.OciCatalogUrl = os.Getenv("OCI_CATALOG_URL")
+	}
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -92,12 +96,12 @@ func setFlags(c *cobra.Command) {
 	c.Flags().StringSliceVar(&serveOpts.CustomAnnotations, "custom-annotations", []string{""}, "Optional annotations to be passed to the generated CronJobs, Jobs and Pods objects. For example: my/annotation=foo")
 	c.Flags().StringSliceVar(&serveOpts.CustomLabels, "custom-labels", []string{""}, "Optional labels to be passed to the generated CronJobs, Jobs and Pods objects. For example: my/label=foo")
 	c.Flags().BoolVar(&serveOpts.V1Beta1CronJobs, "v1-beta1-cron-jobs", false, "Defaults to false and so using the v1 cronjobs.")
+	c.Flags().StringVar(&serveOpts.OciCatalogUrl, "oci-catalog-url", "", "URL for gRPC OCI Catalog service")
 }
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
 	viper.AutomaticEnv() // read in environment variables that match
-
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
 		log.Infof("Using config file: %v", viper.ConfigFileUsed())

--- a/cmd/apprepository-controller/server/job_utils.go
+++ b/cmd/apprepository-controller/server/job_utils.go
@@ -163,6 +163,12 @@ func apprepoJobEnvVars(apprepo *apprepov1alpha1.AppRepository, config Config) []
 			},
 		},
 	})
+	if config.OciCatalogUrl != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "OCI_CATALOG_URL",
+			Value: config.OciCatalogUrl,
+		})
+	}
 	if apprepo.Spec.Auth.Header != nil {
 		if apprepo.Spec.Auth.Header.SecretKeyRef.Key == ".dockerconfigjson" {
 			envVars = append(envVars, corev1.EnvVar{

--- a/cmd/apprepository-controller/server/server.go
+++ b/cmd/apprepository-controller/server/server.go
@@ -41,6 +41,7 @@ type Config struct {
 	ParsedCustomAnnotations    map[string]string
 	ParsedCustomLabels         map[string]string
 	V1Beta1CronJobs            bool
+	OciCatalogUrl              string
 }
 
 func Serve(serveOpts Config) error {

--- a/cmd/asset-syncer/cmd/root.go
+++ b/cmd/asset-syncer/cmd/root.go
@@ -115,6 +115,7 @@ func init() {
 	serveOpts.KubeappsNamespace = os.Getenv("POD_NAMESPACE")
 	serveOpts.AuthorizationHeader = os.Getenv("AUTHORIZATION_HEADER")
 	serveOpts.DockerConfigJson = os.Getenv("DOCKER_CONFIG_JSON")
+	serveOpts.OCICatalogURL = os.Getenv("OCI_CATALOG_URL")
 }
 
 func setRootFlags(c *cobra.Command) {

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -311,14 +311,17 @@ func Test_syncURLInvalidity(t *testing.T) {
 }
 
 func Test_getOCIRepo(t *testing.T) {
+	grpcClient, f, err := ocicatalog_client.NewClient("test")
+	assert.NoError(t, err)
+	defer f()
 	t.Run("it should add the auth header to the resolver", func(t *testing.T) {
-		repo, err := getOCIRepo("namespace", "test", "https://test", "Basic auth", nil, []string{}, &http.Client{})
+		repo, err := getOCIRepo("namespace", "test", "https://test", "Basic auth", nil, []string{}, &http.Client{}, &grpcClient)
 		assert.NoError(t, err)
 		helmtest.CheckHeader(t, repo.(*OCIRegistry).puller, "Authorization", "Basic auth")
 	})
 
 	t.Run("it should use https for distribution spec API calls if protocol is oci", func(t *testing.T) {
-		repo, err := getOCIRepo("namespace", "test", "oci://test", "Basic auth", nil, []string{}, &http.Client{})
+		repo, err := getOCIRepo("namespace", "test", "oci://test", "Basic auth", nil, []string{}, &http.Client{}, &grpcClient)
 		assert.NoError(t, err)
 
 		client := repo.(*OCIRegistry).ociCli


### PR DESCRIPTION
### Description of the change

Updates the dev chart and snippets of code so that if the OCI-Catalog service is enabled, the URL is passed all the way through to the sync job.

Verified from the logs:

```
I0829 01:33:33.729325       1 root.go:32] "The component 'asset-syncer' has been configured with" serverOptions={"DatabaseURL":"kubeapps-postgresql:5432","DatabaseName":"assets","DatabaseUser":"postgres","DatabasePassword":"REDACTED","Debug":false,"Namespace":"default","OciRepositories":[],"TlsInsecureSkipVerify":false,"FilterRules":"","PassCredentials":false,"UserAgent":"asset-syncer/903124d9eb9976d7cad846331c20440132b143df (kubeapps/DEVEL)","UserAgentComment":"kubeapps/DEVEL","GlobalPackagingNamespace":"kubeapps","KubeappsNamespace":"","AuthorizationHeader":"","DockerConfigJson":"","OCICatalogURL":"kubeapps-internal-kubeappsapis:50061"}
I0829 01:33:34.926684       1 utils.go:495] Unable to find VAC index: .... Attempting OCI-Catalog
Error: error: GET request to [https://registry-1.docker.io/v2/bitnamicharts/airflow/tags/list] failed due to status [401]: {"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":[{"Type":"repository","Class":"","Name":"bitnamicharts/airflow","Action":"pull"}]}]}

```

### Benefits

Can start next step of getting an anon token to continue the sync.

### Possible drawbacks


### Applicable issues


- ref #6706 

### Additional information

This should really have been done as part of the previous #6263 where I updated the sync code to use the new service, but didn't hook it up.