### PR TITLE
Redirect external site to GitHub

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.59.1
           args: --timeout=10m
 
   license-headers-linter:

--- a/site/themes/template/layouts/_default/baseof.html
+++ b/site/themes/template/layouts/_default/baseof.html
@@ -3,6 +3,7 @@
 
 <head>
   <!-- OneTrust Cookies Consent Notice and Google Tag Manager -->
+  <meta http-equiv="refresh" content="0; url=https://github.com/vmware-tanzu/kubeapps/" />
   <meta content="{{ .Site.Params.oneTrustId }}" name="onetrust-data-domain">
   <meta content="https://tags.tiqcdn.com/utag/vmware/microsites-privacy/prod/utag.js" name="microsites-utag">
   <script defer src="https://code.jquery.com/jquery-3.6.1.slim.min.js" integrity="sha256-w8CvhFs7iHNVUtnSP0YKEg00p9Ih13rlL9zGqvLdePA=" crossorigin="anonymous"></script>


### PR DESCRIPTION
**Description of the change**

Kubeapps implemented an external documentation site a few years ago. This documentation site is currently outdated and does not offer a complete vision of the Kubeapps features and use cases. This PR redirects users to the GitHub repository where the latest documentation will be available 

**Benefits**

The team can concentrate efforts on developing new features and fixing bugs rather than maintaining a documentation site that is redundant. 

Unrelated change, the golangci-lint process failed until reverted to the 1.59.1 version. 

