### PR TITLE
PostgresSQL request values must match subchart schema

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1804,10 +1804,10 @@ postgresql:
   ## Example:
   ## resources:
   ##   requests:
-  ##     cpu: 2
+  ##     cpu: 2000m
   ##     memory: 512Mi
   ##   limits:
-  ##     cpu: 3
+  ##     cpu: 3000m
   ##     memory: 1024Mi
   ##
   ##


### PR DESCRIPTION
This helm package uses the bitnami/postgres subchart. The subchart specifies a schema for "requests" CPU values. The commented default values in file values.yaml in this repo do not validate the subchart schema because they are casted to an integer. Here is a fix.

Reference: https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.schema.json#L100