### PR TITLE
Ensure already synced versions are included in the result.

### DIFF
--- a/cmd/apprepository-controller/Dockerfile
+++ b/cmd/apprepository-controller/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax = docker/dockerfile:1
 
-FROM bitnami/golang:1.20.7 as builder
+FROM bitnami/golang:1.21.1 as builder
 WORKDIR /go/src/github.com/vmware-tanzu/kubeapps
 COPY go.mod go.sum ./
 COPY pkg pkg

--- a/cmd/asset-syncer/Dockerfile
+++ b/cmd/asset-syncer/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax = docker/dockerfile:1
 
-FROM bitnami/golang:1.20.7 as builder
+FROM bitnami/golang:1.21.1 as builder
 WORKDIR /go/src/github.com/vmware-tanzu/kubeapps
 COPY go.mod go.sum ./
 COPY pkg pkg

--- a/cmd/asset-syncer/server/postgresql_db_test.go
+++ b/cmd/asset-syncer/server/postgresql_db_test.go
@@ -366,7 +366,7 @@ func TestRemoveMissingCharts(t *testing.T) {
 				ensureFilesExist(t, pam, chartID, files)
 			}
 
-			err := pam.removeMissingCharts(repo, tc.remainingCharts)
+			err := pam.RemoveMissingCharts(repo, []string{"TODO", "fixme"})
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}

--- a/cmd/asset-syncer/server/postgresql_db_test.go
+++ b/cmd/asset-syncer/server/postgresql_db_test.go
@@ -171,7 +171,7 @@ func TestInsertFiles(t *testing.T) {
 
 func ensureFilesExist(t *testing.T, pam *postgresAssetManager, chartID string, files []models.ChartFiles) {
 	for _, f := range files {
-		pgtest.EnsureChartsExist(t, pam, []models.Chart{{ID: chartID}}, *f.Repo)
+		pgtest.EnsureChartsExist(t, pam, []models.Chart{{ID: chartID, Name: chartID}}, *f.Repo)
 		err := pam.insertFiles(chartID, f)
 		if err != nil {
 			t.Fatalf("%+v", err)
@@ -257,10 +257,10 @@ func TestRemoveMissingCharts(t *testing.T) {
 		name string
 		// existingFiles maps a chartID to a slice of files for different
 		// versions of that chart.
-		existingFiles   map[string][]models.ChartFiles
-		remainingCharts []models.Chart
-		expectedCharts  int
-		expectedFiles   int
+		existingFiles  map[string][]models.ChartFiles
+		chartsToRemove []string
+		expectedCharts int
+		expectedFiles  int
 	}{
 		{
 			name: "it removes missing charts and files",
@@ -274,9 +274,7 @@ func TestRemoveMissingCharts(t *testing.T) {
 					{ID: "other-chart-3", Readme: "A Readme", Repo: &repo},
 				},
 			},
-			remainingCharts: []models.Chart{
-				{ID: "my-chart"},
-			},
+			chartsToRemove: []string{"other-chart"},
 			expectedCharts: 1,
 			expectedFiles:  1,
 		},
@@ -297,10 +295,7 @@ func TestRemoveMissingCharts(t *testing.T) {
 					{ID: "third-chart-3", Readme: "A Readme", Repo: &repo},
 				},
 			},
-			remainingCharts: []models.Chart{
-				{ID: "my-chart"},
-				{ID: "other-chart"},
-			},
+			chartsToRemove: []string{"third-chart"},
 			expectedCharts: 2,
 			expectedFiles:  4,
 		},
@@ -323,10 +318,7 @@ func TestRemoveMissingCharts(t *testing.T) {
 					{ID: "third-chart-3", Readme: "A Readme", Repo: &repo},
 				},
 			},
-			remainingCharts: []models.Chart{
-				{ID: "my-chart"},
-				{ID: "third-chart"},
-			},
+			chartsToRemove: []string{"other-chart"},
 			expectedCharts: 3,
 			expectedFiles:  7,
 		},
