### PR TITLE
Adds implementation of Helm OCI refererrs endpoint.

### DIFF
--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -1,4 +1,3 @@
-
 # Bitnami package for Kubeapps
 
 Kubeapps is a web-based UI for launching and managing applications on Kubernetes. It allows users to deploy trusted applications and operators to control users access to the cluster.

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories_test.go
@@ -808,7 +808,7 @@ func TestAddPackageRepository(t *testing.T) {
 			if tc.existingDockerSecret != nil {
 				secrets = append(secrets, tc.existingDockerSecret)
 			}
-			s := newServerWithSecretsAndRepos(t, secrets, nil, nil)
+			s := newServerWithSecretsAndRepos(t, secrets, nil)
 			if tc.testRepoServer != nil {
 				defer tc.testRepoServer.Close()
 				s.repoClientGetter = func(_ *appRepov1.AppRepository, _ *apiv1.Secret) (*http.Client, error) {
@@ -1194,22 +1194,12 @@ func TestGetPackageRepositoryDetail(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var unstructuredObjects []k8sruntime.Object
-			for _, obj := range []*appRepov1alpha1.AppRepository{repo1, repo2, repo3, repo4, repo5} {
-				repository := obj
-				if tc.repositoryCustomizer != nil {
-					repository = tc.repositoryCustomizer(obj)
-				}
-				unstructuredContent, _ := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(repository)
-				unstructuredObjects = append(unstructuredObjects, &unstructured.Unstructured{Object: unstructuredContent})
-			}
-
 			var secrets []k8sruntime.Object
 			if tc.existingSecret != nil {
 				secrets = append(secrets, tc.existingSecret)
 			}
 
-			s := newServerWithSecretsAndRepos(t, secrets, unstructuredObjects, nil)
+			s := newServerWithSecretsAndRepos(t, secrets, []*appRepov1alpha1.AppRepository{repo1, repo2, repo3, repo4, repo5})
 
 			actualResponse, err := s.GetPackageRepositoryDetail(context.Background(), connect.NewRequest(tc.request))
 
@@ -1935,12 +1925,6 @@ func TestUpdatePackageRepository(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var unstructuredObjects []k8sruntime.Object
-			for _, obj := range repos {
-				unstructuredContent, _ := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
-				unstructuredObjects = append(unstructuredObjects, &unstructured.Unstructured{Object: unstructuredContent})
-			}
-
 			var secrets []k8sruntime.Object
 			if tc.existingAuthSecret != nil {
 				secrets = append(secrets, tc.existingAuthSecret)
@@ -1949,7 +1933,7 @@ func TestUpdatePackageRepository(t *testing.T) {
 				secrets = append(secrets, tc.existingDockerSecret)
 			}
 
-			s := newServerWithSecretsAndRepos(t, secrets, unstructuredObjects, repos)
+			s := newServerWithSecretsAndRepos(t, secrets, repos)
 
 			request := tc.requestCustomizer(commonRequest())
 			response, err := s.UpdatePackageRepository(context.Background(), connect.NewRequest(request))
@@ -2067,13 +2051,7 @@ func TestDeletePackageRepository(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var unstructuredObjects []k8sruntime.Object
-			for _, obj := range repos {
-				unstructuredContent, _ := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
-				unstructuredObjects = append(unstructuredObjects, &unstructured.Unstructured{Object: unstructuredContent})
-			}
-
-			s := newServerWithSecretsAndRepos(t, nil, unstructuredObjects, repos)
+			s := newServerWithSecretsAndRepos(t, nil, repos)
 
 			_, err := s.DeletePackageRepository(context.Background(), connect.NewRequest(tc.request))
 

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/bufbuild/connect-go"
+	imageSpecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	appRepov1 "github.com/vmware-tanzu/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	"github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/core"
 	corev1 "github.com/vmware-tanzu/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
@@ -44,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	log "k8s.io/klog/v2"
+	"oras.land/oras-go/v2/registry/remote"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -1268,5 +1270,67 @@ func (s *Server) DeletePackageRepository(ctx context.Context, request *connect.R
 }
 
 func (s *Server) GetAvailablePackageMetadatas(ctx context.Context, request *connect.Request[corev1.GetAvailablePackageMetadatasRequest]) (*connect.Response[corev1.GetAvailablePackageMetadatasResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("Unimplemented"))
+	chartID := request.Msg.GetAvailablePackageRef().GetIdentifier()
+	repoNamespace := request.Msg.GetAvailablePackageRef().GetContext().GetNamespace()
+	repoName, chartName, err := pkgutils.SplitPackageIdentifier(chartID)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	// TODO: Ignoring secrets for now, just demoing with public OCI repo
+	appRepo, _, _, _, err := s.getAppRepoAndRelatedSecrets(ctx, request.Header(), s.globalPackagingCluster, repoName, repoNamespace)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("Unable to fetch app repo %q from namespace %q: %v", repoName, repoNamespace, err))
+	}
+	if appRepo.Spec.Type != OCIRepoType {
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("Unimplemented for non-OCI repositories"))
+	}
+
+	repoURL := appRepo.Spec.URL
+	repoURL = strings.TrimPrefix(repoURL, "oci://")
+	repoURL = strings.TrimPrefix(repoURL, "https://")
+	plainHTTP := false
+	if strings.HasPrefix(repoURL, "http://") {
+		plainHTTP = true
+		repoURL = strings.TrimPrefix(repoURL, "http://")
+	}
+
+	tag := path.Join(repoURL, chartName)
+	fmt.Printf("\ntag: %+v", tag)
+	repo, err := remote.NewRepository(tag)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("Unable to call NewRepository with %q: %v", tag, err))
+	}
+	repo.PlainHTTP = plainHTTP
+
+	// Create the ocispec.Descriptor, first need to get the manifest of the chart.
+	descriptor, _, err := repo.Manifests().FetchReference(ctx, request.Msg.GetPkgVersion())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("Unable to fetch manifest for %v with ref %q: %v", repo, request.Msg.GetPkgVersion(), err))
+	}
+
+	referrers := []imageSpecv1.Descriptor{}
+	err = repo.Referrers(ctx, descriptor, "", func(r []imageSpecv1.Descriptor) error {
+		referrers = append(referrers, r...)
+		return nil
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("Unable to fetch referrers for %v with ref %q: %v", repo, request.Msg.GetPkgVersion(), err))
+	}
+
+	package_metadatas := []*corev1.PackageMetadata{}
+	for _, referrer := range referrers {
+		package_metadatas = append(package_metadatas, &corev1.PackageMetadata{
+			Name:         referrer.Annotations["org.opencontainers.image.title"],
+			Description:  referrer.Annotations["org.opencontainers.image.description"],
+			MediaType:    referrer.MediaType,
+			ArtifactType: referrer.ArtifactType,
+			Digest:       referrer.Digest.String(),
+		})
+	}
+
+	return connect.NewResponse(&corev1.GetAvailablePackageMetadatasResponse{
+		AvailablePackageRef: request.Msg.AvailablePackageRef,
+		PackageMetadata:     package_metadatas,
+	}), nil
 }

