### PR TITLE
Split integration tests' main test group into multiple subgroups

### DIFF
--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -436,7 +436,9 @@ jobs:
         tests_group:
           - carvel
           - flux
-          - main
+          - main-group-1
+          - main-group-2
+          - main-group-3
           - multicluster
           - multicluster-nokubeapps
           - operator

--- a/integration/tests/main-group-1/00-log-in.spec.js
+++ b/integration/tests/main-group-1/00-log-in.spec.js
@@ -1,0 +1,17 @@
+// Copyright 2022 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+const { test, expect } = require("@playwright/test");
+const { KubeappsLogin } = require("../utils/kubeapps-login");
+const utils = require("../utils/util-functions");
+
+test.describe("Log in", () => {
+  test("Logs in successfully as view user", async ({ page }) => {
+    const k = new KubeappsLogin(page);
+    // TODO (castelblanque) Set and use proper env variables
+    // like `process.env.VIEW_USER` and `process.env.VIEW_PASSWORD` or similar
+    await k.doLogin("kubeapps-user@example.com", "password", process.env.VIEW_TOKEN);
+
+    await page.waitForSelector('css=h1 >> text="Applications"');
+  });
+});

--- a/integration/tests/main-group-1/01-missing-permissions.spec.js
+++ b/integration/tests/main-group-1/01-missing-permissions.spec.js
@@ -1,0 +1,86 @@
+// Copyright 2022-2023 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+const { test, expect } = require("@playwright/test");
+const { KubeappsLogin } = require("../utils/kubeapps-login");
+const utils = require("../utils/util-functions");
+
+test.describe("Limited user simple deployments", () => {
+  test("Regular user fails to deploy package due to missing permissions", async ({ page }) => {
+    // Log in
+    const k = new KubeappsLogin(page);
+    await k.doLogin("kubeapps-user@example.com", "password", process.env.VIEW_TOKEN);
+
+    // Change to user's namespace using UI
+    await page.click(".kubeapps-dropdown .kubeapps-nav-link");
+    await page.selectOption('select[name="namespaces"]', "default");
+    await page.click('cds-button:has-text("Change Context")');
+
+    // Select package to deploy
+    await page.click('a.nav-link:has-text("Catalog")');
+    await page.click('a .card-title:has-text("apache")');
+    await page.click('cds-button:has-text("Deploy") >> nth=0');
+
+    // Deploy package
+    const releaseNameLocator = page.locator("#releaseName");
+    await releaseNameLocator.waitFor();
+    await expect(releaseNameLocator).toHaveText("");
+    await releaseNameLocator.fill(utils.getRandomName("test-01-release"));
+    await page.locator('cds-button:has-text("Deploy")').click();
+
+    // Assertions
+    const errorLocator = page.locator("cds-alert-group");
+    await errorLocator.waitFor();
+    await expect(errorLocator).toHaveCount(1);
+    await page.waitForTimeout(5000);
+
+    // For some reason, UI is showing different error messages randomly
+    // Custom assertion logic
+    const errorMsg = await errorLocator.textContent();
+    console.log(`Error message on UI = "${errorMsg}"`);
+
+    await page.waitForFunction(msg => {
+      return msg.indexOf("secrets is forbidden") > -1 || msg.indexOf("unable to read secret") > -1;
+    }, errorMsg);
+  });
+
+  test("Regular user fails to deploy package in its own namespace from repos with secret", async ({
+    page,
+  }) => {
+    // Explanation: User has permissions to deploy in its namespace, but can't actually deploy
+    // if the package is from a repo that has a secret to which the user doesn't have access
+
+    // Log in
+    const k = new KubeappsLogin(page);
+    await k.doLogin("kubeapps-user@example.com", "password", process.env.VIEW_TOKEN);
+
+    // Change to user's namespace using UI
+    await page.click(".kubeapps-dropdown .kubeapps-nav-link");
+    await page.selectOption('select[name="namespaces"]', "kubeapps-user-namespace");
+    await page.click('cds-button:has-text("Change Context")');
+
+    // Select package to deploy
+    await page.click('a.nav-link:has-text("Catalog")');
+    await page.click('a .card-title:has-text("apache")');
+    await page.click('cds-button:has-text("Deploy") >> nth=0');
+
+    // Deploy package
+    const releaseNameLocator = page.locator("#releaseName");
+    await releaseNameLocator.waitFor();
+    await expect(releaseNameLocator).toHaveText("");
+    await releaseNameLocator.fill(utils.getRandomName("test-01-release"));
+    await page.locator('cds-button:has-text("Deploy")').click();
+
+    // Assertions
+    const errorLocator = page.locator("cds-alert-group");
+    await errorLocator.waitFor();
+    await expect(errorLocator).toHaveCount(1);
+    await page.waitForTimeout(5000);
+
+    // For some reason, UI is showing different error messages randomly
+    // Custom assertion logic
+    const errorMsg = await errorLocator.textContent();
+    console.log(`Error message on UI = "${errorMsg}"`);
+    await expect(errorLocator).toContainText("unable to read secret");
+  });
+});