@@ -349,10 +341,7 @@ func TestRemoveMissingCharts(t *testing.T) {
 					{ID: "third-chart-3", Readme: "A Readme", Repo: &repo},
 				},
 			},
-			remainingCharts: []models.Chart{
-				{ID: "my-chart"},
-				{ID: "third-chart"},
-			},
+			chartsToRemove: []string{"other-chart"},
 			expectedCharts: 3,
 			expectedFiles:  7,
 		},
@@ -366,7 +355,7 @@ func TestRemoveMissingCharts(t *testing.T) {
 				ensureFilesExist(t, pam, chartID, files)
 			}
 
-			err := pam.RemoveMissingCharts(repo, []string{"TODO", "fixme"})
+			err := pam.RemoveMissingCharts(repo, tc.chartsToRemove)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}

--- a/cmd/asset-syncer/server/postgresql_db_test.go
+++ b/cmd/asset-syncer/server/postgresql_db_test.go
@@ -345,6 +345,22 @@ func TestRemoveMissingCharts(t *testing.T) {
 			expectedCharts: 3,
 			expectedFiles:  7,
 		},
+		{
+			name: "it does not error if no missing charts to remove",
+			existingFiles: map[string][]models.ChartFiles{
+				"my-chart": {
+					{ID: "my-chart-1", Readme: "A Readme", Repo: &repo},
+				},
+				"other-chart": {
+					{ID: "other-chart-1", Readme: "A Readme", Repo: &repo},
+					{ID: "other-chart-2", Readme: "A Readme", Repo: &repo},
+					{ID: "other-chart-3", Readme: "A Readme", Repo: &repo},
+				},
+			},
+			chartsToRemove: []string{},
+			expectedCharts: 2,
+			expectedFiles:  4,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/asset-syncer/server/postgresql_db_test.go
+++ b/cmd/asset-syncer/server/postgresql_db_test.go
@@ -88,14 +88,13 @@ func TestImportCharts(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name   string
-		charts []models.Chart
+		name  string
+		chart models.Chart
 	}{
 		{
 			name: "it inserts the charts",
-			charts: []models.Chart{
-				{Name: "my-chart1", Repo: &repo, ID: "foo/bar:123"},
-				{Name: "my-chart2", Repo: &repo, ID: "foo/bar:456"},
+			chart: models.Chart{
+				Name: "my-chart1", Repo: &repo, ID: "foo/bar:123",
 			},
 		},
 	}
@@ -104,12 +103,8 @@ func TestImportCharts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pam, cleanup := getInitializedManager(t)
 			defer cleanup()
-			_, err := pam.EnsureRepoExists(repo.Namespace, repo.Name)
-			if err != nil {
-				t.Fatalf("%+v", err)
-			}
 
-			err = pam.importCharts(tc.charts, repo)
+			err := pam.Sync(repo, tc.chart)
 			if err != nil {
 				t.Errorf("%+v", err)
 			}

--- a/cmd/asset-syncer/server/postgresql_db_test.go
+++ b/cmd/asset-syncer/server/postgresql_db_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 the Kubeapps contributors.
+// Copyright 2021-2023 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 // Currently these tests will be skipped entirely unless the

--- a/cmd/asset-syncer/server/postgresql_utils.go
+++ b/cmd/asset-syncer/server/postgresql_utils.go
@@ -90,7 +90,7 @@ func (m *postgresAssetManager) RemoveMissingCharts(repo models.AppRepository, ch
 	}
 	chartNamesString := strings.Join(quotedChartNames, ", ")
 	log.V(4).Infof("Removing the following charts that are no longer present in the repo: %s", chartNamesString)
-	rows, err := m.DB.Query(fmt.Sprintf("DELETE FROM %s WHERE info->>'Name' IN (%s) AND repo_name = $1 AND repo_namespace = $2", dbutils.ChartTable, chartNamesString), repo.Name, repo.Namespace)
+	rows, err := m.DB.Query(fmt.Sprintf("DELETE FROM %s WHERE info->>'name' IN (%s) AND repo_name = $1 AND repo_namespace = $2", dbutils.ChartTable, chartNamesString), repo.Name, repo.Namespace)
 	if rows != nil {
 		defer rows.Close()
 	}

--- a/cmd/asset-syncer/server/postgresql_utils.go
+++ b/cmd/asset-syncer/server/postgresql_utils.go
@@ -84,6 +84,10 @@ func (m *postgresAssetManager) UpdateLastCheck(repoNamespace, repoName, checksum
 }
 
 func (m *postgresAssetManager) RemoveMissingCharts(repo models.AppRepository, chartNames []string) error {
+	if len(chartNames) == 0 {
+		log.V(4).Infof("No synced charts missing from repository. Nothing to remove.")
+		return nil
+	}
 	var quotedChartNames []string
 	for _, chartName := range chartNames {
 		quotedChartNames = append(quotedChartNames, fmt.Sprintf("'%s'", chartName))

--- a/cmd/asset-syncer/server/postgresql_utils.go
+++ b/cmd/asset-syncer/server/postgresql_utils.go
@@ -181,7 +181,7 @@ func (m *postgresAssetManager) insertFiles(chartId string, files models.ChartFil
 }
 
 // ChartVersions returns a map of ordered versions for each chart in the repo.
-func (m *postgresAssetManager) ChartVersions(repo models.AppRepository) (map[string][]string, error) {
+func (m *postgresAssetManager) ChartVersions(repo models.AppRepository) (map[string]*models.Chart, error) {
 	dbQuery := fmt.Sprintf("SELECT info FROM %s WHERE repo_namespace = $1 AND repo_name = $2 ORDER BY (info->>'name')", dbutils.ChartTable)
 
 	charts, err := m.QueryAllCharts(dbQuery, repo.Namespace, repo.Name)
@@ -189,17 +189,9 @@ func (m *postgresAssetManager) ChartVersions(repo models.AppRepository) (map[str
 		return nil, err
 	}
 
-	chartVersions := map[string][]string{}
+	chartsByName := map[string]*models.Chart{}
 	for _, chart := range charts {
-		versions := make([]string, len(chart.ChartVersions))
-		for i, cv := range chart.ChartVersions {
-			versions[i] = cv.Version
-		}
-		orderedVersions, err := orderVersions(versions)
-		if err != nil {
-			return nil, err
-		}
-		chartVersions[chart.Name] = orderedVersions
+		chartsByName[chart.Name] = chart
 	}
-	return chartVersions, nil
+	return chartsByName, nil
 }

--- a/cmd/asset-syncer/server/postgresql_utils.go
+++ b/cmd/asset-syncer/server/postgresql_utils.go
@@ -180,8 +180,9 @@ func (m *postgresAssetManager) insertFiles(chartId string, files models.ChartFil
 	return err
 }
 
-// ChartVersions returns a map of ordered versions for each chart in the repo.
-func (m *postgresAssetManager) ChartVersions(repo models.AppRepository) (map[string]*models.Chart, error) {
+// ChartsForRepo returns a map of charts with all previously synced charts in
+// the repo.
+func (m *postgresAssetManager) ChartsForRepo(repo models.AppRepository) (map[string]*models.Chart, error) {
 	dbQuery := fmt.Sprintf("SELECT info FROM %s WHERE repo_namespace = $1 AND repo_name = $2 ORDER BY (info->>'name')", dbutils.ChartTable)
 
 	charts, err := m.QueryAllCharts(dbQuery, repo.Namespace, repo.Name)

--- a/cmd/asset-syncer/server/postgresql_utils_test.go
+++ b/cmd/asset-syncer/server/postgresql_utils_test.go
@@ -80,7 +80,7 @@ func Test_PGremoveMissingCharts(t *testing.T) {
 	defer cleanup()
 
 	repo := models.AppRepository{Name: "repo"}
-	mock.ExpectQuery(`^DELETE FROM charts WHERE info->>'Name' IN \('foo', 'bar'\) AND repo_name = \$1 AND repo_namespace = \$2`).
+	mock.ExpectQuery(`^DELETE FROM charts WHERE info->>'name' IN \('foo', 'bar'\) AND repo_name = \$1 AND repo_namespace = \$2`).
 		WithArgs(repo.Name, repo.Namespace).
 		WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1).AddRow(2))
 

--- a/cmd/asset-syncer/server/postgresql_utils_test.go
+++ b/cmd/asset-syncer/server/postgresql_utils_test.go
@@ -80,12 +80,11 @@ func Test_PGremoveMissingCharts(t *testing.T) {
 	defer cleanup()
 
 	repo := models.AppRepository{Name: "repo"}
-	charts := []models.Chart{{ID: "foo", Repo: &repo}, {ID: "bar"}}
-	mock.ExpectQuery(`^DELETE FROM charts WHERE chart_id NOT IN \('foo', 'bar'\) AND repo_name = \$1 AND repo_namespace = \$2`).
+	mock.ExpectQuery(`^DELETE FROM charts WHERE info->>'Name' IN \('foo', 'bar'\) AND repo_name = \$1 AND repo_namespace = \$2`).
 		WithArgs(repo.Name, repo.Namespace).
 		WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1).AddRow(2))
 
-	err := pgManager.removeMissingCharts(repo, charts)
+	err := pgManager.RemoveMissingCharts(repo, []string{"foo", "bar"})
 	if err != nil {
 		t.Errorf("%+v", err)
 	}

--- a/cmd/asset-syncer/server/sync.go
+++ b/cmd/asset-syncer/server/sync.go
@@ -34,6 +34,7 @@ func Sync(serveOpts Config, version string, args []string) error {
 	if err != nil {
 		return fmt.Errorf("error: %v", err)
 	}
+
 	defer manager.Close()
 
 	netClient, err := httpclient.NewWithCertFile(additionalCAFile, serveOpts.TlsInsecureSkipVerify)
@@ -110,8 +111,6 @@ func Sync(serveOpts Config, version string, args []string) error {
 			return fmt.Errorf("error: %v", err)
 		}
 
-		// TODO(minelson): Still need to ensure that what is synced includes
-		// the previously synced data, not just the new data to be synced.
 		// Also need to collect the apps to be deleted, rather than simply
 		// deleting everything that's not in the set of charts being synced
 		// (as it does today).
@@ -133,9 +132,7 @@ func Sync(serveOpts Config, version string, args []string) error {
 				continue
 			}
 
-			// TODO(minelson): update to pass in tags to delete.
-			// Update Sync to take just *models.Chart and tags to delete.
-			if err = manager.Sync(models.AppRepository{Name: repo.Name, Namespace: repo.Namespace}, []models.Chart{chartBatch.Chart}); err != nil {
+			if err = manager.Sync(models.AppRepository{Name: repo.Name, Namespace: repo.Namespace}, chartBatch.Chart); err != nil {
 				return fmt.Errorf("can't add chart repository to database: %v", err)
 			}
 

--- a/cmd/asset-syncer/server/sync.go
+++ b/cmd/asset-syncer/server/sync.go
@@ -63,7 +63,7 @@ func Sync(serveOpts Config, version string, args []string) error {
 
 	var repoIface ChartCatalog
 	if args[2] == "helm" {
-		repoIface, err = getHelmRepo(serveOpts.Namespace, args[0], args[1], authorizationHeader, filters, netClient, serveOpts.UserAgent)
+		repoIface, err = getHelmRepo(serveOpts.Namespace, args[0], args[1], authorizationHeader, filters, netClient, serveOpts.UserAgent, manager)
 	} else {
 		var grpcClient ocicatalog.OCICatalogServiceClient
 		if serveOpts.OCICatalogURL != "" {
@@ -106,7 +106,7 @@ func Sync(serveOpts Config, version string, args []string) error {
 		// gives us a way to pull results as they're generated (like an
 		// iterator).
 		chartResults := make(chan pullChartResult, 2)
-		err := repoIface.Charts(ctx, fetchLatestOnly, chartResults)
+		chartsToDelete, err := repoIface.Charts(ctx, fetchLatestOnly, chartResults)
 		if err != nil {
 			return fmt.Errorf("error: %v", err)
 		}
@@ -114,17 +114,17 @@ func Sync(serveOpts Config, version string, args []string) error {
 		// Also need to collect the apps to be deleted, rather than simply
 		// deleting everything that's not in the set of charts being synced
 		// (as it does today).
-		for chartBatch := range chartResults {
-			if len(chartBatch.Errors) != 0 {
-				chartName := chartBatch.Chart.Name
+		for chart := range chartResults {
+			if len(chart.Errors) != 0 {
+				chartName := chart.Chart.Name
 
-				log.Infof("There were errors syncing chart %q: %v", chartName, chartBatch.Errors)
-				if len(chartBatch.Chart.ChartVersions) == 0 {
+				log.Infof("There were errors syncing chart %q: %v", chartName, chart.Errors)
+				if len(chart.Chart.ChartVersions) == 0 {
 					continue
 				}
 			}
 
-			matches, err := filterMatches(chartBatch.Chart, repoIface.Filters())
+			matches, err := filterMatches(chart.Chart, repoIface.Filters())
 			if err != nil {
 				return fmt.Errorf("error while applying filter: %w", err)
 			}
@@ -132,14 +132,22 @@ func Sync(serveOpts Config, version string, args []string) error {
 				continue
 			}
 
-			if err = manager.Sync(models.AppRepository{Name: repo.Name, Namespace: repo.Namespace}, chartBatch.Chart); err != nil {
+			if err = manager.Sync(models.AppRepository{Name: repo.Name, Namespace: repo.Namespace}, chart.Chart); err != nil {
 				return fmt.Errorf("can't add chart repository to database: %v", err)
 			}
 
 			// Fetch and store chart icons
 			fImporter := fileImporter{manager, netClient}
-			fImporter.fetchFiles([]models.Chart{chartBatch.Chart}, repoIface, serveOpts.UserAgent, serveOpts.PassCredentials)
+			fImporter.fetchFiles([]models.Chart{chart.Chart}, repoIface, serveOpts.UserAgent, serveOpts.PassCredentials)
 			log.V(4).Infof("Repository synced, shallow=%v", fetchLatestOnly)
+		}
+
+		err = manager.RemoveMissingCharts(models.AppRepository{
+			Namespace: repo.Namespace,
+			Name:      repo.Name,
+		}, chartsToDelete)
+		if err != nil {
+			return fmt.Errorf("error while removing missing charts: %w", err)
 		}
 	}
 

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -1955,3 +1955,105 @@ func Test_isURLDomainEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestOrderedChartVersions(t *testing.T) {
+	testCases := []struct {
+		name          string
+		chartVersions []models.ChartVersion
+		expected      []models.ChartVersion
+	}{
+		{
+			name: "re-orders an unordered slice",
+			chartVersions: []models.ChartVersion{
+				{
+					Version: "1.2.3",
+				},
+				{
+					Version: "1.2.2",
+				},
+				{
+					Version: "1.2.4",
+				},
+			},
+			expected: []models.ChartVersion{
+				{
+					Version: "1.2.4",
+				},
+				{
+					Version: "1.2.3",
+				},
+				{
+					Version: "1.2.2",
+				},
+			},
+		},
+		{
+			name: "an unparsable version is shifted to the end",
+			chartVersions: []models.ChartVersion{
+				{
+					Version: "1.2.4",
+				},
+				{
+					Version: "not-a-version",
+				},
+				{
+					Version: "1.2.2",
+				},
+			},
+			expected: []models.ChartVersion{
+				{
+					Version: "1.2.4",
+				},
+				{
+					Version: "1.2.2",
+				},
+				{
+					Version: "not-a-version",
+				},
+			},
+		},
+		{
+			name: "a combination of unorderd versions andan unparsable version is ordered correctly",
+			chartVersions: []models.ChartVersion{
+				{
+					Version: "1.2.2",
+				},
+				{
+					Version: "1.2.4",
+				},
+				{
+					Version: "not-a-version",
+				},
+				{
+					Version: "1.2.3",
+				},
+			},
+			expected: []models.ChartVersion{
+				{
+					Version: "1.2.4",
+				},
+				{
+					Version: "1.2.3",
+				},
+				{
+					Version: "1.2.2",
+				},
+				{
+					Version: "not-a-version",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			chartVersions := tc.chartVersions
+
+			orderedChartVersions(chartVersions)
+
+			if !cmp.Equal(chartVersions, tc.expected) {
+				t.Errorf(cmp.Diff(tc.expected, chartVersions))
+			}
+		})
+	}
+}

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -178,10 +178,12 @@ func Test_syncURLInvalidity(t *testing.T) {
 
 	fakeServer := newFakeServer(t, nil)
 	defer fakeServer.Close()
+	pgManager, _, cleanup := getMockManager(t)
+	defer cleanup()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := getHelmRepo("namespace", "test", tt.repoURL, "", nil, fakeServer.Client(), "my-user-agent")
+			_, err := getHelmRepo("namespace", "test", tt.repoURL, "", nil, fakeServer.Client(), "my-user-agent", pgManager)
 			assert.Error(t, err, tt.name)
 		})
 	}
@@ -573,14 +575,14 @@ func (r *fakeRepo) Filters() *apprepov1alpha1.FilterRuleSpec {
 	return nil
 }
 
-func (r *fakeRepo) Charts(ctx context.Context, shallow bool, chartResults chan pullChartResult) error {
+func (r *fakeRepo) Charts(ctx context.Context, shallow bool, chartResults chan pullChartResult) ([]string, error) {
 	for _, chart := range r.charts {
 		chartResults <- pullChartResult{
 			Chart: chart,
 		}
 	}
 	close(chartResults)
-	return nil
+	return nil, nil
 }
 
 func (r *fakeRepo) FetchFiles(cv models.ChartVersion, userAgent string, passCredentials bool) (map[string]string, error) {
@@ -1464,7 +1466,7 @@ version: 1.0.0
 				manager: pgManager,
 			}
 			chartResults := make(chan pullChartResult, 2)
-			err = chartsRepo.Charts(context.Background(), tt.shallow, chartResults)
+			_, err = chartsRepo.Charts(context.Background(), tt.shallow, chartResults)
 			assert.NoError(t, err)
 
 			charts := []models.Chart{}
@@ -1545,7 +1547,7 @@ version: 1.0.0
 			manager: pgManager,
 		}
 		chartResults := make(chan pullChartResult, 2)
-		err = chartsRepo.Charts(context.Background(), true, chartResults)
+		_, err = chartsRepo.Charts(context.Background(), true, chartResults)
 		assert.NoError(t, err)
 
 		charts := []models.Chart{}
@@ -1845,13 +1847,18 @@ func TestHelmRepoAppliesUnescape(t *testing.T) {
 			ChartVersions: []models.ChartVersion{{AppVersion: "v2"}},
 		},
 	}
+	pgManager, mock, cleanup := getMockManager(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT info FROM charts").
+		WillReturnRows(sqlmock.NewRows([]string{"info"}).AddRow("{}"))
 	helmRepo := &HelmRepo{
 		content:               []byte(repoIndexYAML),
 		AppRepositoryInternal: repo,
+		manager:               pgManager,
 	}
 	t.Run("Helm repo applies unescaping to chart data", func(t *testing.T) {
 		chartResults := make(chan pullChartResult, 2)
-		err := helmRepo.Charts(context.Background(), false, chartResults)
+		_, err := helmRepo.Charts(context.Background(), false, chartResults)
 		assert.NoError(t, err)
 		charts := []models.Chart{}
 		for cr := range chartResults {

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -36,7 +36,7 @@ RUN curl -sSL "https://github.com/grpc-ecosystem/grpc-health-probe/releases/down
 # https://github.com/golang/go/issues/27719#issuecomment-514747274
 RUN --mount=type=cache,target=/go/pkg/mod  \
     --mount=type=cache,target=/root/.cache/go-build \
-    go mod download
+    GOPROXY="direct" go mod download
 
 # We don't copy the pkg and cmd directories until here so the above layers can
 # be reused.

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax = docker/dockerfile:1
 
-FROM bitnami/golang:1.20.7 as builder
+FROM bitnami/golang:1.21.1 as builder
 WORKDIR /go/src/github.com/vmware-tanzu/kubeapps
 COPY go.mod go.sum ./
 ARG VERSION="devel"

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -343,6 +343,7 @@ func (s *Server) GetAvailablePackageDetail(ctx context.Context, request *connect
 	fileID := fileIDForChart(unescapedChartID, version)
 	chartFiles, err := s.manager.GetChartFiles(namespace, fileID)
 	if err != nil {
+		log.Errorf("unable to retrieve chart files: %w", err)
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("Unable to retrieve chart files: %v", err))
 	}
 

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/postgresql_utils.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/postgresql_utils.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/vmware-tanzu/kubeapps/pkg/chart/models"
 	"github.com/vmware-tanzu/kubeapps/pkg/dbutils"
+	log "k8s.io/klog/v2"
 )
 
 const AllNamespaces = "_all"
@@ -157,8 +158,10 @@ func (m *PostgresAssetManager) GetChartFiles(namespace, filesID string) (models.
 
 func (m *PostgresAssetManager) GetChartFilesWithFallback(namespace, filesID string, withFallback bool) (models.ChartFiles, error) {
 	var chartFiles models.ChartFiles
+	query := fmt.Sprintf("SELECT info FROM %s WHERE repo_namespace = $1 AND chart_files_id = $2", dbutils.ChartFilesTable)
 	err := m.QueryOne(&chartFiles, fmt.Sprintf("SELECT info FROM %s WHERE repo_namespace = $1 AND chart_files_id = $2", dbutils.ChartFilesTable), namespace, filesID)
 	if err != nil {
+		log.Errorf("query %q (%q, %q) failed with %v", query, namespace, filesID, err)
 		splitID := strings.Split(filesID, "/")
 		if withFallback && len(splitID) == 2 {
 			// fallback query when a chart_files_id is not being retrieved

--- a/pkg/dbutils/postgresql_utils.go
+++ b/pkg/dbutils/postgresql_utils.go
@@ -73,6 +73,11 @@ func (m *PostgresAssetManager) Init() error {
 		return err
 	}
 	m.DB = db
+
+	err = m.InitTables()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
### Description of the change

Currently ensures that the existing (already synced) chart versions are included when syncing new chart versions, so that the full set of data is retained in the DB (since the chart versions aren't actually rows in the db, but rather within a json blob of the chart).

This PR refactored the way the syncing happens, specifically ensuring that data is synced to the db as each chart is processed, rather than when all charts are synced (so that we get better feedback in the UI when syincing OCI repos).


### Benefits

Before the change:
- a shallow + deep sync of the non-OCI Helm repo takes around 7s
- a shallow sync of the Bitnami OCI repo would see us hitting the rate limit and getting 429s.

With the changes,
- a shallow + deep sync of a non-OCI Helm repo takes around 10s (extra overhead of sycing to the DB for each chart)
- a shallow sync of the Bitnami OCI repo takes 2 minutes and a syncing the next 5 versions for each chart takes a further 2 minutes (and does not excessively hammer the dockerhub distribution spec API to get banned). (should remove the shallow and just always do 5, also should test 10).

### Possible drawbacks

Currently:
- ~~Something not correct with the db info being synced as getting `Unable to get the available package detail for the package "testoci2/airflow" using the plugin "helm.packages": internal: Unable to retrieve chart files: sql: no rows in result set`~~ Fixed - it was a synchronization issue that left the sync process finishing after charts were synced but before files were synced.
- ~~OCI catalog is taking a *long* time to display (shouldn't be affected, getting info from the DB).~~ This was a resource issue locally.

~~So still more investigation here needed.~~

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #6706 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
