### PR TITLE
Point Helm chart references to the OCI repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ With Kubeapps you can:
 Installing Kubeapps is as simple as:
 
 ```bash
-helm repo add bitnami https://charts.bitnami.com/bitnami
 kubectl create namespace kubeapps
-helm install kubeapps --namespace kubeapps bitnami/kubeapps
+helm install kubeapps --namespace kubeapps oci://registry-1.docker.io/bitnamicharts/kubeapps
 ```
 
 See the [Getting Started Guide](./site/content/docs/latest/tutorials/getting-started.md) for detailed instructions on how to install and use Kubeapps.

--- a/site/content/docs/latest/howto/OIDC/OAuth2OIDC-keycloak.md
+++ b/site/content/docs/latest/howto/OIDC/OAuth2OIDC-keycloak.md
@@ -125,7 +125,7 @@ auth:
 Then just deploy Keycloak either using Kubeapps UI or helm cli as follows:
 
 ```shell
-helm install keycloak bitnami/keycloak --values my-values.yaml
+helm install keycloak oci://registry-1.docker.io/bitnamicharts/keycloak --values my-values.yaml
 ```
 
 ## Keycloak Configuration

--- a/site/content/docs/latest/howto/OIDC/OAuth2OIDC-oauth2-proxy.md
+++ b/site/content/docs/latest/howto/OIDC/OAuth2OIDC-oauth2-proxy.md
@@ -18,7 +18,7 @@ Kubeapps chart allows you to automatically deploy the proxy for you as a sidecar
 This example uses `oauth2-proxy`'s generic OIDC provider with Google, but is applicable to any OIDC provider such as Keycloak, Dex, Okta or Azure Active Directory etc. Note that the issuer url is passed as an additional flag here, together with an option to enable the cookie being set over an insecure connection for local development only:
 
 ```bash
-helm install kubeapps bitnami/kubeapps \
+helm install kubeapps oci://registry-1.docker.io/bitnamicharts/kubeapps \
   --namespace kubeapps \
   --set authProxy.enabled=true \
   --set authProxy.provider=oidc \
@@ -35,7 +35,7 @@ Some of the specific providers that come with `oauth2-proxy` are using OpenIDCon
 Here we no longer need to provide the issuer -url as an additional flag:
 
 ```bash
-helm install kubeapps bitnami/kubeapps \
+helm install kubeapps oci://registry-1.docker.io/bitnamicharts/kubeapps \
   --namespace kubeapps \
   --set authProxy.enabled=true \
   --set authProxy.provider=google \
@@ -56,7 +56,7 @@ For this reason, when deploying Kubeapps on GKE we need to ensure that
 Note that using the custom `google` provider here enables google to prompt the user for consent for the specific permissions requested in the scopes below, in a user-friendly way. You can also use the `oidc` provider but in this case the user is not prompted for the extra consent:
 
 ```bash
-helm install kubeapps bitnami/kubeapps \
+helm install kubeapps oci://registry-1.docker.io/bitnamicharts/kubeapps \
   --namespace kubeapps \
   --set authProxy.enabled=true \
   --set authProxy.provider=google \

--- a/site/content/docs/latest/howto/custom-app-view-support.md
+++ b/site/content/docs/latest/howto/custom-app-view-support.md
@@ -20,7 +20,7 @@ Kubeapps supports the ability for developers to inject custom app views for spec
 1. The bundle can be added via the command line:
 
    ```bash
-   helm install  bitnami/kubeapps --set-file dashboard.customComponents=*path to file* <other_flags>
+   helm install oci://registry-1.docker.io/bitnamicharts/kubeapps --set-file dashboard.customComponents=*path to file* <other_flags>
    ```
 
    Note: The file can be located anywhere on your file system or even a remote source!

--- a/site/content/docs/latest/howto/deploying-to-multiple-clusters.md
+++ b/site/content/docs/latest/howto/deploying-to-multiple-clusters.md
@@ -133,7 +133,7 @@ Updating the value of the `clusters` chart option is just like updating any othe
 So if you had originally installed Kubeapps with a command like:
 
 ```bash
-helm install kubeapps bitnami/kubeapps --namespace kubeapps --values ./path/to/my/values.yaml
+helm install kubeapps oci://registry-1.docker.io/bitnamicharts/kubeapps --namespace kubeapps --values ./path/to/my/values.yaml
 ```
 
 then to modify the clusters configured for Kubeapps at some later point you will need to

--- a/site/content/docs/latest/howto/offline-installation.md
+++ b/site/content/docs/latest/howto/offline-installation.md
@@ -36,7 +36,7 @@ To be able to able to install Kubeapps without an Internet connection, it's nece
 First, download the tarball containing the Kubeapps chart from the publicly available repository maintained by Bitnami.
 
 ```bash
