### PR TITLE
Fix `FromAsCasing` warning in Dockerfiles

### DIFF
--- a/cmd/apprepository-controller/Dockerfile
+++ b/cmd/apprepository-controller/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax = docker/dockerfile:1
 
-FROM bitnami/golang:1.22.2 as builder
+FROM bitnami/golang:1.22.2 AS builder
 WORKDIR /go/src/github.com/vmware-tanzu/kubeapps
 COPY go.mod go.sum ./
 COPY pkg pkg

--- a/cmd/asset-syncer/Dockerfile
+++ b/cmd/asset-syncer/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax = docker/dockerfile:1
 
-FROM bitnami/golang:1.22.2 as builder
+FROM bitnami/golang:1.22.2 AS builder
 WORKDIR /go/src/github.com/vmware-tanzu/kubeapps
 COPY go.mod go.sum ./
 COPY pkg pkg

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax = docker/dockerfile:1
 
-FROM bitnami/golang:1.22.2 as builder
+FROM bitnami/golang:1.22.2 AS builder
 WORKDIR /go/src/github.com/vmware-tanzu/kubeapps
 COPY go.mod go.sum ./
 ARG VERSION="devel"

--- a/cmd/oci-catalog/Dockerfile
+++ b/cmd/oci-catalog/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax = docker/dockerfile:1
 
-FROM rust:1.77.1 as builder
+FROM rust:1.77.1 AS builder
 
 WORKDIR /oci-catalog
 ARG VERSION="devel"

--- a/cmd/pinniped-proxy/Dockerfile
+++ b/cmd/pinniped-proxy/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax = docker/dockerfile:1
 
-FROM rust:1.77.1 as builder
+FROM rust:1.77.1 AS builder
 
 WORKDIR /pinniped-proxy
 ARG VERSION


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Make casing of `FROM` and `AS` keywords in dockerfiles consistent.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

This change will remove the warning being shown when docker images are built.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
```
 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 6)
 ```
 
 Sample job: https://github.com/vmware-tanzu/kubeapps/actions/runs/9937352647/job/27449161644#step:6:978