--- a/integration/tests/main-group-1/02-create-package-repository.spec.js
+++ b/integration/tests/main-group-1/02-create-package-repository.spec.js
@@ -1,0 +1,41 @@
+// Copyright 2022-2023 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+const { test, expect } = require("@playwright/test");
+const { KubeappsLogin } = require("../utils/kubeapps-login");
+const utils = require("../utils/util-functions");
+
+test("Create a new package repository successfully", async ({ page }) => {
+  // Log in
+  const k = new KubeappsLogin(page);
+  await k.doLogin("kubeapps-operator@example.com", "password", process.env.ADMIN_TOKEN);
+
+  // Go to repos page
+  await page.click(".dropdown.kubeapps-menu button.kubeapps-nav-link");
+  await page.locator("text=Package Repositories").click();
+  await expect(page).not.toContain("text=Fetching Package Repositories...");
+
+  // Add new repo
+  console.log('Creating package repository "my-repo"');
+  await page.locator("text=Add Package Repository >> div").click();
+  await page.fill("input#kubeapps-repo-name", "my-repo");
+  await page.fill("input#kubeapps-repo-url", "https://charts.gitlab.io/");
+  await page.locator("text=Helm Charts").first().click();
+  await page.locator("text=Helm Repository").click();
+  await page.locator("text=Install Repository >> div").click();
+
+  // Wait for new packages to be indexed
+  await page.waitForTimeout(5000);
+
+  // Check if packages show up in catalog
+  await page.locator('a:has-text("my-repo")').click();
+  await page.waitForSelector('css=.catalog-container .card-title >> text="gitlab-runner"');
+
+  // Clean up
+  // Go back to repos page and delete repo
+  await page.click(".dropdown.kubeapps-menu button.kubeapps-nav-link");
+  await page.locator("text=Package Repositories").click();
+  await expect(page).not.toContain("text=Fetching Package Repositories...");
+  await page.locator("#delete-repo-my-repo div").click();
+  await page.locator('cds-modal-actions cds-button:has-text("Delete")').click();
+});

