### PR TITLE
Add deprecation notice to indicate project will no longer be maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![CodeQL](https://github.com/vmware-tanzu/kubeapps/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/vmware-tanzu/kubeapps/actions/workflows/codeql-scheduled.yml)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/7e0e2833-1d75-43f6-b006-632d359bb83b/deploy-status)](https://app.netlify.com/sites/kubeapps-dev/deploys)
 
+> [!CAUTION]
+> After many years of growth and milestones, the time has come for the next chapter of Kubeapps. The current maintainers are concentrating their efforts on new projects. We are looking for volunteers to help us maintain the project going forward. Without new volunteers, the project will be deprecated and the repo archived on August 8th, 2025.
+
 ## Overview
 
 Kubeapps is an in-cluster web-based application that enables users with a one-time installation to deploy, manage, and upgrade applications on a Kubernetes cluster.


### PR DESCRIPTION
After many years of growth and milestones, the time has come for the next chapter of Kubeapps. The current maintainers are concentrating their efforts on new projects. We are looking for volunteers to help us maintain the project going forward. Without new volunteers, the project will be deprecated and the repo archived on August 8th, 2025.