### PR TITLE
Update Go version used in the CodeQL action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.21
         if: ${{ matrix.language == 'go' }}
 
       # Initializes the CodeQL tools for scanning.

--- a/site/content/docs/latest/reference/developer/release-process.md
+++ b/site/content/docs/latest/reference/developer/release-process.md
@@ -60,6 +60,8 @@ The versions used there _must_ match the ones used for building the container im
 
 Besides, the `GKE_STABLE_VERSION` and the `GKE_REGULAR_VERSION` might have to be updated if the _Stable_ and _Regular_ Kubernetes versions in GKE have changed. Check this information on [this GKE release notes website](https://cloud.google.com/kubernetes-engine/docs/release-notes).
 
+When updating the `GOLANG_VERSION`, the Go version used in the [CodeQL Github Action](https://github.com/vmware-tanzu/kubeapps/blob/main/.github/workflows/codeql-analysis.yml) might be updated as well.
+
 > As part of this release process, these variables _must_ be updated accordingly. Other variable changes _should_ be tracked in a separate PR.
 
 #### 0.2.2 - CI integration image and dependencies


### PR DESCRIPTION
### Description of the change

I noticed we forgot to update the Go version used in the CodeQL Github Action. This PR is to bump it up and update the docs so that we don't forget again.

### Benefits

No failed CodeQL executions.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A