--- a/site/content/docs/latest/reference/scripts/setup-demo-harbor-oci-metadata.sh
+++ b/site/content/docs/latest/reference/scripts/setup-demo-harbor-oci-metadata.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 the Kubeapps contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Constants
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../../.." >/dev/null && pwd)"
+RESET='\033[0m'
+GREEN='\033[38;5;2m'
+RED='\033[38;5;1m'
+YELLOW='\033[38;5;3m'
+
+VERSION="0.1.0"
+IMAGE="demo.goharbor.io/kubeapps-test/simplechart:${VERSION}"
+
+# shellcheck disable=SC1090
+. "${ROOT_DIR}/script/lib/liblog.sh"
+
+info "Setting up kubeapps project on demo.goharbor with metadata referers..."
+
+# Check if project exists - if not, create it.
+http_code=$(curl --head https://demo.goharbor.io/api/v2.0/projects\?project_name\=kubeapps-test -u "${DEMO_USERNAME}:${DEMO_PASSWORD}" -o /dev/null -sSLw "%{http_code}")
+
+if [[ "${http_code}" -eq 404  ]] ; then
+  info "'kubeapps-test' project does not exist yet, creating..."
+  curl \
+    'https://demo.goharbor.io/api/v2.0/projects' \
+    -u "${DEMO_USERNAME}:${DEMO_PASSWORD}" \
+    -H 'accept: application/json' \
+    -H 'X-Resource-Name-In-Location: false' \
+    -H 'Content-Type: application/json' \
+    -d '{
+    "project_name": "kubeapps-test",
+    "public": true,
+    "metadata": {
+      "public": "true",
+      "enable_content_trust": "string",
+      "enable_content_trust_cosign": "string",
+      "prevent_vul": "string",
+      "severity": "string",
+      "auto_scan": "string",
+      "reuse_sys_cve_allowlist": "string",
+      "retention_id": ""
+    }
+  }'
+elif [[ "${http_code}" -eq 200 ]] ; then
+  info "Project kubeapps-test already exists."
+else
+  error "Unexpected http code: ${http_code}. Exiting"
+fi
+
+info "Creating and pushing chart to kubeapps-test project..."
+helm package ./integration/charts/simplechart
+echo ${DEMO_PASSWORD} | oras login --username ${DEMO_USERNAME} --password-stdin demo.goharbor.io
+
+oras push --artifact-type "application/vnd.cncf.helm.config.v1" --export-manifest "./chart-manifest.json" ${IMAGE} "simplechart-0.1.0.tgz:application/vnd.oci.image.manifest.v1"
+# helm push ./simplechart-${VERSION}.tgz oci://demo.goharbor.io/kubeapps-test
+
+info "Attaching super-important-meta with chart..."
+echo '{"artifact": "'${IMAGE}'", "signature": "trust me"}' > signature.json
+oras attach --export-manifest "./signature-manifest.json" ${IMAGE} --artifact-type "application/vnd.example.signature.v1" "signature.json:application/json"
+
+echo '{"artifact": "'${IMAGE}'", "sbom": "lots of materials"}' > sbom.json
+oras attach --export-manifest "./sbom-manifest.json" --artifact-type "application/vnd.example.sbom.v1" ${IMAGE} "sbom.json:application/vnd.oci.image.manifest.v1"
+
+
+info "Listing referrers of chart..."
+oras discover -o tree ${IMAGE}


### PR DESCRIPTION
### Description of the change

After a small refactor to re-use an existing test function, this PR adds the implementation for fetching the referrers of an OCI chart.

This includes using the annotations in the referrers for the name/description returned (for better UX) as well as an http fake for handling the OCI requests in tests.

### Applicable issues

- ref #7038

### Additional information