-helm pull --untar https://charts.bitnami.com/bitnami/kubeapps-x.y.z.tgz
+helm pull --untar oci://registry-1.docker.io/bitnamicharts/kubeapps --version x.y.z
 helm dep update ./kubeapps
 ```
 

--- a/site/content/docs/latest/reference/scripts/setup-harbor.sh
+++ b/site/content/docs/latest/reference/scripts/setup-harbor.sh
@@ -120,7 +120,7 @@ silence kubectl create ns "$namespace"
 silence helm install harbor \
     --namespace "$namespace" \
     -f <(echo "$values") \
-    bitnami/harbor
+    oci://registry-1.docker.io/bitnamicharts/harbor
 # Wait for Harbor components
 info "Waiting for Harbor components to be ready..."
 deployments=(

--- a/site/content/docs/latest/reference/scripts/setup-kubeapps.sh
+++ b/site/content/docs/latest/reference/scripts/setup-kubeapps.sh
@@ -117,7 +117,7 @@ silence kubectl create ns "$namespace"
 silence helm install kubeapps \
     --namespace "$namespace" \
     -f <(echo "$values") \
-    bitnami/kubeapps
+    oci://registry-1.docker.io/bitnamicharts/kubeapps
 # Wait for Kubeapps components
 info "Waiting for Kubeapps components to be ready..."
 deployments=(

--- a/site/content/docs/latest/tutorials/getting-started.md
+++ b/site/content/docs/latest/tutorials/getting-started.md
@@ -37,9 +37,8 @@ This guide walks you through the process of deploying Kubeapps for your cluster 
 Use the official [Bitnami Kubeapps chart](https://github.com/bitnami/charts/tree/main/bitnami/kubeapps) to install the latest version of Kubeapps:
 
 ```bash
-helm repo add bitnami https://charts.bitnami.com/bitnami
 kubectl create namespace kubeapps
-helm install kubeapps --namespace kubeapps bitnami/kubeapps
+helm install kubeapps --namespace kubeapps oci://registry-1.docker.io/bitnamicharts/kubeapps
 ```
 
 For detailed information on installing, configuring and upgrading Kubeapps, checkout the [chart README](https://github.com/vmware-tanzu/kubeapps/blob/main/chart/kubeapps/README.md).

--- a/site/content/docs/latest/tutorials/kubeapps-on-tkg/step-2.md
+++ b/site/content/docs/latest/tutorials/kubeapps-on-tkg/step-2.md
@@ -43,13 +43,13 @@ Key user interface parameters are:
 > - As values passed via command line:
 >
 > ```bash
-> helm install kubeapps --namespace kubeapps --set ingress.enabled=true bitnami/kubeapps
+> helm install kubeapps --namespace kubeapps --set ingress.enabled=true oci://registry-1.docker.io/bitnamicharts/kubeapps
 > ```
 >
 > - As values stored in a custom `values.yaml` file read in during chart deployment:
 >
 > ```bash
-> helm install kubeapps --namespace kubeapps -f custom-values.yaml  bitnami/kubeapps
+> helm install kubeapps --namespace kubeapps -f custom-values.yaml  oci://registry-1.docker.io/bitnamicharts/kubeapps
 > ```
 
 ### Step 2.1: Configure Authentication
@@ -177,14 +177,11 @@ To install Kubeapps in an air-gapped environment, please follow the [offline ins
 Use the commands below to install Kubeapps. The final command assumes that the Kubeapps chart configuration parameters are defined in a file named `custom-values.yaml`, so ensure this file exists before running that command.
 
 ```bash
-# Install the Bitnami helm repository
-helm repo add bitnami https://charts.bitnami.com/bitnami
-
 # Create a 'kubeapps' namespace in our cluster
 kubectl create namespace kubeapps
 
 # Install a 'kubeapps' release in the 'kubeapps' namespace with the values defined at 'custom-values.yaml'
-helm install kubeapps --namespace kubeapps bitnami/kubeapps -f custom-values.yaml
+helm install kubeapps --namespace kubeapps oci://registry-1.docker.io/bitnamicharts/kubeapps -f custom-values.yaml
 ```
 
 Finally, remember to replace the placeholder _Redirect URIs_ you entered when [creating the OAuth2 application during step 1](./step-1.md#create-an-oauth2-application) with the actual value.


### PR DESCRIPTION
### Description of the change

Point all the references to the Bitnami Kubeapps chart in the `helm install` command to the OCI repository.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Docs and scripts are up-to-date and point to the OCI version of the Bitnami chart.

### Possible drawbacks

None.

### Applicable issues

N/A

### Additional information

N/A