--- a/integration/tests/main-group-2/03-create-private-package-repository.spec.js
+++ b/integration/tests/main-group-2/03-create-private-package-repository.spec.js
@@ -1,0 +1,143 @@
+// Copyright 2022-2023 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+const { test, expect } = require("@playwright/test");
+const { KubeappsLogin } = require("../utils/kubeapps-login");
+const utils = require("../utils/util-functions");
+
+test("Create a new private package repository successfully", async ({ page }) => {
+  const deployTimeout = utils.getDeploymentTimeout();
+
+  // Log in
+  const k = new KubeappsLogin(page);
+  await k.doLogin("kubeapps-operator@example.com", "password", process.env.ADMIN_TOKEN);
+
+  // Change namespace to non-kubeapps
+  await page.click(".kubeapps-dropdown .kubeapps-nav-link");
+  await page.selectOption('select[name="namespaces"]', "default");
+  await page.click('cds-button:has-text("Change Context")');
+
+  // Go to repos page
+  await page.click(".dropdown.kubeapps-menu button.kubeapps-nav-link");
+  await page.locator("text=Package Repositories").click();
+  await expect(page).not.toContain("text=Fetching Package Repositories...");
+
+  // Add new repo
+  const repoName = utils.getRandomName("my-repo");
+  console.log(`Creating package repository "${repoName}"`);
+
+  await page.locator("text=Add Package Repository >> div").click();
+  await page.fill("input#kubeapps-repo-name", repoName);
+  await page.fill(
+    "input#kubeapps-repo-url",
+    "http://chartmuseum.chart-museum.svc.cluster.local:8080",
+  );
+  await page.locator("text=Helm Charts").first().click();
+  await page.locator("text=Helm Repository").click();
+
+  // Set credentials
+  await page.locator("#panel-auth cds-accordion-header div >> nth=0").first().click();
+  // Basic auth
+  await page.locator("text=Basic Auth").click();
+  await page.locator('[id="kubeapps-repo-username"]').fill("admin");
+  await page.locator('[id="kubeapps-repo-password"]').fill("password");
+
+  // Create repository
+  await page.locator("text=Install Repository >> div").click();
+
+  // Wait for new packages to be indexed
+  await page.waitForTimeout(5000);
+
+  // Check if our package shows up in catalog
+  await page.click(`a:has-text("${repoName}")`);
+
+  await page.click('a:has-text("foo apache chart for CI")');
+
+  // Deploy package
+  await page.click('cds-button:has-text("Deploy")');
+  await page.selectOption('select[name="package-versions"]', "8.6.2");
+  const releaseNameLocator = page.locator("#releaseName");
+  await releaseNameLocator.waitFor();
+  await expect(releaseNameLocator).toHaveText("");
+  const appName = utils.getRandomName("test-03-release");
+  console.log(`Creating release "${appName}"`);
+  await releaseNameLocator.fill(appName);
+
+  // Select version and deploy
+  await page.locator('select[name="package-versions"]').selectOption("8.6.2");
+  await page.locator('cds-button:has-text("Deploy")').click();
+
+  // Assertions
+  // Wait for the app to be deployed and select it from "Applications"
+  await page.waitForTimeout(5000);
+  await page.click('a.nav-link:has-text("Applications")');
+  await page.waitForTimeout(3000); // Sometimes typing was too fast to get the result shown
+  await page.locator("input#search").fill(appName);
+  await page.waitForTimeout(3000);
+  await page.click(`a .card-title:has-text("${appName}")`);
+
+  await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
+    timeout: deployTimeout,
+  });
+  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
+    timeout: deployTimeout,
+  });
+
+  // Prepare and verify the upgrade
+  await page.waitForSelector('cds-button:has-text("Upgrade")');
+  await page.click('cds-button:has-text("Upgrade")');
+
+  // Check first current installed version
+  await page.waitForSelector('select[name="package-versions"]');
+  const packageVersionValue = await page.inputValue('select[name="package-versions"]');
+  expect(packageVersionValue).toEqual("8.6.2");
+
+  // Select new version
+  await page.selectOption('select[name="package-versions"]', "8.6.3");
+
+  // Ensure that the new value is selected
+  await page.waitForSelector('select[name="package-versions"]');
+  const newPackageVersionValue = await page.inputValue('select[name="package-versions"]');
+  expect(newPackageVersionValue).toEqual("8.6.3");
+  await page.click('li:has-text("YAML editor")');
+
+  // Use the built-in search function in monaco to find the text we are looking for
+  // so that it get loaded in the DOM when using the toContainText assert
+  await page.locator(".values-editor div.modified").click({ button: "right" });
+  await page.locator("text=Command Palette").click();
+  await page.getByLabel("input").click();
+  await page.getByLabel("input").fill(">find");
+  await page
+    .locator("div")
+    .filter({ hasText: /^Find$/ })
+    .nth(1)
+    .click();
+  await page.getByPlaceholder("Find").fill("tag: 2.4.48");
+  await expect(page.locator(".values-editor div.modified")).toContainText(
+    "tag: 2.4.48-debian-10-r75",
+  );
+
+  // Deploy upgrade
+  await page.click('cds-button:has-text("Deploy")');
+
+  // Check upgrade result
+  await page.waitForSelector(".left-menu");
+  // Wait for the app to be deployed and select it from "Applications"
+  await expect(page.locator(".left-menu")).toContainText("Up to date", { timeout: deployTimeout });
+  await page.waitForTimeout(5000);
+  await page.click('a.nav-link:has-text("Applications")');
+  await page.waitForTimeout(3000); // Sometimes typing was too fast to get the result shown
+  await page.locator("input#search").fill(appName);
+  await page.waitForTimeout(3000);
+  await page.click(`a .card-title:has-text("${appName}")`);
+  await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
+    timeout: deployTimeout,
+  });
+  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
+    timeout: deployTimeout,
+  });
+
+  // Clean up
+  await page.locator('cds-button:has-text("Delete")').click();
+  await page.locator('cds-modal-actions cds-button:has-text("Delete")').click();
+});

