### PR TITLE
fix(app-list-grid): Update docs link from vmware to CW apps catalog docs

### DIFF
--- a/dashboard/src/components/AppList/AppListGrid.tsx
+++ b/dashboard/src/components/AppList/AppListGrid.tsx
@@ -23,7 +23,7 @@ export interface IAppListProps {
 }
 
 function AppListGrid(props: IAppListProps) {
-  const { appList, customResources, cluster, namespace, appVersion, filter } = props;
+  const { appList, customResources, cluster, namespace, filter } = props;
   const filteredReleases = (appList || []).filter(a =>
     new RegExp(escapeRegExp(filter), "i").test(a.name),
   );
@@ -40,7 +40,7 @@ function AppListGrid(props: IAppListProps) {
           Start browsing your <Link to={url.app.catalog(cluster, namespace)}>favourite apps</Link>{" "}
           or check the{" "}
           <a
-            href={`https://github.com/vmware-tanzu/kubeapps/blob/${appVersion}/site/content/docs/latest/tutorials/getting-started.md`}
+            href="https://docs.coreweave.com/cloud-ui/applications-catalog"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
Resolves https://github.com/coreweave/cloud-app/issues/3623.