### PR TITLE
Add implementation for the core API service.

### DIFF
--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
@@ -356,7 +356,29 @@ func (s packagesServer) DeleteInstalledPackage(ctx context.Context, request *con
 }
 
 func (s packagesServer) GetAvailablePackageMetadatas(ctx context.Context, request *connect.Request[packages.GetAvailablePackageMetadatasRequest]) (*connect.Response[packages.GetAvailablePackageMetadatasResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("Unimplemented"))
+	log.InfoS("+core GetAvailablePackageVersions", "cluster", request.Msg.GetAvailablePackageRef().GetContext().GetCluster(), "namespace", request.Msg.GetAvailablePackageRef().GetContext().GetNamespace())
+
+	if request.Msg.GetAvailablePackageRef().GetPlugin() == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Unable to retrieve the plugin (missing AvailablePackageRef.Plugin)"))
+	}
+
+	// Retrieve the plugin with server matching the requested plugin name
+	pluginWithServer := s.getPluginWithServer(request.Msg.AvailablePackageRef.Plugin)
+	if pluginWithServer == nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("Unable to get the plugin %v", request.Msg.AvailablePackageRef.Plugin))
+	}
+
+	// Get the response from the requested plugin
+	ctxForPlugin := updateContextWithAuthz(ctx, request.Header())
+	response, err := pluginWithServer.server.GetAvailablePackageMetadatas(ctxForPlugin, request)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeOf(err), fmt.Errorf("Unable to get the available package metadatas for the package %q using the plugin %q: %w", request.Msg.AvailablePackageRef.Identifier, request.Msg.AvailablePackageRef.Plugin.Name, err))
+	}
+
+	// Build the response
+	return connect.NewResponse(&packages.GetAvailablePackageMetadatasResponse{
+		PackageMetadata: response.Msg.PackageMetadata,
+	}), nil
 }
 
 // getPluginWithServer returns the *pkgPluginsWithServer from a given packagesServer

--- a/cmd/kubeapps-apis/plugin_test/mock_plugin.go
+++ b/cmd/kubeapps-apis/plugin_test/mock_plugin.go
@@ -18,6 +18,7 @@ type TestPackagingPluginServer struct {
 	Plugin                    *plugins.Plugin
 	AvailablePackageSummaries []*corev1.AvailablePackageSummary
 	AvailablePackageDetail    *corev1.AvailablePackageDetail
+	AvailablePackageMetadatas []*corev1.PackageMetadata
 	InstalledPackageSummaries []*corev1.InstalledPackageSummary
 	InstalledPackageDetail    *corev1.InstalledPackageDetail
 	PackageAppVersions        []*corev1.PackageAppVersion
@@ -63,6 +64,16 @@ func (s TestPackagingPluginServer) GetAvailablePackageDetail(ctx context.Context
 	}
 	return connect.NewResponse(&corev1.GetAvailablePackageDetailResponse{
 		AvailablePackageDetail: s.AvailablePackageDetail,
+	}), nil
+}
+
+// GetAvailablePackageMetadatas returns the package metadatas based on the request.
+func (s TestPackagingPluginServer) GetAvailablePackageMetadatas(ctx context.Context, request *connect.Request[corev1.GetAvailablePackageMetadatasRequest]) (*connect.Response[corev1.GetAvailablePackageMetadatasResponse], error) {
+	if s.ErrorCode != 0 {
+		return nil, connect.NewError(s.ErrorCode, fmt.Errorf("Non-OK response"))
+	}
+	return connect.NewResponse(&corev1.GetAvailablePackageMetadatasResponse{
+		PackageMetadata: s.AvailablePackageMetadatas,
 	}), nil
 }
 
@@ -139,10 +150,6 @@ func (s TestPackagingPluginServer) DeleteInstalledPackage(ctx context.Context, r
 		return nil, connect.NewError(s.ErrorCode, fmt.Errorf("Non-OK response"))
 	}
 	return connect.NewResponse(&corev1.DeleteInstalledPackageResponse{}), nil
-}
-
-func (s TestPackagingPluginServer) GetAvailablePackageMetadatas(ctx context.Context, request *connect.Request[corev1.GetAvailablePackageMetadatasRequest]) (*connect.Response[corev1.GetAvailablePackageMetadatasResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("Unimplemented"))
 }
 
 type TestRepositoriesPluginServer struct {

--- a/cmd/kubeapps-apis/plugin_test/utils.go
+++ b/cmd/kubeapps-apis/plugin_test/utils.go
@@ -118,6 +118,15 @@ func MakeAvailablePackageDetail(name string, plugin *plugins.Plugin) *corev1.Ava
 	}
 }
 
+func MakeAvailablePackageMetadata(media_type, name, description, url string) *corev1.PackageMetadata {
+	return &corev1.PackageMetadata{
+		MediaType:   media_type,
+		Name:        name,
+		Description: description,
+		Url:         url,
+	}
+}
+
 func MakeInstalledPackageDetail(name string, plugin *plugins.Plugin) *corev1.InstalledPackageDetail {
 	return &corev1.InstalledPackageDetail{
 		InstalledPackageRef: &corev1.InstalledPackageReference{


### PR DESCRIPTION
### Description of the change

Follows on from #6941 , adding the implementation for the core API service.

Next PR will add the implementation for the helm plugin using the OCI distribution spec API so that we can investigate UX options for displaying the data.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #6548 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