--- a/integration/tests/main-group-2/04-default-deployment.spec.js
+++ b/integration/tests/main-group-2/04-default-deployment.spec.js
@@ -1,0 +1,40 @@
+// Copyright 2022-2023 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+const { test, expect } = require("@playwright/test");
+const { KubeappsLogin } = require("../utils/kubeapps-login");
+const utils = require("../utils/util-functions");
+
+test("Deploys package with default values in main cluster", async ({ page }) => {
+  // Log in
+  const k = new KubeappsLogin(page);
+  await k.doLogin("kubeapps-operator@example.com", "password", process.env.ADMIN_TOKEN);
+
+  // Select package to deploy
+  await page.click('a.nav-link:has-text("Catalog")');
+  await page.locator("input#search").fill("apache");
+  await page.waitForTimeout(3000);
+  await page.click('a:has-text("foo apache chart for CI")');
+  await page.click('cds-button:has-text("Deploy") >> nth=0');
+
+  // Deploy package
+  const releaseNameLocator = page.locator("#releaseName");
+  await releaseNameLocator.waitFor();
+  await expect(releaseNameLocator).toHaveText("");
+  const releaseName = utils.getRandomName("test-04-release");
+  console.log(`Creating release "${releaseName}"`);
+  await releaseNameLocator.fill(releaseName);
+  await page.locator('cds-button:has-text("Deploy")').click();
+
+  // Assertions
+  await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
+    timeout: utils.getDeploymentTimeout(),
+  });
+  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
+    timeout: utils.getDeploymentTimeout(),
+  });
+
+  // Clean up
+  await page.locator('cds-button:has-text("Delete")').click();
+  await page.locator('cds-modal-actions cds-button:has-text("Delete")').click();
+});

