### PR TITLE
Add support for OCI tarball url

### DIFF
--- a/cmd/asset-syncer/server/utils.go
+++ b/cmd/asset-syncer/server/utils.go
@@ -329,7 +329,7 @@ func getOciTarballUrl(chartTarballURL *url.URL, userAgent string, authorizationH
 	// If URL points to an OCI chart, we transform its URL to its tgz blob URL
 	// Extract the tag from the chart Path
 	chartTag := "latest"
-	i := strings.Index(chartTarballURL.Path, ":")
+	i := strings.LastIndex(chartTarballURL.Path, ":")
 	if i >= 0 {
 		chartTag = chartTarballURL.Path[i+1:]
 		chartTarballURL.Path = chartTarballURL.Path[:i]

--- a/cmd/asset-syncer/server/utils.go
+++ b/cmd/asset-syncer/server/utils.go
@@ -311,21 +311,37 @@ func (r *HelmRepo) FetchFiles(cv models.ChartVersion, userAgent string, passCred
 
 	// If URL points to an OCI chart, we transform its URL to its tgz blob URL
 	if chartTarballURL.Scheme == "oci" {
-		// Override the chart tarball with the oci blob tarball
-		chartTarballURL, err = getOciTarballUrl(chartTarballURL, userAgent, authorizationHeader, r.netClient)
-		if err != nil {
-			return nil, err
-		}
+		return FetchChartDetailFromOciUrl(chartTarballURL, userAgent, authorizationHeader, r.netClient)
+	} else {
+		return FetchChartDetailFromTarballUrl(chartTarballURL, userAgent, authorizationHeader, r.netClient)
 	}
-
-	return tarutil.FetchChartDetailFromTarballUrl(
-		chartTarballURL.String(),
-		userAgent,
-		authorizationHeader,
-		r.netClient)
 }
 
-func getOciTarballUrl(chartTarballURL *url.URL, userAgent string, authorizationHeader string, netClient *http.Client) (*url.URL, error) {
+// Fetches helm chart details from a gzipped tarball
+//
+// name is expected in format "foo/bar" or "foo%2Fbar" if url-escaped
+func FetchChartDetailFromTarballUrl(chartTarballURL *url.URL, userAgent string, authz string, netClient *http.Client) (map[string]string, error) {
+	reqHeaders := make(map[string]string)
+	if len(userAgent) > 0 {
+		reqHeaders["User-Agent"] = userAgent
+	}
+	if len(authz) > 0 {
+		reqHeaders["Authorization"] = authz
+	}
+
+	// use our "standard" http-client library
+	reader, _, err := httpclient.GetStream(chartTarballURL.String(), netClient, reqHeaders)
+	if reader != nil {
+		defer reader.Close()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return tarutil.FetchChartDetailFromTarball(reader)
+}
+
+func FetchChartDetailFromOciUrl(chartTarballURL *url.URL, userAgent string, authorizationHeader string, netClient *http.Client) (map[string]string, error) {
 	// If URL points to an OCI chart, we transform its URL to its tgz blob URL
 	// Extract the tag from the chart Path
 	chartTag := "latest"
@@ -334,12 +350,13 @@ func getOciTarballUrl(chartTarballURL *url.URL, userAgent string, authorizationH
 		chartTag = chartTarballURL.Path[i+1:]
 		chartTarballURL.Path = chartTarballURL.Path[:i]
 	}
+	// Separate the appname from the oci Url
 	j := strings.LastIndex(chartTarballURL.Path, "/")
-	RegistryNamespaceUrl, err := url.Parse(chartTarballURL.Path[j+1:])
-	appName := chartTarballURL.Path[:j]
+	appName := chartTarballURL.Path[j+1:]
+	chartTarballURL.Path = chartTarballURL.Path[:j]
 	// TODO: I would like to refactor the OciAPIClient to be generic and allow generating an OCI client without all the oci-catalog specific code
 	// IMPORTANT: Currently, getOrasRepoClient(appname, userAgent) is too specific, I would need to be able to generate an OCI client for other general purposes by simply providing an url.
-	o := OciAPIClient{RegistryNamespaceUrl: RegistryNamespaceUrl, HttpClient: netClient, GrpcClient: nil}
+	o := OciAPIClient{RegistryNamespaceUrl: chartTarballURL, HttpClient: netClient, GrpcClient: nil}
 	orasRepoClient, err := o.getOrasRepoClient(appName, "")
 	if err != nil {
 		panic(err)
@@ -347,13 +364,13 @@ func getOciTarballUrl(chartTarballURL *url.URL, userAgent string, authorizationH
 	ctx := context.TODO()
 	// TODO: This code is too similar to the function 'IsHelmChart'.
 	// Again, I would like to move both functions into a common 'fetchOciManifest' function in order to simplify the code structure
-	descriptor, rc, err := orasRepoClient.Manifests().FetchReference(ctx, chartTag)
+	manifestDescriptor, rc, err := orasRepoClient.Manifests().FetchReference(ctx, chartTag)
 	if err != nil {
 		panic(err)
 	}
 	defer rc.Close()
 
-	manifestData, err := content.ReadAll(rc, descriptor)
+	manifestData, err := content.ReadAll(rc, manifestDescriptor)
 	if err != nil {
 		panic(err)
 	}
@@ -366,17 +383,19 @@ func getOciTarballUrl(chartTarballURL *url.URL, userAgent string, authorizationH
 		return nil, fmt.Errorf("unexpected layer in chart manifest")
 	}
 
-	ociTarballUrl, err := buildChartOciTarballUrl("https", chartTarballURL.Host, chartTarballURL.Path, manifest.Layers[0].Digest)
+	blobDescriptor, err := orasRepoClient.Blobs().Resolve(ctx, manifest.Layers[0].Digest)
+	if err != nil {
+		return nil, err
+	}
+	reader, err := orasRepoClient.Blobs().Fetch(ctx, blobDescriptor)
+	if reader != nil {
+		defer reader.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	return ociTarballUrl, nil
-}
-
-func buildChartOciTarballUrl(schema string, registry string, repository string, blobDigest string) (*url.URL, error) {
-	ociTarballUrl := fmt.Sprintf("%s://%s/v2/%s/blobs/%s", schema, registry, repository, blobDigest)
-	return url.Parse(ociTarballUrl)
+	return tarutil.FetchChartDetailFromTarball(reader)
 }
 
 // TagList represents a list of tags as specified at

--- a/cmd/asset-syncer/server/utils.go
+++ b/cmd/asset-syncer/server/utils.go
@@ -329,15 +329,18 @@ func getOciTarballUrl(chartTarballURL *url.URL, userAgent string, authorizationH
 	// If URL points to an OCI chart, we transform its URL to its tgz blob URL
 	// Extract the tag from the chart Path
 	chartTag := "latest"
-	i := strings.LastIndex(chartTarballURL.Path, ":")
+	i := strings.Index(chartTarballURL.Path, ":")
 	if i >= 0 {
 		chartTag = chartTarballURL.Path[i+1:]
 		chartTarballURL.Path = chartTarballURL.Path[:i]
 	}
+	j := strings.LastIndex(chartTarballURL.Path, "/")
+	RegistryNamespaceUrl, err := url.Parse(chartTarballURL.Path[j+1:])
+	appName := chartTarballURL.Path[:j]
 	// TODO: I would like to refactor the OciAPIClient to be generic and allow generating an OCI client without all the oci-catalog specific code
 	// IMPORTANT: Currently, getOrasRepoClient(appname, userAgent) is too specific, I would need to be able to generate an OCI client for other general purposes by simply providing an url.
-	o := OciAPIClient{RegistryNamespaceUrl: chartTarballURL, HttpClient: netClient, GrpcClient: nil, AuthorizationHeader: authorizationHeader}
-	orasRepoClient, err := o.getOrasRepoClient(path.Join(chartTarballURL.Host, chartTarballURL.Path), "", "")
+	o := OciAPIClient{RegistryNamespaceUrl: RegistryNamespaceUrl, HttpClient: netClient, GrpcClient: nil}
+	orasRepoClient, err := o.getOrasRepoClient(appName, "")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -963,7 +963,7 @@ func (s *Server) fetchChartWithRegistrySecrets(ctx context.Context, headers http
 		},
 		appRepo,
 		caCertSecret, authSecret,
-		s.chartClientFactory.New(appRepo.Spec.Type, userAgentString),
+		s.chartClientFactory.New(tarballURL, userAgentString),
 	)
 	if err != nil {
 		return nil, nil, connect.NewError(connect.CodeInternal, fmt.Errorf("Unable to fetch the chart %s from the namespace %q: %w", chartDetails.ChartName, appRepo.Namespace, err))

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client.go
@@ -183,10 +183,9 @@ func (c *OCIRepoClient) GetChart(details *ChartDetails, repoURL string) (*chart.
 	if c.puller == nil {
 		return nil, fmt.Errorf("unable to retrieve chart, Init should be called first")
 	}
-	if details.TarballURL == "" {
-		return nil, fmt.Errorf("calling GetChart '%s - %s' without any tarball url", details.ChartName, details.Version)
+	if details == nil || details.TarballURL == "" {
+		return nil, fmt.Errorf("unable to retrieve chart, missing chart details")
 	}
-
 	ref := strings.TrimPrefix(strings.TrimSpace(details.TarballURL), "oci://")
 	chartBuffer, _, err := c.puller.PullOCIChart(ref)
 	if err != nil {

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client.go
@@ -188,6 +188,10 @@ func (c *OCIRepoClient) GetChart(details *ChartDetails, repoURL string) (*chart.
 		return nil, fmt.Errorf("unable to retrieve chart, missing chart details")
 	}
 	chartURL, err := resolveChartURL(repoURL, details.TarballURL)
+	if err != nil {
+		return nil, err
+	}
+
 	ref := path.Join(chartURL.Host, chartURL.Path)
 	chartBuffer, _, err := c.puller.PullOCIChart(ref)
 	if err != nil {

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client.go
@@ -183,6 +183,9 @@ func (c *OCIRepoClient) GetChart(details *ChartDetails, repoURL string) (*chart.
 	if c.puller == nil {
 		return nil, fmt.Errorf("unable to retrieve chart, Init should be called first")
 	}
+	if details.TarballURL == "" {
+		return nil, fmt.Errorf("calling GetChart '%s - %s' without any tarball url", details.ChartName, details.Version)
+	}
 
 	ref := strings.TrimPrefix(strings.TrimSpace(details.TarballURL), "oci://")
 	chartBuffer, _, err := c.puller.PullOCIChart(ref)

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 
 	"github.com/containerd/containerd/remotes/docker"
@@ -184,12 +183,8 @@ func (c *OCIRepoClient) GetChart(details *ChartDetails, repoURL string) (*chart.
 	if c.puller == nil {
 		return nil, fmt.Errorf("unable to retrieve chart, Init should be called first")
 	}
-	parsedURL, err := url.Parse(strings.TrimSpace(details.TarballURL))
-	if err != nil {
-		return nil, err
-	}
 
-	ref := path.Join(parsedURL.Host, parsedURL.Path)
+	ref := strings.TrimPrefix(strings.TrimSpace(details.TarballURL), "oci://")
 	chartBuffer, _, err := c.puller.PullOCIChart(ref)
 	if err != nil {
 		return nil, err

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client_test.go
@@ -57,7 +57,7 @@ func Test_resolveChartURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			chartURL, err := resolveChartURL(tt.baseURL, tt.chartURL)
 			assert.NoError(t, err)
-			assert.Equal(t, chartURL, tt.wantedURL, "url")
+			assert.Equal(t, chartURL.String(), tt.wantedURL, "url")
 		})
 	}
 }
@@ -231,7 +231,7 @@ func TestOCIClient(t *testing.T) {
 			ExpectedName: "foo/bar/nginx:5.1.1",
 			Content:      map[string]*bytes.Buffer{"5.1.1": bytes.NewBuffer(data)},
 		}
-		ch, err := cli.GetChart(&ChartDetails{ChartName: "nginx", Version: "5.1.1"}, "http://foo/bar")
+		ch, err := cli.GetChart(&ChartDetails{ChartName: "nginx", Version: "5.1.1", TarballURL: "oci://foo/bar/nginx:5.1.1"}, "http://foo/bar")
 		if ch == nil {
 			t.Errorf("Unexpected error: %s", err)
 		}
@@ -248,7 +248,7 @@ func TestOCIClient(t *testing.T) {
 			ExpectedName: "foo/bar/bar/nginx:5.1.1",
 			Content:      map[string]*bytes.Buffer{"5.1.1": bytes.NewBuffer(data)},
 		}
-		ch, err := cli.GetChart(&ChartDetails{ChartName: "nginx", Version: "5.1.1"}, "http://foo/bar%2Fbar")
+		ch, err := cli.GetChart(&ChartDetails{ChartName: "nginx", Version: "5.1.1", TarballURL: "oci://foo/bar%2Fbar/nginx:5.1.1"}, "http://foo/bar%2Fbar")
 		if ch == nil {
 			t.Errorf("Unexpected error: %s", err)
 		}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/chart-client_test.go
@@ -218,7 +218,7 @@ func TestOCIClient(t *testing.T) {
 		cli := NewOCIClient("foo")
 		cli.(*OCIRepoClient).puller = &helmfake.OCIPuller{}
 		_, err := cli.GetChart(nil, "foo")
-		if !strings.Contains(err.Error(), "invalid URI for request") {
+		if !strings.Contains(err.Error(), "missing chart details") {
 			t.Errorf("Unexpected error %v", err)
 		}
 	})

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/fake/chart.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/utils/fake/chart.go
@@ -47,6 +47,6 @@ func (f *ChartClient) Init(appRepo *appRepov1.AppRepository, caCertSecret *corev
 type ChartClientFactory struct{}
 
 // New returns a fake ChartClient
-func (c *ChartClientFactory) New(repoType, userAgent string) utils.ChartClient {
+func (c *ChartClientFactory) New(tarballURL string, userAgent string) utils.ChartClient {
 	return &ChartClient{}
 }

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -8,39 +8,12 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"net/http"
 	"path"
 	"regexp"
 	"strings"
 
 	chart "github.com/vmware-tanzu/kubeapps/pkg/chart/models"
-	httpclient "github.com/vmware-tanzu/kubeapps/pkg/http-client"
 )
-
-// Fetches helm chart details from a gzipped tarball
-//
-// name is expected in format "foo/bar" or "foo%2Fbar" if url-escaped
-func FetchChartDetailFromTarballUrl(chartTarballURL string, userAgent string, authz string, netClient *http.Client) (map[string]string, error) {
-	reqHeaders := make(map[string]string)
-	if len(userAgent) > 0 {
-		reqHeaders["User-Agent"] = userAgent
-	}
-	if len(authz) > 0 {
-		reqHeaders["Authorization"] = authz
-	}
-
-	// use our "standard" http-client library
-	reader, _, err := httpclient.GetStream(chartTarballURL, netClient, reqHeaders)
-	if reader != nil {
-		defer reader.Close()
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	return FetchChartDetailFromTarball(reader)
-}
 
 // Fetches helm chart details from a gzipped tarball
 //


### PR DESCRIPTION
### Description of the change

This PR aims to fix #8153 by resolving this error:
```
E1219 15:25:15.632218       1 utils.go:1024] Failed to import files, ID=bitnami/nginx, version=17.3.3: Get "oci://registry-1.docker.io/bitnamicharts/nginx:17.3.3": unsupported protocol scheme "oci"
```

### Benefits

Currently, the kubeapps-asset-syncer is unable to fetch the information when the chart URL is stored in OCI.

In this PR, the chart tarballUrl is transformed when the oci schema is detected and replaced by its OCI blob URL, so the asset syncer will be able to fetch the chart tarball the same way as it does for non-OCI charts.

### Possible drawbacks

None known.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #8153
