### PR TITLE
Update go.mod's go version (already did Dockerfiles and CI).

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/vmware-tanzu/kubeapps
 
-go 1.20
+go 1.21
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
### Description of the change

As part of #6706 I'd updated the go version in our Dockerfiles as well as the kubeapps-general.yaml CI config file, but not in the go.mod, which is used by Bitnami to determine the go version for the official images.

### Benefits

The bitnami builds should use the required 1.21 (excellent of Bitnami to automate that!)