--- a/integration/tests/main-group-2/07-upgrade.spec.js
+++ b/integration/tests/main-group-2/07-upgrade.spec.js
@@ -1,0 +1,98 @@
+// Copyright 2022-2023 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+const { test, expect } = require("@playwright/test");
+const { KubeappsLogin } = require("../utils/kubeapps-login");
+const utils = require("../utils/util-functions");
+
+test("Upgrades an application", async ({ page }) => {
+  test.setTimeout(360000);
+  const deployTimeout = utils.getDeploymentTimeout();
+
+  // Log in
+  const k = new KubeappsLogin(page);
+  await k.doLogin("kubeapps-operator@example.com", "password", process.env.EDIT_TOKEN);
+
+  // Go to catalog
+  await page.click('a.nav-link:has-text("Catalog")');
+  await page.click('.filters-menu label:has-text("bitnami")');
+  await page.waitForSelector("input#search");
+  await page.locator("input#search").fill("apache");
+  await page.waitForTimeout(3000);
+
+  // Select package
+  await page.click('.card-title:has-text("kubeapps-apache")');
+
+  // Select an older version to be installed
+  await page.waitForSelector('select[name="package-versions"]');
+  const defaultVersion = await page.inputValue('select[name="package-versions"]');
+  await page.selectOption('select[name="package-versions"]', "8.6.2");
+  const olderVersion = await page.inputValue('select[name="package-versions"]');
+  expect(defaultVersion).not.toBe(olderVersion);
+
+  // Deploy package
+  await page.click('cds-button:has-text("Deploy") >> nth=0');
+
+  // Increase replicas
+  await page.locator('input[id^="replicaCount_text"]').fill("2");
+
+  // Wait until changes are applied (due to the debounce in the input)
+  await page.waitForTimeout(1000);
+  await page.locator('li:has-text("YAML editor")').click();
+  await page.waitForTimeout(1000);
+
+  // Use the built-in search function in monaco to find the text we are looking for
+  // so that it get loaded in the DOM when using the toContainText assert
+  await page.locator(".values-editor div.modified").click({ button: "right" });
+  await page.locator("text=Command Palette").click();
+  await page.getByLabel("input").click();
+  await page.getByLabel("input").fill(">find");
+  await page
+    .locator("div")
+    .filter({ hasText: /^Find$/ })
+    .nth(1)
+    .click();
+  await page.getByPlaceholder("Find").fill("replicaCount: ");
+  await expect(page.locator(".values-editor div.modified")).toContainText("replicaCount: 2");
+
+  // Set release name
+  const releaseNameLocator = page.locator("#releaseName");
+  await releaseNameLocator.waitFor();
+  await expect(releaseNameLocator).toHaveText("");
+  const releaseName = utils.getRandomName("test-07-upgrade");
+  console.log(`Creating release "${releaseName}"`);
+  await releaseNameLocator.fill(releaseName);
+
+  // Trigger deploy
+  await page.locator('cds-button:has-text("Deploy")').click();
+
+  await page.click('cds-button:has-text("Upgrade")');
+
+  await expect(page.locator(".left-menu")).toContainText(olderVersion, { timeout: deployTimeout });
+  await page.selectOption('select[name="package-versions"]', defaultVersion);
+  await page.waitForTimeout(2000);
+  const newSelection = await page.inputValue('select[name="package-versions"]');
+  expect(newSelection).toBe(defaultVersion);
+
+  await page.locator('cds-button:has-text("Deploy")').click();
+
+  // Check upgrade result
+  // Wait for the app to be deployed and select it from "Applications"
+  await expect(page.locator(".left-menu")).toContainText("Up to date", { timeout: deployTimeout });
+  await page.waitForTimeout(5000);
+  await page.click('a.nav-link:has-text("Applications")');
+  await page.waitForTimeout(3000); // Sometimes typing was too fast to get the result shown
+  await page.locator("input#search").fill(releaseName);
+  await page.waitForTimeout(3000);
+  await page.click(`a .card-title:has-text("${releaseName}")`);
+  await page.waitForSelector("css=.application-status-pie-chart-number >> text=2", {
+    timeout: deployTimeout,
+  });
+  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
+    timeout: deployTimeout,
+  });
+
+  // Clean up
+  await page.locator('cds-button:has-text("Delete")').click();
+  await page.locator('cds-modal-actions cds-button:has-text("Delete")').click();
+});

