### PR TITLE
 Bump Hugo from 0.116.1 to 0.121.2

### DIFF
--- a/script/makefiles/site.mk
+++ b/script/makefiles/site.mk
@@ -4,7 +4,7 @@
 WORKDIR = $(shell pwd)
 # HUGO_VERSION should be in sync with the one set in ../../site/netlify.toml
 # see https://github.com/gohugoio/hugo/releases
-HUGO_VERSION = 0.104.3
+HUGO_VERSION = 0.121.2
 
 # This file provides targets that helps with the development of the kubeapps.dev site.
 

--- a/site/content/docs/latest/reference/developer/release-process.md
+++ b/site/content/docs/latest/reference/developer/release-process.md
@@ -56,6 +56,7 @@ The versions used there _must_ match the ones used for building the container im
 - `K8S_KIND_VERSION` _must_ match the Kubernetes minor version used in `GKE_REGULAR_VERSION_XX` and should be updated with one of the available image tags for a given [Kind release](https://github.com/kubernetes-sigs/kind/releases).
 - `POSTGRESQL_VERSION` _must_ match the version used by the [Bitnami PostgreSQL chart](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/Chart.yaml).
 - `FLUX_VERSION` should be updated with the [latest stable version from the Flux releases](https://github.com/fluxcd/flux2/releases).
+- `HUGO_VERSION` should be updated with the [latest stable version from the Hugo releases](https://github.com/gohugoio/hugo/releases).
 
 Besides, the `GKE_STABLE_VERSION` and the `GKE_REGULAR_VERSION` might have to be updated if the _Stable_ and _Regular_ Kubernetes versions in GKE have changed. Check this information on [this GKE release notes website](https://cloud.google.com/kubernetes-engine/docs/release-notes).
 

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -4,7 +4,7 @@ command = "hugo --gc --minify --enableGitInfo"
 ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ."
 
 [context.production.environment]
-HUGO_VERSION = "0.116.1"
+HUGO_VERSION = "0.121.2"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
@@ -12,20 +12,20 @@ HUGO_ENABLEGITINFO = "true"
 command = "hugo --gc --minify --enableGitInfo"
 
 [context.split1.environment]
-HUGO_VERSION = "0.116.1"
+HUGO_VERSION = "0.121.2"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL --enableGitInfo"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.116.1"
+HUGO_VERSION = "0.121.2"
 
 [context.branch-deploy]
 command = "hugo --gc --minify -b $DEPLOY_PRIME_URL --enableGitInfo"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.116.1"
+HUGO_VERSION = "0.121.2"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"


### PR DESCRIPTION
### Description of the change

Bump the Hugo version to the latest one.

### Benefits

Keep our website template engine up to date.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
