### PR TITLE
Update banner to broadcom's onetrust

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -39,7 +39,7 @@ params:
   github_base_url: "https://github.com/vmware-tanzu/kubeapps"
   github_url: "https://github.com/vmware-tanzu/kubeapps/"
   gtmId: GTM-PGL7FMT
-  oneTrustId: b9039ff0-42be-4f63-bc78-e2ecbbed5f06
+  oneTrustId: 018ee8c4-9885-7b0d-9105-e5b631424f1a
   sitename: Kubeapps
   slack_url: "https://kubernetes.slack.com/messages/kubeapps"
   twitter: bitnami

--- a/site/themes/template/layouts/_default/baseof.html
+++ b/site/themes/template/layouts/_default/baseof.html
@@ -8,6 +8,7 @@
   <script defer src="https://code.jquery.com/jquery-3.6.1.slim.min.js" integrity="sha256-w8CvhFs7iHNVUtnSP0YKEg00p9Ih13rlL9zGqvLdePA=" crossorigin="anonymous"></script>
   <script defer src="https://www.vmware.com/files/templates/inc/utag_data.js"></script>
   <script defer src="https://tags.tiqcdn.com/utag/vmware/microsites-privacy/prod/utag.sync.js"></script>
+  <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" type="text/javascript" charset="UTF-8" data-domain-script="{{ .Site.Params.oneTrustId }}"></script>
   <script defer>
     function OptanonWrapper() { { window.dataLayer.push({ event: 'OneTrustGroupsUpdated' }); } }
   </script>

--- a/site/themes/template/layouts/partials/base-footer.html
+++ b/site/themes/template/layouts/partials/base-footer.html
@@ -50,7 +50,6 @@
           <a target="_blank" rel="noopener" title="This link will open in a new tab" href="https://www.vmware.com/help/legal.html">Terms of Use</a> |
           <a target="_blank" rel="noopener" title="This link will open in a new tab" href="https://www.vmware.com/help/privacy.html">Privacy Policy</a> |
           <a target="_blank" rel="noopener" title="This link will open in a new tab" href="https://www.vmware.com/help/privacy/california-privacy-rights.html">Your California Privacy Rights</a> |
-          <a target="_blank" rel="noopener" title="This link will open in a new tab" tabindex=0 class="ot-sdk-show-settings">Cookie Settings</a>
         </span>
       </p>
     </div>


### PR DESCRIPTION
### Description of the change

This PR update the cookie banner to use the Broadcom's OneTrust one.

### Benefits

Compliant website,

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A