--- a/integration/tests/main-group-3/08-rollback.spec.js
+++ b/integration/tests/main-group-3/08-rollback.spec.js
@@ -1,0 +1,120 @@
+// Copyright 2022-2023 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+const { test, expect } = require("@playwright/test");
+const { KubeappsLogin } = require("../utils/kubeapps-login");
+const utils = require("../utils/util-functions");
+
+test("Rolls back an application", async ({ page }) => {
+  test.setTimeout(360000);
+
+  // Log in
+  const k = new KubeappsLogin(page);
+  await k.doLogin("kubeapps-operator@example.com", "password", process.env.EDIT_TOKEN);
+
+  // Go to catalog
+  await page.click('a.nav-link:has-text("Catalog")');
+  await page.click('.filters-menu label:has-text("bitnami")');
+  await page.waitForSelector("input#search");
+  await page.locator("input#search").fill("apache");
+  await page.waitForTimeout(3000);
+
+  // Select package
+  await page.click('.card-title:has-text("kubeapps-apache")');
+
+  // Go to Deploy package
+  await page.click('cds-button:has-text("Deploy") >> nth=0');
+
+  // Set release name
+  const releaseNameLocator = page.locator("#releaseName");
+  await releaseNameLocator.waitFor();
+  await expect(releaseNameLocator).toHaveText("");
+  const releaseName = utils.getRandomName("test-08-rollback");
+  console.log(`Creating release "${releaseName}"`);
+  await releaseNameLocator.fill(releaseName);
+
+  // Trigger deploy
+  await page.locator('cds-button:has-text("Deploy")').click();
+
+  // Check deployment
+  await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
+    timeout: utils.getDeploymentTimeout(),
+  });
+  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
+    timeout: utils.getDeploymentTimeout(),
+  });
+
+  // Try rollback
+  await page.locator('cds-button:has-text("Rollback")').click();
+  await expect(page.locator("cds-modal-content")).toContainText(
+    "The application has not been upgraded, it's not possible to rollback.",
+  );
+  await page.locator('cds-button:has-text("Cancel")').click();
+
+  // Upgrade the app to get another revision
+  await page.locator('cds-button:has-text("Upgrade")').click();
+
+  // Increase replicas
+  await page.locator('input[id^="replicaCount_text"]').fill("2");
+
+  // Wait until changes are applied (due to the debounce in the input)
+  await page.waitForTimeout(1000);
+  await page.locator('li:has-text("YAML editor")').click();
+  await page.waitForTimeout(1000);
+
+  // Use the built-in search function in monaco to find the text we are looking for
+  // so that it get loaded in the DOM when using the toContainText assert
+  await page.locator(".values-editor div.modified").click({ button: "right" });
+  await page.locator("text=Command Palette").click();
+  await page.getByLabel("input").click();
+  await page.getByLabel("input").fill(">find");
+  await page
+    .locator("div")
+    .filter({ hasText: /^Find$/ })
+    .nth(1)
+    .click();
+  await page.getByPlaceholder("Find").fill("replicaCount: ");
+  await expect(page.locator(".values-editor div.modified")).toContainText("replicaCount: 2");
+
+  await page.locator('cds-button:has-text("Deploy")').click();
+
+  // Check upgrade result
+  await page.waitForSelector("css=.application-status-pie-chart-number >> text=2", {
+    timeout: utils.getDeploymentTimeout(),
+  });
+  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
+    timeout: utils.getDeploymentTimeout(),
+  });
+
+  //  Rollback to the previous revision (default selected value)
+  await page.locator('cds-button:has-text("Rollback")').click();
+  await page.waitForSelector("cds-select#revision-selector");
+  await expect(page.locator("cds-select#revision-selector cds-control-message")).toContainText(
+    "(current: 2)",
+  );
+  await page.locator('cds-modal-actions cds-button:has-text("Rollback")').click();
+  await page.waitForTimeout(5000);
+
+  // Check revision and rollback to a revision (manual selected value)
+  await page.locator('cds-button:has-text("Rollback")').click();
+  await page.waitForSelector("cds-select#revision-selector");
+  await expect(page.locator("cds-select#revision-selector cds-control-message")).toContainText(
+    "(current: 3)",
+  );
+  await page.selectOption("cds-select#revision-selector select", "1");
+  await page.locator('cds-modal-actions cds-button:has-text("Rollback")').click();
+  await page.waitForTimeout(5000);
+
+  // Check revisions
+  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready");
+  await page.locator('cds-button:has-text("Rollback")').click();
+  await page.waitForSelector("cds-select#revision-selector");
+  await expect(page.locator("cds-select#revision-selector cds-control-message")).toContainText(
+    "(current: 4)",
+  );
+  await page.locator('cds-button:has-text("Cancel")').click();
+
+  // Clean up
+  await page.locator('cds-button:has-text("Delete")').click();
+  await page.locator('cds-modal-actions cds-button:has-text("Delete")').click();
+});

