### PR TITLE
6891 - Add _blank attribute to links on LinkRenderer to open urls on …

### DIFF
--- a/dashboard/src/components/MarkdownRenderer/LinkRenderer.tsx
+++ b/dashboard/src/components/MarkdownRenderer/LinkRenderer.tsx
@@ -9,7 +9,11 @@ const LinkRenderer: React.FunctionComponent<{}> = (props: any) => {
   }
   // If it's not a hash link it's an external link since it's rendering
   // the package README. Because of that, render it as a normal anchor
-  return <a href={props.href}>{props.children}</a>;
+  return (
+    <a href={props.href} target="_blank" rel="noreferrer">
+      {props.children}
+    </a>
+  );
 };
 
 export default LinkRenderer;


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change
 Adds target=_blank (with rel=noreferrer) to links generated from Notes.txt on the LinkRenderer.tsx
 - Describe any known limitations with your change.
 This did not include the object link on Line 8. That one seems to be more internal routing and shouldn't be opened to a new tab, unless you think otherwise. 
 - Please run any tests or examples that can exercise your modified code.
1. Add a helm chart that has an external link on the `Notes.txt` and go to that helm on kubeapps. 
2. Click on the link

 Thank you for contributing!
 -->

### Description of the change

Fixes the #6891 ticket

### Benefits

Opens a new tab for external links

### Possible drawbacks
N/A

### Applicable issues

- fixes #6891 

### Additional information
N/A