### PR TITLE
Part two removing test interface httpclient.Client

### DIFF
--- a/cmd/asset-syncer/server/utils.go
+++ b/cmd/asset-syncer/server/utils.go
@@ -303,7 +303,7 @@ type OCIRegistry struct {
 	filter *apprepov1alpha1.FilterRuleSpec
 }
 
-func doReq(url string, cli httpclient.Client, headers map[string]string, userAgent string) ([]byte, error) {
+func doReq(url string, cli *http.Client, headers map[string]string, userAgent string) ([]byte, error) {
 	headers["User-Agent"] = userAgent
 	return httpclient.Get(url, cli, headers)
 }
@@ -342,7 +342,7 @@ type OciAPIClient struct {
 	RegistryNamespaceUrl *url.URL
 	// The HttpClient is used for all http requests to the OCI Distribution
 	// spec API.
-	HttpClient httpclient.Client
+	HttpClient *http.Client
 	// The GrpcClient is used when querying our OCI Catalog service, which
 	// aims to work around some of the shortfalls of the OCI Distribution spec
 	// API
@@ -834,7 +834,7 @@ func getOCIRepo(namespace, name, repoURL, authorizationHeader string, filter *ap
 	}, nil
 }
 
-func fetchRepoIndex(url, authHeader string, cli httpclient.Client, userAgent string) ([]byte, error) {
+func fetchRepoIndex(url, authHeader string, cli *http.Client, userAgent string) ([]byte, error) {
 	indexURL, err := parseRepoURL(url)
 	if err != nil {
 		log.Errorf("Failed to parse URL, url=%s: %v", url, err)
@@ -863,7 +863,7 @@ func chartTarballURL(r *models.AppRepositoryInternal, cv models.ChartVersion) st
 
 type fileImporter struct {
 	manager   assetManager
-	netClient httpclient.Client
+	netClient *http.Client
 }
 
 func (f *fileImporter) fetchFiles(charts []models.Chart, repo ChartCatalog, userAgent string, passCredentials bool) {

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -690,32 +690,6 @@ func Test_fetchAndImportFiles(t *testing.T) {
 	})
 }
 
-type goodOCIAPIHTTPClient struct {
-	response       string
-	responseByPath map[string]string
-}
-
-func (h *goodOCIAPIHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	w := httptest.NewRecorder()
-	// Don't accept trailing slashes
-	if strings.HasPrefix(req.URL.Path, "//") {
-		w.WriteHeader(500)
-	}
-
-	if r, ok := h.responseByPath[req.URL.Path]; ok {
-		_, err := w.Write([]byte(r))
-		if err != nil {
-			log.Fatalf("%+v", err)
-		}
-	} else {
-		_, err := w.Write([]byte(h.response))
-		if err != nil {
-			log.Fatalf("%+v", err)
-		}
-	}
-	return w.Result(), nil
-}
-
 func Test_ociAPICli(t *testing.T) {
 	t.Run("TagList - failed request", func(t *testing.T) {
 		server := newFakeServer(t, map[string]*http.Response{

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_validation.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_validation.go
@@ -22,7 +22,6 @@ import (
 	// TODO(minelson): refactor these utils into shareable lib.
 	utils "github.com/vmware-tanzu/kubeapps/cmd/asset-syncer/server"
 	ocicatalog "github.com/vmware-tanzu/kubeapps/cmd/oci-catalog/gen/catalog/v1alpha1"
-	httpclient "github.com/vmware-tanzu/kubeapps/pkg/http-client"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -111,7 +110,7 @@ type repoManifest struct {
 }
 
 // getOCIAppRepositoryTag Gets a tag for the given repo URL & name
-func getOCIAppRepositoryTag(cli httpclient.Client, repoURL string, repoName string) (string, error) {
+func getOCIAppRepositoryTag(cli *http.Client, repoURL string, repoName string) (string, error) {
 	// This function is the implementation of below curl command
 	// curl -XGET -H "Authorization: Basic $harborauthz"
 	//		-H "Accept: application/vnd.oci.image.manifest.v1+json"
@@ -170,7 +169,7 @@ func getOCIAppRepositoryTag(cli httpclient.Client, repoURL string, repoName stri
 }
 
 // getOCIAppRepositoryMediaType Gets manifests config.MediaType for the given repo URL & Name
-func getOCIAppRepositoryMediaType(client httpclient.Client, repoURL string, repoName string, tagVersion string) (string, error) {
+func getOCIAppRepositoryMediaType(client *http.Client, repoURL string, repoName string, tagVersion string) (string, error) {
 	// This function is the implementation of below curl command
 	// curl -XGET -H "Authorization: Basic $harborauthz"
 	//		 -H "Accept: application/vnd.oci.image.manifest.v1+json"
@@ -224,7 +223,7 @@ func (v *HelmOCIValidator) validateOCIAppRepository(ctx context.Context, appRepo
 	// spec API.
 	repoURL = strings.Replace(repoURL, "oci://", fmt.Sprintf("%s://", v.OCIReplacementProto), 1)
 
-	var httpCLI httpclient.Client
+	var httpCLI *http.Client
 	var err error
 	if v.ClientGetter != nil {
 		httpCLI, err = v.ClientGetter(v.AppRepo, v.Secret)

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client.go
@@ -5,20 +5,20 @@ package utils
 
 import (
 	"fmt"
-	"github.com/containerd/containerd/remotes/docker"
-	appRepov1 "github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	"github.com/vmware-tanzu/kubeapps/pkg/helm"
-	httpclient "github.com/vmware-tanzu/kubeapps/pkg/http-client"
-	"github.com/vmware-tanzu/kubeapps/pkg/kube"
-	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/chart/loader"
 	"io"
-	corev1 "k8s.io/api/core/v1"
-	log "k8s.io/klog/v2"
 	"net/http"
 	"net/url"
 	"path"
 	"strings"
+
+	"github.com/containerd/containerd/remotes/docker"
+	appRepov1 "github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	"github.com/vmware-tanzu/kubeapps/pkg/helm"
+	"github.com/vmware-tanzu/kubeapps/pkg/kube"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	corev1 "k8s.io/api/core/v1"
+	log "k8s.io/klog/v2"
 
 	k8scorev1 "k8s.io/api/core/v1"
 )
@@ -53,7 +53,7 @@ type ChartClient interface {
 // HelmRepoClient struct contains the clients required to retrieve charts info
 type HelmRepoClient struct {
 	userAgent string
-	netClient httpclient.Client
+	netClient *http.Client
 }
 
 // NewChartClient returns a new ChartClient
@@ -101,7 +101,7 @@ func (c *HelmRepoClient) GetChart(details *ChartDetails, repoURL string) (*chart
 	}
 
 	log.Infof("Downloading %s ...", chartURL)
-	chart, err := fetchChart(&c.netClient, chartURL)
+	chart, err := fetchChart(c.netClient, chartURL)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func resolveChartURL(indexURL, chartURL string) (string, error) {
 }
 
 // fetchChart returns the Chart content given an URL
-func fetchChart(netClient *httpclient.Client, chartURL string) (*chart.Chart, error) {
+func fetchChart(netClient *http.Client, chartURL string) (*chart.Chart, error) {
 	req, err := getReq(chartURL)
 	if err != nil {
 		return nil, err

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client_test.go
@@ -5,23 +5,18 @@ package utils
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	appRepov1 "github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	helmfake "github.com/vmware-tanzu/kubeapps/pkg/helm/fake"
-	helmtest "github.com/vmware-tanzu/kubeapps/pkg/helm/test"
-	httpclient "github.com/vmware-tanzu/kubeapps/pkg/http-client"
-	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/repo"
-	"io"
-	corev1 "k8s.io/api/core/v1"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path"
 	"strings"
 	"testing"
-	"time"
+
+	appRepov1 "github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	helmfake "github.com/vmware-tanzu/kubeapps/pkg/helm/fake"
+	helmtest "github.com/vmware-tanzu/kubeapps/pkg/helm/test"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -70,95 +65,76 @@ func Test_resolveChartURL(t *testing.T) {
 func TestGetChartHttp(t *testing.T) {
 	const repoName = "foo-repo"
 	testCases := []struct {
-		name          string
-		chartVersion  string
-		userAgent     string
-		tarballURL    string
-		errorExpected bool
+		name         string
+		chartVersion string
+		userAgent    string
+		tarballPath  string
 	}{
 		{
 			name:         "gets the chart with tarballURL",
 			chartVersion: "5.1.1-apiVersionV1",
-			tarballURL:   "http://example.com/nginx-5.1.1-apiVersionV1.tgz",
+			tarballPath:  "/nginx-5.1.1-apiVersionV1.tgz",
 		},
 		{
 			name:         "gets the chart without a user agent",
 			chartVersion: "5.1.1-apiVersionV1",
 			userAgent:    "",
-			tarballURL:   "http://example.com/nginx-5.1.1-apiVersionV1.tgz",
+			tarballPath:  "/nginx-5.1.1-apiVersionV1.tgz",
 		},
 		{
 			name:         "gets the chart with a user agent",
 			chartVersion: "5.1.1-apiVersionV1",
 			userAgent:    "kubeapps-apis/devel",
-			tarballURL:   "http://example.com/nginx-5.1.1-apiVersionV1.tgz",
+			tarballPath:  "/nginx-5.1.1-apiVersionV1.tgz",
 		},
 		{
 			name:         "gets a v2 chart without error when v1 support not required",
 			chartVersion: "5.1.1-apiVersionV2",
-			tarballURL:   "http://example.com/nginx-5.1.1-apiVersionV2.tgz",
+			tarballPath:  "/nginx-5.1.1-apiVersionV2.tgz",
 		},
 	}
 
-	const repoURL = "http://example.com/"
 	for _, tc := range testCases {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == tc.tarballPath {
+				data, err := os.ReadFile(path.Join(".", "testdata", tc.tarballPath))
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				w.WriteHeader(200)
+				_, err = w.Write(data)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				return
+			}
+			w.WriteHeader(404)
+		}))
+		defer server.Close()
 		target := ChartDetails{
 			AppRepositoryResourceName: repoName,
 			ChartName:                 "nginx",
 			Version:                   tc.chartVersion,
-			TarballURL:                tc.tarballURL,
+			TarballURL:                server.URL + tc.tarballPath,
 		}
 		t.Run(tc.name, func(t *testing.T) {
-			httpClient := newHTTPClient(repoURL, []ChartDetails{target}, tc.userAgent)
+
 			chUtils := HelmRepoClient{
 				userAgent: tc.userAgent,
 			}
-			chUtils.netClient = httpClient
-			ch, err := chUtils.GetChart(&target, repoURL)
+			chUtils.netClient = server.Client()
+			ch, err := chUtils.GetChart(&target, server.URL)
 
 			if err != nil {
-				if tc.errorExpected {
-					if got, want := err.Error(), "apiVersion 'v2' is not valid. The value must be \"v1\""; got != want {
-						t.Fatalf("got: %q, want: %q", got, want)
-					} else {
-						// Continue to the next test.
-						return
-					}
-				}
 				t.Fatalf("Unexpected error: %v", err)
 			}
 			if ch == nil {
 				t.Errorf("got: nil, want: non-nil")
-			} else if got, want := ch.Name(), "nginx"; got != want {
+			}
+
+			if got, want := ch.Name(), "nginx"; got != want {
 				t.Errorf("got: %q, want: %q", got, want)
 			}
-
-			requests := getFakeClientRequests(t, httpClient)
-			expectedLen := 1
-			if tc.tarballURL == "" {
-				// We expect one request for the index and one for the chart
-				expectedLen = 2
-			}
-
-			if got, want := len(requests), expectedLen; got != want {
-				t.Fatalf("got: %d, want %d", got, want)
-			}
-			for i, url := range []string{
-				repoURL + "index.yaml",
-				fmt.Sprintf("%s%s-%s.tgz", repoURL, target.ChartName, target.Version),
-			} {
-				// Skip the index.yaml request if a tarballURL is passed
-				if tc.tarballURL != "" {
-					continue
-				}
-				if got, want := requests[i].URL.String(), url; got != want {
-					t.Errorf("got: %q, want: %q", got, want)
-				}
-				if got, want := requests[i].Header.Get("User-Agent"), tc.userAgent; got != want {
-					t.Errorf("got: %q, want: %q", got, want)
-				}
-			}
-
 		})
 	}
 
@@ -258,7 +234,7 @@ func TestOCIClient(t *testing.T) {
 		ch, err := cli.GetChart(&ChartDetails{ChartName: "nginx", Version: "5.1.1"}, "http://foo/bar")
 		if ch == nil {
 			t.Errorf("Unexpected error: %s", err)
-		} 
+		}
 		if ch.Name() != "nginx" || ch.Metadata.Version != "5.1.1" {
 			t.Errorf("Unexpected chart %s:%s", ch.Name(), ch.Metadata.Version)
 		}
@@ -275,175 +251,9 @@ func TestOCIClient(t *testing.T) {
 		ch, err := cli.GetChart(&ChartDetails{ChartName: "nginx", Version: "5.1.1"}, "http://foo/bar%2Fbar")
 		if ch == nil {
 			t.Errorf("Unexpected error: %s", err)
-		} 
+		}
 		if ch.Name() != "nginx" || ch.Metadata.Version != "5.1.1" {
 			t.Errorf("Unexpected chart %s:%s", ch.Name(), ch.Metadata.Version)
 		}
 	})
-}
-
-func TestClientWithDefaultHeaders(t *testing.T) {
-	testCases := []struct {
-		name            string
-		requestHeaders  http.Header
-		defaultHeaders  http.Header
-		expectedHeaders http.Header
-	}{
-		{
-			name:            "no headers added when none set",
-			defaultHeaders:  http.Header{},
-			expectedHeaders: http.Header{},
-		},
-		{
-			name:            "existing headers in the request remain present",
-			requestHeaders:  http.Header{"Some-Other": []string{"value"}},
-			defaultHeaders:  http.Header{},
-			expectedHeaders: http.Header{"Some-Other": []string{"value"}},
-		},
-		{
-			name: "headers are set when present",
-			defaultHeaders: http.Header{
-				"User-Agent":    []string{"foo/devel"},
-				"Authorization": []string{"some-token"},
-			},
-			expectedHeaders: http.Header{
-				"User-Agent":    []string{"foo/devel"},
-				"Authorization": []string{"some-token"},
-			},
-		},
-		{
-			name: "headers can have multiple values",
-			defaultHeaders: http.Header{
-				"Authorization": []string{"some-token", "some-other-token"},
-			},
-			expectedHeaders: http.Header{
-				"Authorization": []string{"some-token", "some-other-token"},
-			},
-		},
-		{
-			name: "default headers do not overwrite request headers",
-			requestHeaders: http.Header{
-				"Authorization":        []string{"request-auth-token"},
-				"Other-Request-Header": []string{"other-request-header"},
-			},
-			defaultHeaders: http.Header{
-				"Authorization":        []string{"default-auth-token"},
-				"Other-Default-Header": []string{"other-default-header"},
-			},
-			expectedHeaders: http.Header{
-				"Authorization":        []string{"request-auth-token"},
-				"Other-Request-Header": []string{"other-request-header"},
-				"Other-Default-Header": []string{"other-default-header"},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			client := &fakeHTTPClient{
-				defaultHeaders: tc.defaultHeaders,
-			}
-
-			request, err := http.NewRequest("GET", "http://example.com/foo", nil)
-			if err != nil {
-				t.Fatalf("%+v", err)
-			}
-			for k, v := range tc.requestHeaders {
-				request.Header[k] = v
-			}
-			_, err = client.Do(request)
-			if err != nil && !strings.Contains(err.Error(), "Unexpected path") {
-				t.Fatalf("%+v", err)
-			}
-			requestsWithHeaders := getFakeClientRequests(t, client)
-			if got, want := len(requestsWithHeaders), 1; got != want {
-				t.Fatalf("got: %d, want: %d", got, want)
-			}
-
-			requestWithHeader := requestsWithHeaders[0]
-
-			if got, want := requestWithHeader.Header, tc.expectedHeaders; !cmp.Equal(got, want) {
-				t.Errorf(cmp.Diff(want, got))
-			}
-		})
-	}
-}
-
-// Fake server for repositories and charts
-type fakeHTTPClient struct {
-	repoURL   string
-	chartURLs []string
-	index     *repo.IndexFile
-	userAgent string
-	// TODO(absoludity): perhaps switch to use httptest instead of our own fake?
-	requests       []*http.Request
-	defaultHeaders http.Header
-}
-
-// Do for this fake client will return a chart if it exists in the
-// index *and* the corresponding chart exists in the testdata directory.
-func (f *fakeHTTPClient) Do(h *http.Request) (*http.Response, error) {
-	// Record the request for later test assertions.
-	for k, v := range f.defaultHeaders {
-		// Only add the default header if it's not already set in the request.
-		if _, ok := h.Header[k]; !ok {
-			h.Header[k] = v
-		}
-	}
-	f.requests = append(f.requests, h)
-	if f.userAgent != "" && h.Header.Get("User-Agent") != f.userAgent {
-		return nil, fmt.Errorf("Wrong user agent: %s", h.Header.Get("User-Agent"))
-	}
-	if h.URL.String() == fmt.Sprintf("%sindex.yaml", f.repoURL) {
-		// Return fake chart index
-		body, err := json.Marshal(*f.index)
-		if err != nil {
-			return nil, err
-		}
-		return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(body))}, nil
-	}
-	for _, chartURL := range f.chartURLs {
-		if h.URL.String() == chartURL {
-			// Fake chart response
-			testChartPath := path.Join(".", "testdata", h.URL.Path)
-			f, err := os.Open(testChartPath)
-			if err != nil {
-				return &http.Response{StatusCode: 404}, fmt.Errorf("unable to open test chart archive: %q", testChartPath)
-			}
-			return &http.Response{StatusCode: 200, Body: f}, nil
-		}
-	}
-	// Unexpected path
-	return &http.Response{StatusCode: 404}, fmt.Errorf("Unexpected path %q for chartURLs %+v", h.URL.String(), f.chartURLs)
-}
-
-// getFakeClientRequests returns the requests which were issued to the fake test client.
-func getFakeClientRequests(t *testing.T, c httpclient.Client) []*http.Request {
-	fakeClient, ok := c.(*fakeHTTPClient)
-	if !ok {
-		t.Fatalf("client was not a fakeHTTPClient")
-	}
-	return fakeClient.requests
-}
-
-func newHTTPClient(repoURL string, charts []ChartDetails, userAgent string) httpclient.Client {
-	var chartURLs []string
-	entries := map[string]repo.ChartVersions{}
-	// Populate Chart registry with content of the given helmReleases
-	for _, ch := range charts {
-		chartMeta := chart.Metadata{Name: ch.ChartName, Version: ch.Version}
-		chartURL := fmt.Sprintf("%s%s-%s.tgz", repoURL, ch.ChartName, ch.Version)
-		chartURLs = append(chartURLs, chartURL)
-		chartVersion := repo.ChartVersion{Metadata: &chartMeta, URLs: []string{chartURL}}
-		chartVersions := []*repo.ChartVersion{&chartVersion}
-		entries[ch.ChartName] = chartVersions
-	}
-	index := &repo.IndexFile{APIVersion: "v1", Generated: time.Now(), Entries: entries}
-	return &fakeHTTPClient{
-		repoURL:        repoURL,
-		chartURLs:      chartURLs,
-		index:          index,
-		userAgent:      userAgent,
-		defaultHeaders: http.Header{"User-Agent": []string{userAgent}},
-	}
 }

--- a/pkg/http-client/httpclient.go
+++ b/pkg/http-client/httpclient.go
@@ -18,10 +18,6 @@ const (
 	defaultTimeoutSeconds = 180
 )
 
-type Client interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
 // DefaultHeaderTransport
 //
 // Used for an http.Client that will have default headers set.
@@ -174,7 +170,7 @@ func NewClientTLS(certBytes, keyBytes, caBytes []byte) (*tls.Config, error) {
 // Get performs an HTTP GET request using provided client, URL and request headers.
 // returns response body, as bytes on successful status, or error body,
 // if applicable on error status
-func Get(url string, cli Client, headers map[string]string) ([]byte, error) {
+func Get(url string, cli *http.Client, headers map[string]string) ([]byte, error) {
 	reader, _, err := GetStream(url, cli, headers)
 	if reader != nil {
 		defer reader.Close()
@@ -190,7 +186,7 @@ func Get(url string, cli Client, headers map[string]string) ([]byte, error) {
 // if applicable on error status
 // returns response as a stream, as well as response content type
 // NOTE: it is the caller's responsibility to close the reader stream when no longer needed
-func GetStream(url string, cli Client, reqHeaders map[string]string) (io.ReadCloser, string, error) {
+func GetStream(url string, cli *http.Client, reqHeaders map[string]string) (io.ReadCloser, string, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
### Description of the change

Follows on from #6746 removing more uses of the httpclient.Client test interface that's causing pain when adding new features, and updates tests to use an `httptest.Server` instead of mocking the client.

### Benefits

See #6726 

Also fixes more tests that were feigning to assert that errors were equal, but were simply asserting that an error was raised.

### Possible drawbacks

### Applicable issues

- fixes #6726

### Additional information

~~One more PR following which removes the remainder and the interface itself.~~ (Ended up just adding to this PR).