--- a/integration/tests/main-group-3/09-user-positive-installation.spec.js
+++ b/integration/tests/main-group-3/09-user-positive-installation.spec.js
@@ -1,0 +1,88 @@
+// Copyright 2022-2023 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+const { test, expect } = require("@playwright/test");
+const { KubeappsLogin } = require("../utils/kubeapps-login");
+const utils = require("../utils/util-functions");
+
+test.describe("Limited user simple deployments", () => {
+  test("Regular user can deploy and delete packages in its own namespace from global repo without secrets", async ({
+    page,
+  }) => {
+    // Log in as admin to create a repo without password
+    const k = new KubeappsLogin(page);
+    await k.doLogin("kubeapps-operator@example.com", "password", process.env.ADMIN_TOKEN);
+
+    // Change namespace using UI
+    await page.click(".kubeapps-dropdown .kubeapps-nav-link");
+    await page.selectOption('select[name="namespaces"]', "kubeapps-repos-global");
+    await page.click('cds-button:has-text("Change Context")');
+
+    // Go to repos page
+    await page.click(".dropdown.kubeapps-menu button.kubeapps-nav-link");
+    await page.locator("text=Package Repositories").click();
+    await expect(page).not.toContain("text=Fetching Package Repositories...");
+
+    // Add new repo
+    const repoName = utils.getRandomName("repo-09");
+    console.log(`Creating package repository "${repoName}"`);
+    await page.locator("text=Add Package Repository >> div").click();
+    await page.fill("input#kubeapps-repo-name", repoName);
+    await page.fill(
+      "input#kubeapps-repo-url",
+      "https://prometheus-community.github.io/helm-charts",
+    );
+    await page.locator("text=Helm Charts").first().click();
+    await page.locator("text=Helm Repository").click();
+    await page.locator("text=Install Repository >> div").click();
+
+    await page.waitForLoadState("networkidle");
+    await page.click(`div.page-content table td a:has-text("${repoName}")`);
+
+    // Log out admin and log in regular user
+    await k.doLogout();
+    await k.doLogin("kubeapps-user@example.com", "password", process.env.VIEW_TOKEN);
+
+    // Switch to user's namespace using UI
+    await page.click(".kubeapps-dropdown .kubeapps-nav-link");
+    await page.selectOption('select[name="namespaces"]', "kubeapps-user-namespace");
+    await page.click('cds-button:has-text("Change Context")');
+
+    // Select package to deploy
+    await page.click('a.nav-link:has-text("Catalog")');
+    await page.locator("input#search").fill("alertmanager");
+    await page.waitForTimeout(3000);
+    await page.click('a:has-text("alertmanager")');
+    await page.click('cds-button:has-text("Deploy") >> nth=0');
+
+    // Deploy package
+    const releaseNameLocator = page.locator("#releaseName");
+    await releaseNameLocator.waitFor();
+    await expect(releaseNameLocator).toHaveText("");
+    const releaseName = utils.getRandomName("test-09-release");
+    console.log(`Creating release "${releaseName}"`);
+    await releaseNameLocator.fill(releaseName);
+    await page.locator('cds-button:has-text("Deploy")').click();
+
+    // Check that package is deployed
+    await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
+      timeout: utils.getDeploymentTimeout(),
+    });
+    await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
+      timeout: utils.getDeploymentTimeout(),
+    });
+
+    // Delete deployment
+    await page.locator('cds-button:has-text("Delete")').click();
+    await page.locator('cds-modal-actions cds-button:has-text("Delete")').click();
+    await page.waitForTimeout(10000);
+
+    // Search for package deployed
+    await page.click('a.nav-link:has-text("Applications")');
+    await page.waitForTimeout(3000); // Sometimes typing was too fast to get the result shown
+    await page.locator("input#search").fill("alertmanager");
+    await page.waitForTimeout(3000);
+    const packageLocator = page.locator('a:has-text("alertmanager")');
+    await expect(packageLocator).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->
The `main` group of the integration tests takes quite a while to complete, which makes the feedback loop of the CI fairly slow. To improve that situation a little bit, we could split the `main` group of tests into several subgroups that run in parallel.

### Description of the change

The `main` group of the integration tests is split into several (three) subgroups that run in parallel.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Reduce the time the `test_e2e_local` job takes to complete.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

Increase the resources required by the CI as we need to spin up more k8s clusters in parallel.
<!-- Describe any known limitations with your change -->

