### PR TITLE
Removing httpclient.Client interface.

### DIFF
--- a/cmd/asset-syncer/server/utils.go
+++ b/cmd/asset-syncer/server/utils.go
@@ -136,7 +136,7 @@ type ChartCatalog interface {
 type HelmRepo struct {
 	content []byte
 	*models.AppRepositoryInternal
-	netClient httpclient.Client
+	netClient *http.Client
 	filter    *apprepov1alpha1.FilterRuleSpec
 }
 
@@ -781,7 +781,7 @@ func parseFilters(filters string) (*apprepov1alpha1.FilterRuleSpec, error) {
 	return filterSpec, nil
 }
 
-func getHelmRepo(namespace, name, repoURL, authorizationHeader string, filter *apprepov1alpha1.FilterRuleSpec, netClient httpclient.Client, userAgent string) (ChartCatalog, error) {
+func getHelmRepo(namespace, name, repoURL, authorizationHeader string, filter *apprepov1alpha1.FilterRuleSpec, netClient *http.Client, userAgent string) (ChartCatalog, error) {
 	url, err := parseRepoURL(repoURL)
 	if err != nil {
 		log.Errorf("Failed to parse URL, url=%s: %v", repoURL, err)

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
@@ -95,7 +95,6 @@ func (s *Server) newRepo(ctx context.Context, headers http.Header, repo *HelmRep
 	if err != nil {
 		return nil, err
 	}
-
 	// Repository validation
 	if repo.customDetail != nil && repo.customDetail.PerformValidation {
 		if err = s.ValidateRepository(ctx, helmRepoCrd, secret); err != nil {

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_validation.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_validation.go
@@ -77,7 +77,7 @@ func (s *Server) getValidator(appRepo *apprepov1alpha1.AppRepository, secret *co
 	}
 }
 
-func newRepositoryClient(appRepo *apprepov1alpha1.AppRepository, secret *corev1.Secret) (httpclient.Client, error) {
+func newRepositoryClient(appRepo *apprepov1alpha1.AppRepository, secret *corev1.Secret) (*http.Client, error) {
 	if cli, err := helm.InitNetClient(appRepo, secret, secret, nil); err != nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("Unable to create HTTP client for repository: %w", err))
 	} else {

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -30,7 +30,6 @@ import (
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/plugins/pkg/resourcerefs"
 	"github.com/vmware-tanzu/kubeapps/pkg/chart/models"
 	"github.com/vmware-tanzu/kubeapps/pkg/dbutils"
-	httpclient "github.com/vmware-tanzu/kubeapps/pkg/http-client"
 	"github.com/vmware-tanzu/kubeapps/pkg/kube"
 	"google.golang.org/protobuf/types/known/anypb"
 	"helm.sh/helm/v3/pkg/action"
@@ -59,7 +58,7 @@ const (
 )
 
 type createRelease func(*action.Configuration, string, string, string, *chart.Chart, map[string]string, int32) (*release.Release, error)
-type repositoryClientGetter func(appRepo *appRepov1.AppRepository, secret *corek8sv1.Secret) (httpclient.Client, error)
+type repositoryClientGetter func(appRepo *appRepov1.AppRepository, secret *corek8sv1.Secret) (*http.Client, error)
 
 // Server implements the helm packages v1alpha1 interface.
 type Server struct {

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/test_util_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/test_util_test.go
@@ -9,13 +9,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
 	appRepov1 "github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	corev1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	plugins "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
-	httpclient "github.com/vmware-tanzu/kubeapps/pkg/http-client"
 	apiv1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -160,24 +160,24 @@ func addTlsToSecret(secret *apiv1.Secret, pub, priv, ca []byte) *apiv1.Secret {
 	return secret
 }
 
-func newRepoHttpClient(responses map[string]*http.Response) repositoryClientGetter {
-	return func(appRepo *appRepov1.AppRepository, secret *apiv1.Secret) (httpclient.Client, error) {
-		return &fakeHTTPClient{
-			responses: responses,
-		}, nil
-	}
-}
-
-type fakeHTTPClient struct {
-	responses map[string]*http.Response
-}
-
-func (f *fakeHTTPClient) Do(h *http.Request) (*http.Response, error) {
-	if resp, ok := f.responses[h.URL.String()]; !ok {
-		return nil, fmt.Errorf("url requested '%s' not found in valid responses %v", h.URL.String(), f.responses)
-	} else {
-		return resp, nil
-	}
+func newFakeRepoServer(t *testing.T, responses map[string]*http.Response) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for path, response := range responses {
+			if path == r.URL.Path {
+				w.WriteHeader(response.StatusCode)
+				body := []byte{}
+				if response.Body != nil {
+					var err error
+					body, err = io.ReadAll(response.Body)
+					if err != nil {
+						t.Fatalf("%+v", err)
+					}
+				}
+				w.Write(body)
+				return
+			}
+		}
+	}))
 }
 
 func httpResponse(statusCode int, body string) *http.Response {

--- a/pkg/helm/chartclient.go
+++ b/pkg/helm/chartclient.go
@@ -6,13 +6,14 @@ package helm
 import (
 	"crypto/tls"
 	"fmt"
+	"net/http"
+	"net/url"
+
 	"github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	httpclient "github.com/vmware-tanzu/kubeapps/pkg/http-client"
 	"github.com/vmware-tanzu/kubeapps/pkg/kube"
 	"golang.org/x/net/http/httpproxy"
 	corev1 "k8s.io/api/core/v1"
-	"net/http"
-	"net/url"
 )
 
 // InitHTTPClient returns an HTTP client using the configuration from the apprepo and CA secret given.
@@ -60,7 +61,7 @@ func InitHTTPClient(appRepo *v1alpha1.AppRepository, caCertSecret *corev1.Secret
 
 // InitNetClient returns an HTTP client based on the chart details loading a
 // custom CA if provided (as a secret)
-func InitNetClient(appRepo *v1alpha1.AppRepository, caCertSecret, authSecret *corev1.Secret, defaultHeaders http.Header) (httpclient.Client, error) {
+func InitNetClient(appRepo *v1alpha1.AppRepository, caCertSecret, authSecret *corev1.Secret, defaultHeaders http.Header) (*http.Client, error) {
 	netClient, err := InitHTTPClient(appRepo, caCertSecret)
 	if err != nil {
 		return nil, err
@@ -77,10 +78,7 @@ func InitNetClient(appRepo *v1alpha1.AppRepository, caCertSecret, authSecret *co
 		defaultHeaders.Set("Authorization", auth)
 	}
 
-	return &httpclient.ClientWithDefaults{
-		Client:         netClient,
-		DefaultHeaders: defaultHeaders,
-	}, nil
+	return httpclient.NewDefaultHeaderClient(netClient, defaultHeaders), nil
 }
 
 func getProxyConfig(appRepo *v1alpha1.AppRepository) *httpproxy.Config {

--- a/pkg/http-client/httpclient_test.go
+++ b/pkg/http-client/httpclient_test.go
@@ -7,12 +7,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	errors "errors"
-	"github.com/google/go-cmp/cmp"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 const pemCert = `
@@ -218,7 +220,7 @@ func (c testClient) Do(req *http.Request) (*http.Response, error) {
 		Header: req.Header,
 	}, nil
 }
-func TestClientWithDefaults(t *testing.T) {
+func TestDefaultHeaderTransport(t *testing.T) {
 	initialHdrName := "TestHeader"
 	initialHdrValue := "TestHeaderValue"
 	initialHeaders := http.Header{initialHdrName: {initialHdrValue}}
@@ -265,39 +267,47 @@ func TestClientWithDefaults(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
-			// test client to capture headers
-			testclient := &testClient{}
+			var headersReceived http.Header
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				headersReceived = r.Header
+				fmt.Fprintln(w, "Hello, world")
+			}))
+			defer server.Close()
 
 			// init invocation
-			client := &ClientWithDefaults{
-				Client:         testclient,
-				DefaultHeaders: tc.headers,
+			client := http.Client{
+				Transport: &DefaultHeaderTransport{
+					DefaultHeaders: tc.headers,
+					Transport:      http.DefaultTransport,
+				},
 			}
 
 			requestHeaders := http.Header{}
 			for k, v := range tc.initialHeaders {
 				requestHeaders[k] = v
 			}
+			testURL, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
 			request := &http.Request{
 				Header: requestHeaders,
+				URL:    testURL,
 			}
 
 			// invocation
-			response, err := client.Do(request)
-			if err != nil || response == nil || response.Header == nil {
-				t.Fatal("unexpected error during invocation")
+			_, err = client.Do(request)
+			if err != nil {
+				t.Fatalf("unexpected error during invocation: %+v", err)
 			}
-
-			// check
-			if len(response.Header) != len(tc.expectedHeaders) {
-				t.Fatalf("response header length differs from expected, got {%+v} when expecting {%+v}", response.Header, tc.expectedHeaders)
+			// The default transport adds `Accept-Encoding` and `User-Agent`.
+			if len(headersReceived) != len(tc.expectedHeaders)+2 {
+				t.Fatalf("response header length differs from expected, got {%+v} when expecting {%+v}", headersReceived, tc.expectedHeaders)
 			}
-			for k := range tc.expectedHeaders {
-				got := response.Header.Get(k)
-				expected := tc.expectedHeaders.Get(k)
-				if got != expected {
-					t.Fatalf("response header differs from expected, got {%s} when expecting {%s}", got, expected)
+			for k, expected := range tc.expectedHeaders {
+				got := headersReceived.Get(k)
+				if got != expected[0] {
+					t.Fatalf("requested header differs from expected, got {%s} when expecting {%s}", got, expected)
 				}
 			}
 		})

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
+	"net/http"
 	"path"
 	"regexp"
 	"strings"
@@ -19,7 +20,7 @@ import (
 // Fetches helm chart details from a gzipped tarball
 //
 // name is expected in format "foo/bar" or "foo%2Fbar" if url-escaped
-func FetchChartDetailFromTarballUrl(chartTarballURL string, userAgent string, authz string, netClient httpclient.Client) (map[string]string, error) {
+func FetchChartDetailFromTarballUrl(chartTarballURL string, userAgent string, authz string, netClient *http.Client) (map[string]string, error) {
 	reqHeaders := make(map[string]string)
 	if len(userAgent) > 0 {
 		reqHeaders["User-Agent"] = userAgent


### PR DESCRIPTION
### Description of the change

Part 1 removing the httpclient.Client interface. See #6726 for which this is needed.

### Benefits

Able to write code that expects a plain http.Client.
Better tests.

### Possible drawbacks

### Applicable issues

- ref #6726

### Additional information
