### PR TITLE
Less obnoxious OCI pulling on sync

### DIFF
--- a/cmd/asset-syncer/cmd/root.go
+++ b/cmd/asset-syncer/cmd/root.go
@@ -104,7 +104,7 @@ func init() {
 	log.InitFlags(nil)
 	cobra.OnInitialize(initConfig)
 	//set initial value of verbosity
-	err := flag.Set("v", "3")
+	err := flag.Set("v", "4")
 	if err != nil {
 		log.Errorf("Error parsing verbosity: %v", viper.ConfigFileUsed())
 	}

--- a/cmd/asset-syncer/server/sync.go
+++ b/cmd/asset-syncer/server/sync.go
@@ -92,8 +92,8 @@ func Sync(serveOpts Config, version string, args []string) error {
 		return nil
 	}
 
-	// First filter the list of charts (still without applying custom filters)
-	repoIface.FilterIndex()
+	// Sort the versions for each app within the catalog according to semver.
+	repoIface.SortVersions()
 
 	fetchLatestOnlySlice := []bool{false}
 	if lastChecksum == "" {

--- a/cmd/asset-syncer/server/utils.go
+++ b/cmd/asset-syncer/server/utils.go
@@ -95,17 +95,6 @@ type pullChartResult struct {
 	Error error
 }
 
-type checkTagJob struct {
-	AppName string
-	Tag     string
-}
-
-type checkTagResult struct {
-	checkTagJob
-	isHelmChart bool
-	Error       error
-}
-
 func parseRepoURL(repoURL string) (*url.URL, error) {
 	repoURL = strings.TrimSpace(repoURL)
 	return url.ParseRequestURI(repoURL)
@@ -565,13 +554,6 @@ func (o *OciAPIClient) Catalog(ctx context.Context, userAgent string) ([]string,
 	} else {
 		log.V(4).Infof("Unable to find VAC index: %+v and oci-catalog service not configured", err)
 		return nil, err
-	}
-}
-
-func tagCheckerWorker(o ociAPI, tagJobs <-chan checkTagJob, resultChan chan checkTagResult) {
-	for j := range tagJobs {
-		isHelmChart, err := o.IsHelmChart(j.AppName, j.Tag, GetUserAgent("", ""))
-		resultChan <- checkTagResult{j, isHelmChart, err}
 	}
 }
 

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -1087,27 +1087,6 @@ func Test_ociAPICli(t *testing.T) {
 	})
 }
 
-type fakeOCIAPICli struct {
-	tagList *TagList
-	err     error
-}
-
-func (o *fakeOCIAPICli) TagList(appName, userAgent string) (*TagList, error) {
-	return o.tagList, o.err
-}
-
-func (o *fakeOCIAPICli) IsHelmChart(appName, tag, userAgent string) (bool, error) {
-	return true, o.err
-}
-
-func (o *fakeOCIAPICli) CatalogAvailable(ctx context.Context, userAgent string) (bool, error) {
-	return false, nil
-}
-
-func (o *fakeOCIAPICli) Catalog(ctx context.Context, userAgent string) ([]string, error) {
-	return nil, nil
-}
-
 func Test_OCIRegistry(t *testing.T) {
 	chartYAML := `
 annotations:

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -564,7 +564,7 @@ func (r *fakeRepo) AppRepository() *models.AppRepositoryInternal {
 	return r.AppRepositoryInternal
 }
 
-func (r *fakeRepo) FilterIndex() {
+func (r *fakeRepo) SortVersions() {
 	// no-op
 }
 
@@ -1147,7 +1147,7 @@ func Test_OCIRegistry(t *testing.T) {
 		}, "expected tags")
 	})
 
-	t.Run("FilterIndex - order tags by semver", func(t *testing.T) {
+	t.Run("SortVersions - order tags by semver", func(t *testing.T) {
 		repo := OCIRegistry{
 			repositories: []string{"apache"},
 			AppRepositoryInternal: &models.AppRepositoryInternal{
@@ -1158,7 +1158,7 @@ func Test_OCIRegistry(t *testing.T) {
 			},
 			ociCli: &fakeOCIAPICli{},
 		}
-		repo.FilterIndex()
+		repo.SortVersions()
 		assert.Equal(t, repo.tags, map[string]TagList{
 			"apache": {Name: "test/apache", Tags: []string{"2.0.0", "1.1.0", "1.0.0"}},
 		}, "tag list")

--- a/pkg/helm/fake/helm.go
+++ b/pkg/helm/fake/helm.go
@@ -19,7 +19,8 @@ type OCIPuller struct {
 
 // PullOCIChart returns some fake content
 func (f *OCIPuller) PullOCIChart(ociFullName string) (*bytes.Buffer, string, error) {
-	tag := strings.Split(ociFullName, ":")[1]
+	parts := strings.Split(ociFullName, ":")
+	tag := parts[len(parts)-1]
 	if f.ExpectedName != "" && f.ExpectedName != ociFullName {
 		return nil, "", fmt.Errorf("expecting %s got %s", f.ExpectedName, ociFullName)
 	}


### PR DESCRIPTION
### Description of the change

This PR update the way we pull OCI repos, so that we:
- Don't pull all manifests of all tags to verify that they are helm charts before syncing
- Don't do an all-or-nothing sync (previous code synced all tags from the repo if the checksum differed), instead only syncing those tags that don't exist in the cache.
- Reduces the number of workers to 5 for now, but I want to put this back to 10 in a subsequent PR with other changes.

### Benefits

We can pull large OCI catalogs from public repos (in particular, can pull the Bitnami catalog from Dockerhub) without hitting public pull limits.

### Possible drawbacks

The initial time until the catalog can be used is slightly longer. But I have two things I want to improve in a subsequent PR:

- Update the cache after each app/repo is synced so they can be viewed in the catalog more quickly (more responsive). Currently it doesn't update the cache until the sync completes.
- Only sync a maximum of 5 missing tags per app per sync. This means that we can run the initial sync with 10 workers, and will get the latest 5 versions for each app, then subsequent syncs will add more each time. We should make this adjustable too, perhaps.

This combination of changes will also remove another issue we have where a subsequent sync, running within 10m of the original (by default) will do the same work currently, rather than just doing the work that hasn't been done yet.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #6706 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
