### PR TITLE
Fix e2e tests by allowing custom images in helm install

### DIFF
--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -319,6 +319,7 @@ installOrUpgradeKubeapps() {
     --set apprepository.initialRepos[0].basicAuth.user=admin
     --set apprepository.initialRepos[0].basicAuth.password=password
     --set apprepository.globalReposNamespaceSuffix=-repos-global
+    --set global.security.allowInsecureImages=true
     --wait)
 
   echo "${cmd[@]}"
@@ -793,6 +794,7 @@ if [[ -z "${GKE_VERSION-}" && ("${TESTS_GROUP}" == "${ALL_TESTS}" || "${TESTS_GR
     --set apprepository.initialRepos[0].basicAuth.password=password
     --set apprepository.globalReposNamespaceSuffix=-repos-global
     --set global.postgresql.auth.postgresPassword=password
+    --set global.security.allowInsecureImages=true
     --wait)
 
   echo "${cmd[@]}"


### PR DESCRIPTION
### Description of the change

Fixes e2e tests by adding 'global.security.allowInsecureImages=true' to helm install/upgrade commands
This is required since the tests will use the custom built images for testing purposes.